### PR TITLE
Fix joining player stuck "carried" forever when the carrier is authoritative (owner-side carried self-heal)

### DIFF
--- a/src/plugin/core/CarriedHeal.h
+++ b/src/plugin/core/CarriedHeal.h
@@ -1,0 +1,61 @@
+// CarriedHeal.h - owner-side carried-body reconcile policy (pure, zero
+// game/Win32 deps).
+//
+// Carry edges are CARRIER-authored (EVT_PICKUP_BODY / EVT_DROP_BODY; the host
+// authors them for world-NPC carriers, doctrine 28), and applyTargets never
+// drives a body in ownHands_ - so an OWNED body sitting on someone's shoulder
+// has no self-heal path of its own: if the host's EVT_DROP_BODY fails to apply
+// on the local carrier copy (resolve fail, carrier re-containered, or the local
+// sim never executed the pickup) the owner stays carried indefinitely
+// (SYNC_GAPS 16b, 2026-07-11 field report: the join PC, KO'd and hauled by a
+// cross-visible enemy pack, was put down in the host's world but stayed carried
+// on the join).
+//
+// The rule: the owner of a carried body reconciles its LOCAL isBeingCarried
+// against the carrier's streamed TASK_CARRY_BODY claim. While some live stream
+// still claims the body as its carry subject, the local carry is believed. When
+// NO stream claims it, a debounce window arms (stance samples ride the lossy
+// batch - a one-tick gap must never rip a genuine carry apart, the carry-side
+// carryNoSeeTick lesson); only after the window elapses does the owner release
+// the body locally. Firing resets the window, so a release that fails to take
+// (carrier not found this pass) re-arms and retries a full window later.
+// Tested in src/prototest/main.cpp (testCarriedHeal); used by
+// Replicator::applyTargets in ReplicatorDrive.cpp.
+
+#ifndef COOP_CARRIED_HEAL_H
+#define COOP_CARRIED_HEAL_H
+
+namespace coop {
+
+enum CarriedHealAct {
+    CARRIED_HEAL_NONE = 0, // in sync (or debounce still running) - do nothing
+    CARRIED_HEAL_ARM  = 1, // divergence first seen - debounce window armed
+    CARRIED_HEAL_FIRE = 2  // window elapsed - execute the local release now
+};
+
+// One reconcile step for one owned body. beingCarried = the LOCAL
+// Character::isBeingCarried truth; streamClaims = some live streamed row still
+// reports TASK_CARRY_BODY with this body as subject; *noSeeTick = the per-hand
+// debounce anchor (0 = disarmed), updated in place exactly like the carrier-side
+// carryNoSeeTick.
+inline CarriedHealAct carriedHealStep(bool beingCarried, bool streamClaims,
+                                      unsigned long nowMs, unsigned long dropMs,
+                                      unsigned long* noSeeTick) {
+    if (!beingCarried || streamClaims) { // in sync: disarm any pending window
+        *noSeeTick = 0;
+        return CARRIED_HEAL_NONE;
+    }
+    if (*noSeeTick == 0) {              // first unclaimed tick: arm, don't act
+        *noSeeTick = nowMs;
+        return CARRIED_HEAL_ARM;
+    }
+    if ((nowMs - *noSeeTick) > dropMs) { // window elapsed: release + re-arm
+        *noSeeTick = 0;
+        return CARRIED_HEAL_FIRE;
+    }
+    return CARRIED_HEAL_NONE;           // window still running
+}
+
+} // namespace coop
+
+#endif // COOP_CARRIED_HEAL_H

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -799,6 +799,11 @@ private:
     void logDriveTelemetry(unsigned long now);
     //   * age out long-stale targets_ entries (reliable-event latches preserved).
     void ageOutStaleTargets(unsigned long now);
+    //   * owner-side carried self-heal (SYNC_GAPS 16b): unlike the phases above
+    //     this one also reads LOCAL carry state, so it takes gw + the captured
+    //     squad rather than only Replicator members + the tick clock.
+    void healOwnCarried(GameWorld* gw, const EntityState* oracleSquad,
+                        unsigned int oracleSquadN, unsigned long now);
 
     std::map<Key, Driven> targets_;
     // Host side: last bodyState we published per owned entity (+ when it was last
