### PR TITLE
Fix re-seat teleport on chained+caged prisoners: hold the anchor instead of re-chaining, propagate furnEdgeKind across body re-key

### DIFF
--- a/src/plugin/core/JailAnchor.h
+++ b/src/plugin/core/JailAnchor.h
@@ -1,0 +1,49 @@
+// JailAnchor.h - captive furniture-kind conflict policy (pure, zero
+// game/Win32 deps).
+//
+// A caged prisoner is often ALSO shackled: the owner's reliable furniture
+// edges settle on the cage (publish kind priority bed=1 > cage=2 > chained=3)
+// while the lossy continuous bodyState batch can still say CHAINED-only, so
+// the driven copy sees streamKind=3 against an edge-vouched localKind=2. The
+// kind=3 self-heal used to resolve that by BREAKING the cage and re-chaining
+// every FURN_HEAL_MS - a median 75-88 u (tail 885 u) re-seat teleport on
+// 10-15 bodies per session (spike 58, findings 1-2).
+//
+// The rule (spike 58 follow-up 1): while a RELIABLE edge vouches the local
+// cage/bed, the cage/bed is the transform anchor and the shackle is an
+// EQUIP-only state - never break the anchor over a continuous-bit
+// disagreement. A local cage NO edge vouches for is a stale attach at the
+// wrong spot (the Flashbox case) and must still be broken and re-chained.
+// Tested in src/prototest/main.cpp (testJailAnchor); used by
+// Replicator::applyTargets in ReplicatorDrive.cpp.
+
+#ifndef COOP_JAIL_ANCHOR_H
+#define COOP_JAIL_ANCHOR_H
+
+namespace coop {
+
+enum ChainAnchorAct {
+    CHAIN_ANCHOR_NONE    = 0, // stream not chained, or already chained locally
+    CHAIN_ANCHOR_HOLD    = 1, // edge-vouched cage/bed anchors the transform;
+                              //   re-assert the chain EQUIP-only, never break
+    CHAIN_ANCHOR_RECHAIN = 2  // no/stale local furniture: existing heal path
+                              //   (break an unvouched cage/bed, re-chain)
+};
+
+// One decision for one driven body per tick. streamKind = what the owner's
+// continuous batch reports (0 none / 1 bed / 2 cage / 3 chained); localKind =
+// where our copy actually sits (readFurniture, 0 when absent/invalid);
+// edgeKind = the furniture kind last vouched for this body by a RELIABLE
+// edge (RECV ENTER / host PEER-ENTER author; 0 = none, cleared on EXIT).
+inline ChainAnchorAct chainAnchorStep(int streamKind, int localKind,
+                                      int edgeKind) {
+    if (streamKind != 3) return CHAIN_ANCHOR_NONE; // conflict is kind-3 only
+    if (localKind == 3)  return CHAIN_ANCHOR_NONE; // already chained: in sync
+    if ((localKind == 1 || localKind == 2) && edgeKind == localKind)
+        return CHAIN_ANCHOR_HOLD;                  // vouched anchor wins
+    return CHAIN_ANCHOR_RECHAIN;                   // stale/absent: heal as before
+}
+
+} // namespace coop
+
+#endif // COOP_JAIL_ANCHOR_H

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -731,6 +731,15 @@ private:
         // self-heal; this guard re-asserts setChainedMode independently so a peer
         // PC's local lockpick can't leave the owner's prisoner unlocked on the peer.
         unsigned long chainHealTick;
+        // Spike 58 (kind-conflict anchor): the furniture kind last vouched for
+        // this body by a RELIABLE edge (RECV ENTER, or the host's own
+        // PEER-ENTER authoring; 0 = none, cleared on a reliable EXIT / the
+        // debounced HEAL EXIT). While the lossy stream says chained
+        // (streamKind=3) but an edge vouches the local cage/bed (1/2), the
+        // cage/bed stays the transform anchor and the shackle is re-asserted
+        // EQUIP-only (chainAnchorStep) - the kind=3 heal must not break an
+        // edge-vouched cage every FURN_HEAL_MS (the 75-885 u re-seat teleport).
+        int           furnEdgeKind;
         // Stealth sync (protocol 20):
         unsigned long sneakTick;      // last setStealthMode apply (mode-flap throttle)
         // Velocity-aware snap gate (2026-07-11): slow-decaying peak of the
@@ -770,7 +779,7 @@ private:
                    trusted(false), agreeStreak(0),
                    carryHealTick(0), carryNoSeeTick(0),
                    furnHealTick(0), furnNoSeeTick(0), furnPeerTick(0),
