### PR TITLE
Fix stale-row rejection on symmetric sync channels: per-sender seq guards (factions, doors, build-doors)

### DIFF
--- a/src/plugin/core/StaleGuard.h
+++ b/src/plugin/core/StaleGuard.h
@@ -1,0 +1,46 @@
+// StaleGuard.h - per-sender stale-row guard for the symmetric state channels
+// (pure, zero game/Win32 deps).
+//
+// The faction (protocol 24), door (26) and placed-building-door (28) channels
+// are SYMMETRIC: both clients publish rows for the SAME key, each stamping its
+// own independent seq counter (facSeqOut_/doorSeqOut_/bdoorSeqOut_). The
+// original guard compared the incoming seq against a single high-water mark
+// shared by ALL senders of the row, so whichever side happened to run the
+// higher counter starved the other side's fresh rows as "stale" - one player
+// silently stopped seeing the other's changes on that row (fix 2026-07-19).
+// The guard is therefore keyed by the packet's ownerId (already on the wire in
+// all three packets): each sender is judged only against its own counter.
+//
+// Contract (mirrors the seq producers in ReplicatorChannels.cpp):
+//   * seq counters are per-sender, monotonically increasing, starting at 1
+//     (0 is reserved: "nothing seen yet from this sender").
+//   * a row is APPLIED exactly when its seq is newer than the last one
+//     applied from THIS sender; duplicates (safety resends) and reordered
+//     stragglers drop.
+//   * per-sender progress is independent: a slow sender's seq=1 must land
+//     even after a fast sender pushed seq=500 on the same row.
+// Tested in src/prototest/main.cpp (testStaleGuard); used by
+// Replicator::applyFactions / applyDoors / applyBuildDoors in
+// ReplicatorChannels.cpp.
+
+#ifndef COOP_STALE_GUARD_H
+#define COOP_STALE_GUARD_H
+
+#include <map>
+
+namespace coop {
+
+// Returns true if a row stamped (ownerId, seq) must be applied, advancing the
+// per-sender high-water mark; false drops it as stale/duplicate. seqSeen is
+// the row's per-sender map (FacRow/DoorRow/BdoorRow::seqSeen).
+inline bool staleRowAccept(std::map<unsigned int, unsigned int>& seqSeen,
+                           unsigned int ownerId, unsigned int seq) {
+    unsigned int& seen = seqSeen[ownerId];
+    if (seen != 0 && seq <= seen) return false; // stale row (this sender)
+    seen = seq;
+    return true;
+}
+
+} // namespace coop
+
+#endif // COOP_STALE_GUARD_H

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -1299,11 +1299,14 @@ private:
     //              echo guard: an applied row is never re-detected as local).
     // lastSendVal/lastSendMs = change gate + safety resend (rows never sent
     //              never resend, so a settled diplomacy is silent).
-    // seqSeen    = newest per-sender seq applied (stale-row guard).
+    // seqSeen    = newest seq applied PER SENDER (keyed by the packet's
+    //              ownerId; both clients publish this symmetric channel with
+    //              INDEPENDENT counters, so one shared counter would let a
+    //              faster sender starve the slower one's rows as "stale").
     struct FacRow {
         float known; float lastSendVal; unsigned long lastSendMs;
-        u32 seqSeen; bool seeded;
-        FacRow() : known(0), lastSendVal(0), lastSendMs(0), seqSeen(0), seeded(false) {}
+        std::map<u32, u32> seqSeen; bool seeded;
+        FacRow() : known(0), lastSendVal(0), lastSendMs(0), seeded(false) {}
     };
     std::map<std::string, FacRow> facRows_;
     u32           facSeqOut_;
@@ -1312,12 +1315,13 @@ private:
     // Protocol 26 door-state sync, per door hand (the faction shape: known =
     // baseline, updated on every local change sent AND every received row
     // applied - the echo guard; lastSendMs = change gate + safety resend;
-    // seqSeen = stale-row guard).
+    // seqSeen = per-sender stale-row guard, keyed by the packet's ownerId -
+    // both clients publish this symmetric channel with independent counters).
     struct DoorRow {
         int knownOpen; int knownLocked; unsigned long lastSendMs;
-        u32 seqSeen; bool seeded;
+        std::map<u32, u32> seqSeen; bool seeded;
         DoorRow() : knownOpen(-1), knownLocked(-1), lastSendMs(0),
-                    seqSeen(0), seeded(false) {}
+                    seeded(false) {}
     };
     std::map<Key, DoorRow> doorRows_;
     u32           doorSeqOut_;
@@ -1364,12 +1368,13 @@ private:
     unsigned long buildSampleMs_;
     bool          buildSync_;
     // Protocol 28 placed-door rows, keyed by (placer building key, door