@@ -955,6 +960,12 @@ private:
     // (5 s re-author window) PEER-ENTER must not re-jail a body its owner
     // just freed - the exit-vs-reauthor race guard.
     std::map<Key, unsigned long> ownFurnExit_;
+    // Owner-side carried self-heal (SYNC_GAPS 16b): per-own-hand debounce
+    // anchor - first tick an OWNED body's local isBeingCarried had NO live
+    // streamed TASK_CARRY_BODY claim backing it (0 = disarmed). Stepped by
+    // coop::carriedHealStep in applyTargets; entries erased once the body is
+    // no longer carried, so the map stays squad-sized.
+    std::map<Key, unsigned long> ownCarriedNoSee_;
     InterpConfig          cfg_;
     float                 catchupK_;  // walk-drive gap-proportional speed gain
     float                 snapDist_;  // moving-body hard-snap distance floor (u)

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -189,6 +189,7 @@ void Replicator::resetSession() {
     peerCamMs_ = 0;
     furnPeerPend_.clear();
     ownFurnExit_.clear();
+    ownCarriedNoSee_.clear(); // 16b owner-side carry heal: old world's anchors
     // Session maps + change-gate baselines (they describe the OLD world; the
     // reloaded save re-seeds them on first sample).
     ownBuilds_.clear();

--- a/src/plugin/sync/ReplicatorDrive.cpp
+++ b/src/plugin/sync/ReplicatorDrive.cpp
@@ -1493,6 +1493,11 @@ void Replicator::applyTargets(GameWorld* gw) {
         }
         if (haveActual) { d.haveActual = true; d.lx = ax; d.ly = ay; d.lz = az; }
     }
+    // Owner-side carried self-heal (SYNC_GAPS 16b): reconcile each OWN member's
+    // local carry against the peer's streamed claim. Runs right after the drive
+    // loop (needs gw + the captured squad still in scope) before the telemetry
+    // epilogue phases.
+    healOwnCarried(gw, oracleSquad, oracleSquadN, now);
     pruneDriveGrace(now);
     logDriveTelemetry(now);
     ageOutStaleTargets(now);
@@ -1601,6 +1606,123 @@ void Replicator::logDriveTelemetry(unsigned long now) {
                   trusted, (unsigned)targets_.size() - trusted, trustGrants_, trustRevokes_);
         b[sizeof(b) - 1] = '\0';
         coop::logLine(b);