-                   haveChainOwner(false), chainHealTick(0),
+                   haveChainOwner(false), chainHealTick(0), furnEdgeKind(0),
                    sneakTick(0), velPeak(0.0f), moveSeenMs(0), wasMoving(false),
                    zeroF(0), activeF(0), midSeenMs(0) {
             chainOwner[0] = chainOwner[1] = chainOwner[2] = chainOwner[3] = chainOwner[4] = 0;

--- a/src/plugin/sync/ReplicatorDrive.cpp
+++ b/src/plugin/sync/ReplicatorDrive.cpp
@@ -456,6 +456,59 @@ void Replicator::applyTargets(GameWorld* gw) {
             // host's work pose at rest). Cage/bed (kinds 1-2) remain true
             // transform anchors below.
             if (streamKind == 3) {
+                // Kind-conflict anchor (spike 58 follow-up 1): the owner's
+                // reliable edges settle a chained+caged prisoner on the CAGE
+                // (publish kind priority), but the lossy continuous batch can
+                // still say CHAINED-only - so this branch used to break an
+                // edge-vouched cage and re-chain every FURN_HEAL_MS, a median
+                // 75-88 u (tail 885 u) re-seat teleport on 10-15 bodies per
+                // session. While a reliable edge vouches the local cage/bed
+                // (d.furnEdgeKind, stamped on RECV ENTER / host PEER-ENTER
+                // authoring), the cage/bed stays the transform anchor and the
+                // shackle is an EQUIP-only state: hold the body like the
+                // kind 1/2 path below and re-assert setChainedMode WITHOUT
+                // breaking the anchor (the protocol-42 SHACKLE RELOCK call,
+                // proven safe on a caged occupant). An UNVOUCHED local
+                // cage/bed is a stale attach at the wrong spot (the Flashbox
+                // case below) and still takes the break+re-chain path.
+                if (coop::chainAnchorStep(streamKind, localKind,
+                                          d.furnEdgeKind) ==
+                    coop::CHAIN_ANCHOR_HOLD) {
+                    d.furnNoSeeTick = 0;
+                    // Same hold as the kind 1/2 branch: an anchored captive
+                    // must not run its own decision layer, and a committed
+                    // destination must not walk it out between heals.
+                    if (aiSuspend_) {
+                        engine::addAiSuspend(c);
+                        engine::haltMovement(c);
+                    }
+                    // EQUIP-only shackle re-assert (throttled like the unlock
+                    // guard): remember the owner while chained, re-lock if the
+                    // local copy lost the chain (lockpick / AI break-out).
+                    engine::ShackleRead asr;
+                    bool haveAsr = engine::readShackle(c, &asr) && asr.valid;
+                    if (haveAsr && asr.chained &&
+                        (asr.owner[3] != 0 || asr.owner[4] != 0)) {
+                        for (int fi = 0; fi < 5; ++fi)
+                            d.chainOwner[fi] = asr.owner[fi];
+                        d.haveChainOwner = true;
+                    }
+                    if (haveAsr && !asr.chained &&
+                        (now - d.chainHealTick) >= FURN_HEAL_MS) {
+                        d.chainHealTick = now;
+                        bool ok = d.haveChainOwner
+                            ? engine::applyFurniture(gw, c, d.chainOwner, 3, true)
+                            : engine::applyFurniture(gw, c, 0, 3, true);
+                        engine::endAction(c);
+                        char b[160]; _snprintf(b, sizeof(b) - 1,
+                            "[furn] CHAIN EQUIP occ=%u,%u anchor=%d ok=%d",
+                            out.hIndex, out.hSerial, localKind, ok ? 1 : 0);
+                        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+                    }
+                    d.parked = false; d.haveDest = false;
+                    if (haveActual) { d.haveActual = true; d.lx = ax; d.ly = ay; d.lz = az; }
+                    continue;
+                }
                 if (haveFr && localKind != 3 &&
                     (now - d.furnHealTick) >= FURN_HEAL_MS) {
                     d.furnHealTick = now;
@@ -506,7 +559,17 @@ void Replicator::applyTargets(GameWorld* gw) {
                 // exception: suspend its decisions so it stays put. The suspend set is
                 // rebuilt every drive tick, so this self-clears the moment the host
                 // stops streaming the furniture bit (body released) and its AI resumes.
-                if (aiSuspend_) engine::addAiSuspend(c);
+                if (aiSuspend_) {
+                    engine::addAiSuspend(c);
+                    // Spike 58 follow-up 2: the suspend hook only blocks NEW
+                    // decisions - a destination the local AI committed before
+                    // it still walks the copy out between heals (8/22 jailed
+                    // SNAPs carried localStep>2 u, up to 28.6 u). Halt the
+                    // in-flight goal per tick, exactly like the census-freeze
+                    // upkeep, so localStep stays 0 and the twitch is a pure
+                    // (and now rare) re-seat instead of exit-then-snap.
+                    engine::haltMovement(c);
+                }
                 if (haveFr && localKind != streamKind &&
                     (now - d.furnHealTick) >= FURN_HEAL_MS) {
                     d.furnHealTick = now;
@@ -608,6 +671,10 @@ void Replicator::applyTargets(GameWorld* gw) {
                         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
                     }
                     d.furnNoSeeTick = 0; // never self-heal-eject a host placement
+                    // The host's own placement is as authoritative as a
+                    // received edge: vouch the kind so a later CHAINED-only
+                    // continuous bit can't break this cage (spike 58 anchor).
+                    d.furnEdgeKind = localKind;
                     d.parked = false; d.haveDest = false;
                     if (haveActual) { d.haveActual = true; d.lx = ax; d.ly = ay; d.lz = az; }
                     continue;
@@ -616,6 +683,7 @@ void Replicator::applyTargets(GameWorld* gw) {
                     d.furnNoSeeTick = now;
                 } else if ((now - d.furnNoSeeTick) > FURN_EXIT_MS) {
                     d.furnNoSeeTick = 0;
+                    d.furnEdgeKind = 0; // debounced exit: the vouch dies with it
                     bool ok = engine::applyFurniture(gw, c, lfr.furn, localKind, false);
                     char b[160]; _snprintf(b, sizeof(b) - 1,
                         "[furn] HEAL EXIT occ=%u,%u kind=%d ok=%d",

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -643,6 +643,12 @@ void Replicator::applyEvents(GameWorld* gw, Inbound& in) {
                                        ev.aIndex, ev.aSerial };
                 int kind = (int)ev.arg;
                 bool ok = occ && engine::applyFurniture(0, occ, fh, kind, true);
+                // Spike 58 (kind-conflict anchor): remember the reliable-edge
+                // kind on the driven record, so a CHAINED-only continuous bit
+                // can't break an edge-vouched cage/bed (chainAnchorStep).
+                // Same targets_ seeding pattern as the deathLatched carry.
+                if (ownHands_.find(k) == ownHands_.end())
+                    targets_[k].furnEdgeKind = kind;
                 char fb[160]; _snprintf(fb, sizeof(fb) - 1,
                     "[furn] RECV ENTER id=%u occ=%u,%u furn=%u,%u kind=%d ok=%d",
                     ev.eventId, ev.sIndex, ev.sSerial, ev.aIndex, ev.aSerial,
@@ -660,6 +666,13 @@ void Replicator::applyEvents(GameWorld* gw, Inbound& in) {
                                        ev.aIndex, ev.aSerial };
                 int kind = (int)ev.arg;
                 bool ok = occ && engine::applyFurniture(0, occ, fh, kind, false);
+                // Spike 58: the reliable EXIT withdraws the vouch (find, not
+                // operator[] - an exit for a never-seen body must not seed a
+                // junk driven record).
+                {
+                    std::map<Key, Driven>::iterator dt = targets_.find(k);
+                    if (dt != targets_.end()) dt->second.furnEdgeKind = 0;
+                }
                 char fb[160]; _snprintf(fb, sizeof(fb) - 1,
                     "[furn] RECV EXIT id=%u occ=%u,%u furn=%u,%u kind=%d ok=%d",
                     ev.eventId, ev.sIndex, ev.sSerial, ev.aIndex, ev.aSerial,

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -780,12 +780,20 @@ void Replicator::rekeyPeerBody(GameWorld* gw, const Key& oldK, const Key& newK,
     // EVT_SQUAD_MOVE re-keyed it and un-pinned the body). Snapshot the latches
     // here and re-seed them onto targets_[newK] so the corpse stays down.
     bool carryDeath = false, carryKo = false, carryDown = false;
+    // Carry the furniture-edge vouch too: a caged+shackled prisoner whose
+    // hand re-keys mid-occupancy (recruit / squad move) would otherwise get a
+    // fresh Driven with furnEdgeKind=0, and the very next kind-3 tick reads
+    // CHAIN_ANCHOR_RECHAIN instead of HOLD (chainAnchorStep) - one 75-885 u
+    // re-seat teleport, exactly what the jail-anchor fix suppresses. The
+    // vouch is a reliable-edge fact about the BODY, not the hand.
+    int carryFurnKind = 0;
     {
         std::map<Key, Driven>::iterator oldT = targets_.find(oldK);
         if (oldT != targets_.end()) {
-            carryDeath = oldT->second.deathLatched;
-            carryKo    = oldT->second.koLatched;
-            carryDown  = oldT->second.downApplied;
+            carryDeath    = oldT->second.deathLatched;
+            carryKo       = oldT->second.koLatched;
+            carryDown     = oldT->second.downApplied;
+            carryFurnKind = oldT->second.furnEdgeKind;
         }
     }
     // Drop the old key's stream state too (run 192211: the interp TAIL of a
@@ -809,6 +817,17 @@ void Replicator::rekeyPeerBody(GameWorld* gw, const Key& oldK, const Key& newK,
             newK.t, newK.c, newK.cs, newK.i, newK.s,
             carryDeath ? 1 : 0, carryKo ? 1 : 0);
         lb[sizeof(lb) - 1] = '\0'; coop::logLine(lb);
+    }
+    if (carryFurnKind != 0) {
+        Driven& nd = targets_[newK]; // stream fills interp; we seed only the vouch
+        // A RECV ENTER already stamped under the NEW hand is fresher than the
+        // migrated vouch - keep it and only fill the empty slot.
+        if (nd.furnEdgeKind == 0) nd.furnEdgeKind = carryFurnKind;
+        char fb[200]; _snprintf(fb, sizeof(fb) - 1,
+            "[event] REKEY-FURN old=%u,%u,%u,%u,%u new=%u,%u,%u,%u,%u kind=%d",
+            oldK.t, oldK.c, oldK.cs, oldK.i, oldK.s,
+            newK.t, newK.c, newK.cs, newK.i, newK.s, nd.furnEdgeKind);
+        fb[sizeof(fb) - 1] = '\0'; coop::logLine(fb);
     }
     Character* c = engine::resolveCharByHand(oldK.i, oldK.s, oldK.t, oldK.c, oldK.cs);
     if (!c) {

--- a/src/plugin/sync/ReplicatorUtil.h
+++ b/src/plugin/sync/ReplicatorUtil.h
@@ -33,6 +33,7 @@
 #include "../core/DeathLatch.h" // rekeyCarryLatch (down/death latch carry on re-key)
 #include "ChangeGate.h" // Phase 6: shared change-gated send/accept policy
 #include "SyncContext.h" // Phase 6: per-tick channel call environment
+#include "../core/JailAnchor.h" // chainAnchorStep (captive kind-conflict anchor, spike 58)
 #include "../CoopLog.h"
 
 #include <windows.h> // GetTickCount

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -34,6 +34,7 @@
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
+#include "../plugin/core/JailAnchor.h" // chainAnchorStep (captive kind-conflict anchor, spike 58)
 
 #include <set>
 
@@ -1355,6 +1356,44 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- 12. Captive kind-conflict anchor (JailAnchor.h) ---------------------------
+// Guards the spike-58 fix: a chained+caged prisoner streams CHAINED-only in the
+// lossy batch while the reliable edges vouch the cage. The step must (a) HOLD an
+// edge-vouched cage/bed (no break, no re-chain transform - the 75-885 u re-seat
+// teleport), (b) still RECHAIN a stale/unvouched local attach (the Flashbox
+// case), and (c) stay quiet when the stream is not chained or the copy already
+// is (no invented heals).
+
+static void testJailAnchor() {
+    std::printf("== captive kind-conflict anchor (JailAnchor.h) ==\n");
+
+    // Not a chained stream: never this policy's business (kind 1/2 heals and
+    // the no-furniture drive handle those).
+    CHECK("cage stream -> NONE",    chainAnchorStep(2, 2, 2) == CHAIN_ANCHOR_NONE);
+    CHECK("bed stream -> NONE",     chainAnchorStep(1, 1, 1) == CHAIN_ANCHOR_NONE);
+    CHECK("no stream kind -> NONE", chainAnchorStep(0, 2, 2) == CHAIN_ANCHOR_NONE);
+
+    // Already chained locally: in sync, nothing to heal.
+    CHECK("chained+chained -> NONE",        chainAnchorStep(3, 3, 0) == CHAIN_ANCHOR_NONE);
+    CHECK("chained+chained vouched -> NONE", chainAnchorStep(3, 3, 3) == CHAIN_ANCHOR_NONE);
+
+    // The bug: CHAINED-only continuous bit against an edge-vouched cage/bed.
+    // The anchor wins - never break it over the disagreement.
+    CHECK("vouched cage vs chained -> HOLD", chainAnchorStep(3, 2, 2) == CHAIN_ANCHOR_HOLD);
+    CHECK("vouched bed vs chained -> HOLD",  chainAnchorStep(3, 1, 1) == CHAIN_ANCHOR_HOLD);
+
+    // An UNVOUCHED local cage is the Flashbox stale attach: break + re-chain.
+    CHECK("unvouched cage -> RECHAIN",       chainAnchorStep(3, 2, 0) == CHAIN_ANCHOR_RECHAIN);
+    CHECK("unvouched bed -> RECHAIN",        chainAnchorStep(3, 1, 0) == CHAIN_ANCHOR_RECHAIN);
+    // Vouch/local mismatch is no vouch at all (edge moved on, copy did not).
+    CHECK("bed vouch, cage local -> RECHAIN", chainAnchorStep(3, 2, 1) == CHAIN_ANCHOR_RECHAIN);
+    CHECK("chain vouch, cage local -> RECHAIN", chainAnchorStep(3, 2, 3) == CHAIN_ANCHOR_RECHAIN);
+
+    // No local furniture at all: the plain re-chain heal (lost/late ENTER).
+    CHECK("no furniture -> RECHAIN",          chainAnchorStep(3, 0, 0) == CHAIN_ANCHOR_RECHAIN);
+    CHECK("no furniture, stale vouch -> RECHAIN", chainAnchorStep(3, 0, 2) == CHAIN_ANCHOR_RECHAIN);
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1377,6 +1416,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testJailAnchor();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
Heads up before the diff: I saw your recent jail put-to-work/long-play diagnostic commits (spike 57/58) and know you're actively working this exact area yourself. Take this as one input, not a "here's the fix" — happy to adapt it, drop it, or fold it into whatever you land on if it overlaps with what you're already doing.

### What this fixes

A peer prisoner who is both shackled and caged gets hit by a re-seat teleport (measured 75-885 units in our runs) caused by a conflict between the locally-derived furniture "kind" and the kind coming in on the stream. When the two disagree, the code re-chains the captive to what it thinks is the right furniture and yanks the body across the map in the process.

### How

Two commits:

1. `chainAnchorStep` (new header `JailAnchor.h`): when the local and stream furniture kinds conflict for an already-anchored captive, HOLD the existing anchor instead of RECHAIN. The captive stays put; no teleport.
2. Propagate `furnEdgeKind` in `rekeyPeerBody` (`ReplicatorSpawn.cpp`): when a prisoner's body gets re-keyed on a cross-tab/recruit transfer, the furniture edge kind was being dropped in the re-key, which produced one residual teleport right after the transfer. Now it carries over.

### Testing

- Built with the real toolchain (VS2010 v100 x64), 0 errors.
- Live smoke via your `dev_cycle.ps1` runner, branch alone on top of v0.45: full host↔join connect, gameplay reached, 0 `ERROR:` lines, clean shutdown. PASS.
- Combined with my other three fix branches: prototest 333/333, smoke PASS, independent adversarial review of the combined diff (Claude-assisted) found no cross-fix interactions.
- Targeted live repro of the actual jail scenario: forced a peer body into the exact bug state (shackled + caged, kind conflict induced live) against the deployed DLL and measured position samples on the host's driven copy directly. Result: 0 re-seat teleports across the whole session (the original bug measured 75-885 units) — position held steady through both the stable phase and 36 forced conflict pulses. `prototest` on the deployed binary: 333/333, including the 13 `JailAnchor.h` checks (vouched cage/bed → HOLD, unvouched → RECHAIN). Full logs available if useful.

### What was NOT tested

The exact network-race timing that produces the conflict window in the wild (guard put-to-work cycles, or WAN packet loss) wasn't reproduced bit-for-bit — the live repro forced the same *state* (kind conflict on an anchored captive) via direct memory writes rather than waiting for the real race, and the host followed `streamKind` (re-chained cleanly) rather than hitting the `HOLD` branch in that specific run. The `HOLD` branch itself is covered by the 13 unit checks against the real binary, not exercised end-to-end live. Flagging that distinction honestly.