-    // index) - the protocol-26 DoorRow shape on the translated identity.
+    // index) - the protocol-26 DoorRow shape on the translated identity
+    // (seqSeen is per-sender for the same reason: both sides publish).
     struct BdoorRow {
         int knownOpen; int knownLocked; unsigned long lastSendMs;
-        u32 seqSeen; bool seeded;
+        std::map<u32, u32> seqSeen; bool seeded;
         BdoorRow() : knownOpen(-1), knownLocked(-1), lastSendMs(0),
-                     seqSeen(0), seeded(false) {}
+                     seeded(false) {}
     };
     std::map<std::pair<Key, int>, BdoorRow> bdoorRows_;
     u32           bdoorSeqOut_;

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -11,6 +11,7 @@
 // PowerShell oracles (see resources/CODE_MAP.md, log-tag index).
 
 #include "ReplicatorUtil.h"
+#include "../core/StaleGuard.h"
 
 namespace coop {
 
@@ -617,12 +618,11 @@ void Replicator::applyFactions(const SyncContext& ctx) {
         const FactionPacket& p = it->pkt;
         if (p.sid[0] == '\0') continue;
         FacRow& fr = facRows_[std::string(p.sid)];
-        // Per-sender stale guard: both clients publish this row with
-        // INDEPENDENT seq counters, so the comparison must be against the
-        // newest seq seen FROM THIS SENDER, not a shared high-water mark.
-        u32& seen = fr.seqSeen[p.ownerId];
-        if (seen != 0 && p.seq <= seen) continue; // stale row (this sender)
-        seen = p.seq;
+        // Per-sender stale guard (StaleGuard.h, prototest testStaleGuard):
+        // both clients publish this row with INDEPENDENT seq counters, so the
+        // comparison must be against the newest seq seen FROM THIS SENDER,
+        // not a shared high-water mark.
+        if (!staleRowAccept(fr.seqSeen, p.ownerId, p.seq)) continue;
         float us = -999.0f, them = -999.0f;
         engine::readRelationBySid(gw, p.sid, &us, &them);
         // Updating the baseline FIRST is the echo guard: the local change this
@@ -712,12 +712,11 @@ void Replicator::applyDoors(const SyncContext& ctx) {
         Key k; k.t = p.hand[0]; k.c = p.hand[1]; k.cs = p.hand[2];
         k.i = p.hand[3]; k.s = p.hand[4];
         DoorRow& dr = doorRows_[k];
-        // Per-sender stale guard: both clients publish this row with
-        // INDEPENDENT seq counters, so the comparison must be against the
-        // newest seq seen FROM THIS SENDER, not a shared high-water mark.
-        u32& seen = dr.seqSeen[p.ownerId];
-        if (seen != 0 && p.seq <= seen) continue; // stale row (this sender)
-        seen = p.seq;
+        // Per-sender stale guard (StaleGuard.h, prototest testStaleGuard):
+        // both clients publish this row with INDEPENDENT seq counters, so the
+        // comparison must be against the newest seq seen FROM THIS SENDER,
+        // not a shared high-water mark.
+        if (!staleRowAccept(dr.seqSeen, p.ownerId, p.seq)) continue;
         // Updating the baseline FIRST is the echo guard: the local change this
         // write causes must not be re-detected as ours next sample.
         dr.knownOpen = (int)p.open; dr.knownLocked = (int)p.locked;
@@ -1430,12 +1429,11 @@ void Replicator::applyBuildDoors(const SyncContext& ctx) {
                 localHand = pit->second.localHand;
         }
         BdoorRow& row = bdoorRows_[std::make_pair(k, (int)p.doorIndex)];
-        // Per-sender stale guard: both clients publish this row with
-        // INDEPENDENT seq counters, so the comparison must be against the
-        // newest seq seen FROM THIS SENDER, not a shared high-water mark.
-        u32& seen = row.seqSeen[p.ownerId];
-        if (seen != 0 && p.seq <= seen) continue; // stale row (this sender)
-        seen = p.seq;
+        // Per-sender stale guard (StaleGuard.h, prototest testStaleGuard):
+        // both clients publish this row with INDEPENDENT seq counters, so the
+        // comparison must be against the newest seq seen FROM THIS SENDER,
+        // not a shared high-water mark.
+        if (!staleRowAccept(row.seqSeen, p.ownerId, p.seq)) continue;
         // Updating the baseline FIRST is the echo guard: the local change this
         // write causes must not be re-detected as ours next sample.
         row.knownOpen = (int)p.open; row.knownLocked = (int)p.locked;

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -617,8 +617,12 @@ void Replicator::applyFactions(const SyncContext& ctx) {
         const FactionPacket& p = it->pkt;
         if (p.sid[0] == '\0') continue;
         FacRow& fr = facRows_[std::string(p.sid)];
-        if (!sync::gateSeqAccept(fr.seqSeen, p.seq)) continue; // stale/dup row
-        fr.seqSeen = p.seq;
+        // Per-sender stale guard: both clients publish this row with
+        // INDEPENDENT seq counters, so the comparison must be against the
+        // newest seq seen FROM THIS SENDER, not a shared high-water mark.
+        u32& seen = fr.seqSeen[p.ownerId];
+        if (seen != 0 && p.seq <= seen) continue; // stale row (this sender)
+        seen = p.seq;
         float us = -999.0f, them = -999.0f;
         engine::readRelationBySid(gw, p.sid, &us, &them);
         // Updating the baseline FIRST is the echo guard: the local change this
@@ -708,8 +712,12 @@ void Replicator::applyDoors(const SyncContext& ctx) {
         Key k; k.t = p.hand[0]; k.c = p.hand[1]; k.cs = p.hand[2];
         k.i = p.hand[3]; k.s = p.hand[4];
         DoorRow& dr = doorRows_[k];
-        if (!sync::gateSeqAccept(dr.seqSeen, p.seq)) continue; // stale/dup row
-        dr.seqSeen = p.seq;
+        // Per-sender stale guard: both clients publish this row with
+        // INDEPENDENT seq counters, so the comparison must be against the
+        // newest seq seen FROM THIS SENDER, not a shared high-water mark.
+        u32& seen = dr.seqSeen[p.ownerId];
+        if (seen != 0 && p.seq <= seen) continue; // stale row (this sender)
+        seen = p.seq;
         // Updating the baseline FIRST is the echo guard: the local change this
         // write causes must not be re-detected as ours next sample.
         dr.knownOpen = (int)p.open; dr.knownLocked = (int)p.locked;
@@ -1422,8 +1430,12 @@ void Replicator::applyBuildDoors(const SyncContext& ctx) {
                 localHand = pit->second.localHand;
         }
         BdoorRow& row = bdoorRows_[std::make_pair(k, (int)p.doorIndex)];
-        if (!sync::gateSeqAccept(row.seqSeen, p.seq)) continue; // stale/dup row
-        row.seqSeen = p.seq;
+        // Per-sender stale guard: both clients publish this row with
+        // INDEPENDENT seq counters, so the comparison must be against the
+        // newest seq seen FROM THIS SENDER, not a shared high-water mark.
+        u32& seen = row.seqSeen[p.ownerId];
+        if (seen != 0 && p.seq <= seen) continue; // stale row (this sender)
+        seen = p.seq;
         // Updating the baseline FIRST is the echo guard: the local change this
         // write causes must not be re-detected as ours next sample.
         row.knownOpen = (int)p.open; row.knownLocked = (int)p.locked;

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -34,6 +34,7 @@
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
+#include "../plugin/core/StaleGuard.h"   // per-sender stale-row guard (symmetric channels)
 
 #include <set>
 
@@ -1355,6 +1356,80 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- 12. Per-sender stale-row guard (StaleGuard.h staleRowAccept) ----------------
+// Guards the symmetric-channel fix (2026-07-19): the faction (24), door (26)
+// and placed-building-door (28) channels are published by BOTH clients, each
+// stamping its own independent seq counter on rows for the SAME key. The old
+// guard kept ONE shared high-water mark per row, so once the faster sender
+// pushed seq=N, every packet from the other sender with seq <= N was dropped
+// as "stale" - one player silently stopped seeing the other's changes on that
+// row. staleRowAccept keys the mark by the packet's ownerId; this locks that
+// contract (and the unchanged single-sender discipline around it).
+static void testStaleGuard() {
+    std::printf("== per-sender stale-row guard (StaleGuard.h) ==\n");
+    const unsigned int A = 1, B = 2; // two peers publishing the SAME row
+
+    // Single-sender semantics unchanged: first row lands, duplicates (safety
+    // resends) and reordered stragglers drop, newer seqs land, loss-gaps jump.
+    {
+        std::map<unsigned int, unsigned int> row;
+        CHECK("first row from a sender applies",      staleRowAccept(row, A, 1));
+        CHECK("duplicate seq drops (safety resend)", !staleRowAccept(row, A, 1));
+        CHECK("newer seq applies",                    staleRowAccept(row, A, 2));
+        CHECK("reordered straggler drops",           !staleRowAccept(row, A, 1));
+        CHECK("gap jump applies (loss tolerated)",    staleRowAccept(row, A, 9));
+        CHECK("straggler behind the gap drops",      !staleRowAccept(row, A, 5));
+    }
+
+    // THE FIX: two senders write the SAME row with independent counters. A's
+    // counter is far ahead (seq 500); B's fresh seq=1 must still land. The
+    // pre-fix shared mark rejected exactly this packet (1 <= 500 -> "stale").
+    {
+        std::map<unsigned int, unsigned int> row;
+        CHECK("fast sender A seq=500 applies",  staleRowAccept(row, A, 500));
+        CHECK("slow sender B seq=1 still applies (the fix)",
+              staleRowAccept(row, B, 1));
+        // Per-sender discipline holds independently on both counters.
+        CHECK("B duplicate seq=1 drops",       !staleRowAccept(row, B, 1));
+        CHECK("B seq=2 applies",                staleRowAccept(row, B, 2));
+        CHECK("A straggler seq=499 drops",     !staleRowAccept(row, A, 499));
+        CHECK("A seq=501 applies",              staleRowAccept(row, A, 501));
+    }
+
+    // Regression documentation (the RED half): the pre-fix shared-counter
+    // guard, replayed on the same trace, drops B's fresh packet - proof this
+    // scenario detects the bug the per-sender map removes.
+    {
+        unsigned int sharedSeen = 0;   // pre-fix FacRow::seqSeen (one u32)
+        sharedSeen = 500;              // A's seq=500 row applied
+        bool bDropped = (sharedSeen != 0 && 1u <= sharedSeen); // B's seq=1 arrives
+        CHECK("shared counter would drop B's row (the bug)", bDropped);
+    }
+
+    // Interleaving: both sides toggling the same door alternately - every
+    // fresh packet from either side lands, every safety resend drops, and
+    // neither counter ever disturbs the other's progress.
+    {
+        std::map<unsigned int, unsigned int> row;
+        bool ok = true;
+        for (unsigned int s = 1; s <= 10; ++s) {
+            ok = ok &&  staleRowAccept(row, A, s);  // A's fresh row
+            ok = ok &&  staleRowAccept(row, B, s);  // B's fresh row, same key
+            ok = ok && !staleRowAccept(row, A, s);  // A's safety resend
+            ok = ok && !staleRowAccept(row, B, s);  // B's safety resend
+        }
+        CHECK("alternating same-row writes all land, resends all drop", ok);
+    }
+
+    // The guard state is per ROW: a second row's counters start clean, so a
+    // sender's high counter on one door never stales its rows on another.
+    {
+        std::map<unsigned int, unsigned int> door1, door2;
+        CHECK("row1 A seq=3 applies",                    staleRowAccept(door1, A, 3));
+        CHECK("row2 A seq=1 applies (rows independent)", staleRowAccept(door2, A, 1));
+    }
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1377,6 +1452,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testStaleGuard();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
### What this fixes

Three sync channels that flow symmetrically (faction relations, door state, build-door state) shared a single `seqSeen` counter per row. With two senders writing to the same row, the row-level counter gets pushed up by whichever sender is "faster", and legitimate updates from the slower sender then compare against that inflated seq and get dropped as stale. Net effect: silently discarded updates on those three channels whenever both sides touch the same row.

Concrete symptom this produces on the faction channel: one player attacks something, the relation change (`affectRelations`) fires and gets published, but the row gets silently dropped as stale on the other side because of the shared-counter bug above — so hostility doesn't consistently spread to both players even though the game engine changed the same faction relation both sides should see. Confirmed by tracing the faction channel logic tonight, separate from writing this fix.

### How

New pure header `StaleGuard.h` with a single function:

```
staleRowAccept(std::map<u32,u32>& seqSeen, u32 ownerId, u32 seq)
```

The guard keeps a per-sender seq map instead of one shared counter, so each sender's updates are only checked against that sender's own last-seen seq. The three call sites (factions, doors, build-doors) switch to it; no protocol change, no wire format change.

### Testing

- Unit: `testStaleGuard`, 16 checks. Written red-first against the old shared-counter behavior (fails on it), green with the per-sender map.
- Built with the real toolchain (VS2010 v100 x64), 0 errors.
- Live smoke via your `dev_cycle.ps1` runner, this branch alone on top of v0.45: full host↔join connect, gameplay reached, 0 `ERROR:` lines, clean shutdown. PASS.
- Same smoke with all four of my fix branches merged together: prototest 333/333, smoke PASS, plus an independent adversarial review of the combined diff (we use Claude as a tool throughout this work, including for that review pass) — no cross-fix interactions found.

### What was NOT tested

The smoke run is a happy-path connect/gameplay/shutdown cycle — it does not specifically reproduce the two-senders-racing-on-one-row scenario in live play. The behavior change is covered by the unit tests, not by a live repro. Flagging that honestly rather than overclaiming.