+    }
+}
+
+
+// --- Drive-tick epilogue phase: owner-side carried self-heal (SYNC_GAPS 16b) --
+// Split out of applyTargets' post-loop tail like the other epilogue phases, but
+// this one also reconciles LOCAL carry state, so it needs gw + the already
+// captured squad (oracleSquad/oracleSquadN) - passed in rather than read from
+// Replicator members alone. Body is verbatim the original applyTargets hook.
+void Replicator::healOwnCarried(GameWorld* gw, const EntityState* oracleSquad,
+                                unsigned int oracleSquadN, unsigned long now) {
+    // ---- Carried-body sync (SYNC_GAPS 16b): owner-side carried self-heal ----
+    // Carry edges are CARRIER-authored (EVT_PICKUP_BODY/EVT_DROP_BODY; the host
+    // authors them for world-NPC carriers, doctrine 28), and the loop above
+    // skips ownHands_ - so an OWNED body on someone's shoulder had NO reconcile
+    // path of its own: when the host's EVT_DROP_BODY failed to apply on the
+    // local carrier copy (resolve fail, carrier re-containered, or the local
+    // sim never executed the pickup) the owner stayed carried indefinitely
+    // (2026-07-11 field report: the join PC, KO'd + hauled by an enemy pack,
+    // was put down in the host's world but stayed carried on the join). Heal
+    // the owner side: an own squad member whose LOCAL isBeingCarried is set
+    // while NO live streamed row claims it as its carry subject
+    // (TASK_CARRY_BODY + subject hand) gets a debounced local release through
+    // the ordinary engine drop chain on its LOCAL carrier. The heal only ever
+    // judges carries whose truth lives on the PEER: a carrier we own, and a
+    // world-NPC carrier when WE are the world authority (streamNpcs_), are
+    // local sim facts with no stream to reconcile against - never touched.
+    // Debounced like the carrier-side carryNoSeeTick (stance samples ride the
+    // lossy batch), and a row only stops "claiming" once it either streams a
+    // non-carry task or ages past the claim horizon - a WAN stall alone must
+    // never rip a genuine carry apart.
+    if (carrySync_) {
+        for (unsigned int i = 0; i < oracleSquadN; ++i) {
+            const EntityState& m = oracleSquad[i];
+            Key mk; mk.t = m.hType; mk.c = m.hContainer;
+            mk.cs = m.hContainerSerial; mk.i = m.hIndex; mk.s = m.hSerial;
+            // Owner-scope only: the PEER's tab members are its owner's job
+            // (this heal running on both machines covers both directions).
+            if (ownHands_.find(mk) == ownHands_.end()) continue;
+            Character* mc = engine::resolveCharByHand(m.hIndex, m.hSerial, m.hType,
+                                                      m.hContainer, m.hContainerSerial);
+            engine::CarryRead mcr;
+            if (!mc || !engine::readCarry(mc, &mcr) || !mcr.beingCarried) {
+                ownCarriedNoSee_.erase(mk); // not carried (or unreadable): disarm
+                continue;
+            }
+            // Find the LOCAL carrier and classify its authority. Squad pass
+            // first (a player hauling a player); world-NPC scan only where an
+            // NPC carrier could ever be healed (the join - on the host a world
+            // NPC IS the authority, and an unfound carrier is indistinguishable
+            // from one, so the host judges peer-squad carriers only). Scans by
+            // live local state, not the streamed hand: carrier re-container is
+            // one of the very failure modes this heals.
+            Character* carrier = 0;
+            bool carrierLocal = false; // carrier's truth is OUR local sim
+            unsigned int cIdx = 0, cSer = 0;
+            for (unsigned int j = 0; j < oracleSquadN && !carrier; ++j) {
+                if (j == i) continue;
+                const EntityState& q = oracleSquad[j];
+                Character* qc = engine::resolveCharByHand(q.hIndex, q.hSerial,
+                                    q.hType, q.hContainer, q.hContainerSerial);
+                engine::CarryRead qcr;
+                if (qc && engine::readCarry(qc, &qcr) && qcr.carrying &&
+                    qcr.carried[3] == m.hIndex && qcr.carried[4] == m.hSerial) {
+                    carrier = qc; cIdx = q.hIndex; cSer = q.hSerial;
+                    Key qk; qk.t = q.hType; qk.c = q.hContainer;
+                    qk.cs = q.hContainerSerial; qk.i = q.hIndex; qk.s = q.hSerial;
+                    carrierLocal = (ownHands_.find(qk) != ownHands_.end());
+                }
+            }
+            if (!carrier && !streamNpcs_) {
+                static Character*  healChars[96];  // main-thread only
+                static EntityState healStates[96];
+                unsigned int nn = engine::listNpcs(gw, healChars, healStates, 96);
+                for (unsigned int j = 0; j < nn && !carrier; ++j) {
+                    engine::CarryRead ccr;
+                    if (engine::readCarry(healChars[j], &ccr) && ccr.carrying &&
+                        ccr.carried[3] == m.hIndex && ccr.carried[4] == m.hSerial) {
+                        carrier = healChars[j];
+                        cIdx = healStates[j].hIndex; cSer = healStates[j].hSerial;
+                    }
+                }
+            }
+            if (carrierLocal || (!carrier && streamNpcs_)) {
+                ownCarriedNoSee_.erase(mk); // locally-authoritative carry: believe it
+                continue;
+            }
+            // Does any live streamed row still claim this member as its carry
+            // subject? latest() (not this tick's sample) so a between-batches
+            // gap on a slow-streamed carrier does not read as a drop.
+            bool claimed = false;
+            for (std::map<Key, Driven>::iterator ct = targets_.begin();
+                 !claimed && ct != targets_.end(); ++ct) {
+                if (ownHands_.find(ct->first) != ownHands_.end()) continue;
+                if (ct->second.lastSeenMs == 0 ||
+                    (now - ct->second.lastSeenMs) > CARRY_CLAIM_STALE_MS) continue;
+                EntityState ls;
+                if (!ct->second.interp.latest(&ls, 0, 0, 0)) continue;
+                claimed = coop::taskIsCarry(ls.task) &&
+                          ls.sIndex == m.hIndex && ls.sSerial == m.hSerial;
+            }
+            unsigned long& tick = ownCarriedNoSee_[mk];
+            if (coop::carriedHealStep(true, claimed, now, CARRY_DROP_MS,
+                                      &tick) == coop::CARRIED_HEAL_FIRE) {
+                // No carrier found at all: nothing to drop - the fired log line
+                // is the triage evidence (and the window re-arms, so a body
+                // stuck this way reports once per window, not per tick).
+                bool ok = carrier ? engine::applyDrop(carrier, /*ragdoll*/true)
+                                  : false;
+                char b[160]; _snprintf(b, sizeof(b) - 1,
+                    "[carry] OWNER HEAL DROP subj=%u,%u carrier=%u,%u ok=%d",
+                    m.hIndex, m.hSerial, cIdx, cSer, ok ? 1 : 0);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+                // drop refused / carrier missing: carriedHealStep re-armed the
+                // window, so a still-stuck body retries a full window later.
+            }
+        }
     }
 }
 

--- a/src/plugin/sync/ReplicatorUtil.h
+++ b/src/plugin/sync/ReplicatorUtil.h
@@ -33,6 +33,7 @@
 #include "../core/DeathLatch.h" // rekeyCarryLatch (down/death latch carry on re-key)
 #include "ChangeGate.h" // Phase 6: shared change-gated send/accept policy
 #include "SyncContext.h" // Phase 6: per-tick channel call environment
+#include "../core/CarriedHeal.h" // carriedHealStep (owner-side carried self-heal, 16b)
 #include "../CoopLog.h"
 
 #include <windows.h> // GetTickCount
@@ -163,6 +164,11 @@ const unsigned long ATTR_WINDOW_MS = 3000; // remember a combatant's victim this
 const unsigned long CARRY_HEAL_MS = 1500; // min gap between self-heal pickups
 const unsigned long CARRY_DROP_MS = 3000; // stream must stop reporting the carry
                                           // this long before the local copy drops
+const unsigned long CARRY_CLAIM_STALE_MS = 30000; // owner-side heal (16b): a streamed
+                                          // row older than this no longer counts as
+                                          // claiming its carry subject (matches the
+                                          // targets_ prune horizon - a WAN stall must
+                                          // never read as a host-side drop)
 // Furniture occupancy sync (protocol 19): same shape as the carry self-heal.
 const unsigned long FURN_HEAL_MS = 1500;  // min gap between self-heal enters
 const unsigned long FURN_EXIT_MS = 3000;  // stream must stop reporting occupancy

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -34,6 +34,7 @@
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
+#include "../plugin/core/CarriedHeal.h"  // owner-side carried self-heal (16b)
 
 #include <set>
 
@@ -1355,6 +1356,70 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- 12. Owner-side carried self-heal debounce (CarriedHeal.h) ------------------
+// Guards the SYNC_GAPS 16b fix: the owner of a carried body reconciles its LOCAL
+// isBeingCarried against the carrier's streamed TASK_CARRY_BODY claim. The step
+// must (a) stay quiet while a live stream claims the carry, (b) arm-then-fire only
+// after a full debounce window with NO claim (a one-batch stream blip must never
+// rip a genuine carry apart - the carryNoSeeTick lesson), and (c) re-arm after
+// firing so a release that failed to take retries a full window later.
+
+static void testCarriedHeal() {
+    std::printf("== owner-side carried heal debounce (CarriedHeal.h) ==\n");
+    const unsigned long DROP = 3000;
+    unsigned long tick = 0;
+
+    // Not carried: nothing to do, anchor stays disarmed.
+    tick = 0;
+    CHECK("not carried -> NONE",
+          carriedHealStep(false, false, 1000, DROP, &tick) == CARRIED_HEAL_NONE);
+    CHECK("not carried -> anchor disarmed", tick == 0);
+
+    // Carried + claimed by a live stream: believed, anchor stays disarmed.
+    tick = 0;
+    CHECK("carried+claimed -> NONE",
+          carriedHealStep(true, true, 1000, DROP, &tick) == CARRIED_HEAL_NONE);
+    CHECK("carried+claimed -> anchor disarmed", tick == 0);
+
+    // First unclaimed tick arms the window but must NOT act yet.
+    tick = 0;
+    CHECK("first unclaimed -> ARM",
+          carriedHealStep(true, false, 1000, DROP, &tick) == CARRIED_HEAL_ARM);
+    CHECK("ARM stamps the anchor", tick == 1000);
+
+    // Inside the window: still quiet (a stream blip shorter than the window).
+    CHECK("inside window -> NONE",
+          carriedHealStep(true, false, 1000 + DROP, DROP, &tick) == CARRIED_HEAL_NONE);
+    CHECK("window boundary is exclusive (== dropMs does not fire)", tick == 1000);
+
+    // A claim arriving mid-window disarms it - no release ever happens.
+    CHECK("claim mid-window -> NONE + disarm",
+          carriedHealStep(true, true, 2500, DROP, &tick) == CARRIED_HEAL_NONE &&
+          tick == 0);
+
+    // Full window with no claim: fire, and re-arm (anchor back to 0).
+    tick = 0;
+    carriedHealStep(true, false, 1000, DROP, &tick);           // arm at t=1000
+    CHECK("window elapsed -> FIRE",
+          carriedHealStep(true, false, 1000 + DROP + 1, DROP, &tick) ==
+          CARRIED_HEAL_FIRE);
+    CHECK("FIRE re-arms (anchor cleared)", tick == 0);
+
+    // Still stuck after a failed release: the NEXT pass arms again, then fires
+    // again a full window later (throttled retry, never a per-tick drop spam).
+    CHECK("post-FIRE re-arms on next pass",
+          carriedHealStep(true, false, 5000, DROP, &tick) == CARRIED_HEAL_ARM);
+    CHECK("post-FIRE retry fires a full window later",
+          carriedHealStep(true, false, 5000 + DROP + 1, DROP, &tick) ==
+          CARRIED_HEAL_FIRE);
+
+    // Body put down locally (drop finally applied): disarmed, back to quiet.
+    carriedHealStep(true, false, 12000, DROP, &tick);          // re-armed
+    CHECK("local drop applied -> NONE + disarm",
+          carriedHealStep(false, false, 12500, DROP, &tick) == CARRIED_HEAL_NONE &&
+          tick == 0);
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1377,6 +1442,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testCarriedHeal();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
### What this fixes

A joining player who gets picked up by an enemy stays carried forever if that enemy is authoritative on the other side — the carry never clears locally, so the join PC is permanently stuck. This is the gap you had logged as 16b in your sync-gap notes (before the resources/ cleanup).

### How

`carriedHealStep` (new header `CarriedHeal.h`): an owner-side self-heal that clears a stuck carry — but only under an authority guard. It never heals a carry whose truth is local; it only acts when the truth for the carry lives on the peer. That guard is the whole point: without it the heal would fight legitimate local carries.

### Known limitation (by design, not a bug in this fix)

The symmetric inverse case — a host squad member carried by a peer-authoritative NPC — is NOT healed by this. That's a known remaining gap, documented, and out of scope here; covering it needs the same logic on the other side plus its own authority reasoning, and I didn't want to ship a guess.

### Testing

- Built with the real toolchain (VS2010 v100 x64), 0 errors.
- Live smoke via your `dev_cycle.ps1` runner, branch alone on top of v0.45: full host↔join connect, gameplay reached, 0 `ERROR:` lines, clean shutdown. PASS.
- Combined with my other three fix branches: prototest 333/333, smoke PASS, independent adversarial review of the combined diff (Claude-assisted) found no cross-fix interactions.

### What was NOT tested

No targeted live repro of the join-gets-carried scenario — the smoke run has no combat pickup. The authority guard logic is the part I'd most like a second pair of eyes on.