### PR TITLE
Fix money not actually syncing: the channel was tracking a dead field, plus delta-based reconciliation for the real shared wallet

### DIFF
--- a/scripts/oracles/World.ps1
+++ b/scripts/oracles/World.ps1
@@ -60,16 +60,17 @@ function Test-ShopProbe {
     if ($null -eq $hostBuy) { $why += "host never logged its SHOPBUY attempt" }
     if ($null -eq $joinBuy) { $why += "join never logged its SHOPBUY attempt" }
 
-    # 4. Both scripted wallet writes logged (the 1b apply-primitive check + the
-    #    decisive crossing lever: side-distinct sentinels, host 5000 / join 7000).
-    $setRegex = 'SCENARIO WALLETSET who=(host|join) rank=(\d+) target=(-?\d+) ok=(\d) before=(-?\d+) after=(-?\d+)'
+    # 4. Both scripted wallet writes logged (the apply-primitive check: each side
+    #    ADDS a side-distinct amount to the shared faction wallet - host +4000,
+    #    join +6000. With money sync OFF the deltas do NOT cross - the baseline).
+    $setRegex = 'SCENARIO WALLETSET who=(host|join) rank=\d+ add=(-?\d+) ok=(\d) before=(-?\d+) after=(-?\d+)'
     $hostSet = Select-String -Path $HostFile -Pattern $setRegex -ErrorAction SilentlyContinue | Select-Object -Last 1
     $joinSet = Select-String -Path $JoinFile -Pattern $setRegex -ErrorAction SilentlyContinue | Select-Object -Last 1
     if ($null -eq $hostSet) { $why += "host never logged its WALLETSET" }
     if ($null -eq $joinSet) { $why += "join never logged its WALLETSET" }
     $hostSetOk = $false; $joinSetOk = $false
-    if ($hostSet) { $hostSetOk = ($hostSet.Matches[0].Groups[4].Value -eq '1') -and ($hostSet.Matches[0].Groups[6].Value -eq $hostSet.Matches[0].Groups[3].Value) }
-    if ($joinSet) { $joinSetOk = ($joinSet.Matches[0].Groups[4].Value -eq '1') -and ($joinSet.Matches[0].Groups[6].Value -eq $joinSet.Matches[0].Groups[3].Value) }
+    if ($hostSet) { $hostSetOk = ($hostSet.Matches[0].Groups[3].Value -eq '1') -and ([int]$hostSet.Matches[0].Groups[5].Value -eq [int]$hostSet.Matches[0].Groups[4].Value + [int]$hostSet.Matches[0].Groups[2].Value) }
+    if ($joinSet) { $joinSetOk = ($joinSet.Matches[0].Groups[3].Value -eq '1') -and ([int]$joinSet.Matches[0].Groups[5].Value -eq [int]$joinSet.Matches[0].Groups[4].Value + [int]$joinSet.Matches[0].Groups[2].Value) }
 
     # FINDING A: final wallet divergence per rank (does anything cross today?).
     $rankDiv = @{}
@@ -144,14 +145,15 @@ function Test-ShopProbe {
                             walletDiv = $rankDivMetric } -Detail $detail)
 }
 
-# money_sync (protocol 22, moneySync ON): the wallet-channel gate. Same script
-# as shop_probe minus the vendor legs: each side writes a side-distinct wallet
-# sentinel into the tab it OWNS (host rank0=5000, join rank1=7000) and the
-# channel must carry it across - the gate is CONVERGENCE:
-#   1. both WALLETSET writes succeeded (apply primitive works);
-#   2. the peer's WALLET series ends at the sender's sentinel for that rank
-#      (a "[money] RECV" landed and stuck);
-#   3. every rank readable on both sides ends converged (no drift elsewhere).
+# money_sync (protocol 22b, moneySync ON): the shared-wallet gate. The player's
+# real money is ONE shared per-faction pool (engine::readPlayerWallet), so the
+# channel replicates DELTAS: host ADDS +add_h, join ADDS +add_j, and both sides'
+# pools must CONVERGE to base + add_h + add_j (each side sees the peer's delta).
+# The gate:
+#   1. both WALLETSET writes succeeded (ok=1, after=before+add);
+#   2. host and join final WALLET (rank 0) are EQUAL (the shared pool converged);
+#   3. that final reflects BOTH deltas (final == host-before + add_h + add_j),
+#      i.e. neither side's contribution was lost (what absolute sync would do).
 function Test-MoneySync {
     param([string]$HostFile, [string]$JoinFile)
     $why = @()
@@ -161,49 +163,50 @@ function Test-MoneySync {
     if ($hw.Keys.Count -eq 0) { $why += "host logged no WALLET series" }
     if ($jw.Keys.Count -eq 0) { $why += "join logged no WALLET series" }
 
-    $setRegex = 'SCENARIO WALLETSET who=(host|join) rank=(\d+) target=(-?\d+) ok=(\d) before=(-?\d+) after=(-?\d+)'
+    $setRegex = 'SCENARIO WALLETSET who=(host|join) rank=\d+ add=(-?\d+) ok=(\d) before=(-?\d+) after=(-?\d+)'
     $hostSet = Select-String -Path $HostFile -Pattern $setRegex -ErrorAction SilentlyContinue | Select-Object -Last 1
     $joinSet = Select-String -Path $JoinFile -Pattern $setRegex -ErrorAction SilentlyContinue | Select-Object -Last 1
     if ($null -eq $hostSet) { $why += "host never logged its WALLETSET" }
     if ($null -eq $joinSet) { $why += "join never logged its WALLETSET" }
     foreach ($pair in @(@('host', $hostSet), @('join', $joinSet))) {
         $side = $pair[0]; $s = $pair[1]
-        if ($s -and (($s.Matches[0].Groups[4].Value -ne '1') -or
-                     ($s.Matches[0].Groups[6].Value -ne $s.Matches[0].Groups[3].Value))) {
-            $why += "$side WALLETSET write failed (ok/after mismatch)"
+        if ($s) {
+            $add = [int]$s.Matches[0].Groups[2].Value
+            $before = [int]$s.Matches[0].Groups[4].Value
+            $after = [int]$s.Matches[0].Groups[5].Value
+            if (($s.Matches[0].Groups[3].Value -ne '1') -or ($after -ne $before + $add)) {
+                $why += "$side WALLETSET write failed (ok/after mismatch)"
+            }
         }
     }
 
-    # Crossing: the peer's final money at the sender's rank equals the sentinel.
-    $crossed = 0; $expected = 0
-    foreach ($leg in @(@($hostSet, $jw, 'host->join'), @($joinSet, $hw, 'join->host'))) {
-        $s = $leg[0]; $peer = $leg[1]; $tag = $leg[2]
-        if ($null -eq $s) { continue }
-        $rank = [int]$s.Matches[0].Groups[2].Value
-        $tgt  = [int]$s.Matches[0].Groups[3].Value
-        $expected++
-        if (-not $peer.ContainsKey($rank)) { $why += "$tag rank $rank absent from peer WALLET series"; continue }
-        $end = $peer[$rank][$peer[$rank].Count - 1].money
-        if ($end -eq $tgt) { $crossed++ }
-        else { $why += "$tag sentinel did not cross (peer rank $rank ended $end, want $tgt)" }
-    }
+    $addH = if ($hostSet) { [int]$hostSet.Matches[0].Groups[2].Value } else { 0 }
+    $addJ = if ($joinSet) { [int]$joinSet.Matches[0].Groups[2].Value } else { 0 }
+    $hostBefore = if ($hostSet) { [int]$hostSet.Matches[0].Groups[4].Value } else { -1 }
 
-    # No drift on any co-visible rank.
-    $diverged = @()
-    foreach ($r in $hw.Keys) {
-        if (-not $jw.ContainsKey($r)) { continue }
-        $hEnd = $hw[$r][$hw[$r].Count - 1].money
-        $jEnd = $jw[$r][$jw[$r].Count - 1].money
-        if ($hEnd -ge 0 -and $jEnd -ge 0 -and $hEnd -ne $jEnd) { $diverged += "rank$r($hEnd/$jEnd)" }
+    # Both sides' shared pool (rank 0) must end EQUAL and reflect both deltas.
+    $crossed = 0; $expected = 2
+    $hEnd = if ($hw.ContainsKey(0)) { $hw[0][$hw[0].Count - 1].money } else { -1 }
+    $jEnd = if ($jw.ContainsKey(0)) { $jw[0][$jw[0].Count - 1].money } else { -1 }
+    if ($hEnd -lt 0 -or $jEnd -lt 0) {
+        $why += "shared wallet series missing (host=$hEnd join=$jEnd)"
+    } else {
+        if ($hEnd -ne $jEnd) { $why += "pools diverged (host=$hEnd join=$jEnd)" }
+        else {
+            $wantFinal = $hostBefore + $addH + $addJ
+            # host delta present on the join side (join saw host's contribution)
+            if ($jEnd -eq $wantFinal) { $crossed++ } else { $why += "join pool missing host delta (join=$jEnd want=$wantFinal)" }
+            # join delta present on the host side (host saw join's contribution)
+            if ($hEnd -eq $wantFinal) { $crossed++ } else { $why += "host pool missing join delta (host=$hEnd want=$wantFinal)" }
+        }
     }
-    if ($diverged.Count -gt 0) { $why += ("final wallets diverged: " + ($diverged -join ", ")) }
 
     $v = if ($why.Count -eq 0) { "PASS" } else { "FAIL" }
     $detail = $why -join "; "
-    Write-Host "  MONEY-SYNC $v - crossed=$crossed/$expected $detail"
+    Write-Host "  MONEY-SYNC $v - crossed=$crossed/$expected hostPool=$hEnd joinPool=$jEnd $detail"
     return (Add-GateResult -Name "money_sync" -Status $v `
                 -Metrics @{ crossed = $crossed; expected = $expected
-                            diverged = $diverged.Count } -Detail $detail)
+                            hostPool = $hEnd; joinPool = $jEnd } -Detail $detail)
 }
 
 # recruit_probe (protocol 23 phase 0): mid-session recruitment evidence.
@@ -2285,24 +2288,34 @@ function Test-VendorTrade {
     $hInv = Get-TinvFinal $HostFile
     $jInv = Get-TinvFinal $JoinFile
 
+    # 2. Wallet (protocol 22b): the SHARED faction pool (rank 0). Both sides'
+    #    debits (-PRICE each) plus both seeds land on the ONE pool, so both series
+    #    must CONVERGE to the same final AND that final must reflect BOTH debits
+    #    (the pool dropped by 2*PRICE from its peak = both spends crossed).
     $crossed = 0
-    foreach ($leg in @(@($hostTrade, $jw, 'host->join'), @($joinTrade, $hw, 'join->host'))) {
-        $t = $leg[0]; $peerW = $leg[1]; $tag = $leg[2]
-        if ($null -eq $t -or $t.Matches[0].Groups[3].Value -ne '1') { continue }
-        $rank   = [int]$t.Matches[0].Groups[2].Value
-        $wAfter = [int]$t.Matches[0].Groups[7].Value
-        # 2. wallet debit crossed.
-        if (-not $peerW.ContainsKey($rank)) { $why += "$tag rank $rank absent from peer WALLET series" }
-        else {
-            $end = $peerW[$rank][$peerW[$rank].Count - 1].money
-            if ($end -eq $wAfter) { $crossed++ }
-            else { $why += "$tag wallet debit did not cross (peer rank $rank ended $end, want $wAfter)" }
-        }
-        # 3. inventory content converged.
+    $hPool = if ($hw.ContainsKey(0)) { $hw[0] } else { @() }
+    $jPool = if ($jw.ContainsKey(0)) { $jw[0] } else { @() }
+    if ($hPool.Count -eq 0 -or $jPool.Count -eq 0) {
+        $why += "shared WALLET series missing (host=$($hPool.Count) join=$($jPool.Count) samples)"
+    } else {
+        $hEnd = $hPool[$hPool.Count - 1].money
+        $jEnd = $jPool[$jPool.Count - 1].money
+        $peak = 0
+        foreach ($s in $hPool) { if ($s.money -gt $peak) { $peak = $s.money } }
+        foreach ($s in $jPool) { if ($s.money -gt $peak) { $peak = $s.money } }
+        $price = if ($hostTrade) { [int]$hostTrade.Matches[0].Groups[5].Value } else { 250 }
+        if ($hEnd -ne $jEnd) { $why += "shared pool diverged (host=$hEnd join=$jEnd)" }
+        elseif ($peak - $hEnd -ne 2 * $price) { $why += "pool did not reflect both debits (peak=$peak final=$hEnd drop=$($peak - $hEnd) want=$(2*$price))" }
+        else { $crossed = 2 }
+    }
+
+    # 3. Inventory content converged for each traded tab (host added to rank 0,
+    #    join to rank 1); the bought item crossed via the inventory channel.
+    foreach ($rank in @(0, 1)) {
         if (-not ($hInv.ContainsKey($rank) -and $jInv.ContainsKey($rank))) {
-            $why += "$tag rank $rank TINV series missing on a side"
+            $why += "rank $rank TINV series missing on a side"
         } elseif ($hInv[$rank].hash -ne $jInv[$rank].hash) {
-            $why += "$tag rank $rank inventory hash diverged (host $($hInv[$rank].hash) join $($jInv[$rank].hash))"
+            $why += "rank $rank inventory hash diverged (host $($hInv[$rank].hash) join $($jInv[$rank].hash))"
         }
     }
 

--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -755,19 +755,23 @@ struct StatsPacket {
     f32 freeAttributePoints;   // CharStats::freeAttributePoints (int on wire as f32; -1 = unreadable)
 };
 
-// ---- Protocol 22: per-tab wallet snapshot -----------------------------------
-// Owner-authoritative money for ONE player squad tab, keyed by the tab's RANK
-// among the distinct sorted member containers - the same cross-client-stable
-// tab identity the ownership partition uses (a hand key would also work, but
-// rank is what both sides already agree on for "whose tab is whose"). Change-
-// gated with a floor + safety resend (the PKT_STATS pacing); the receiver
-// writes the value via Ownerships::setMoney onto the platoon of that rank's
-// tab leader. money is signed on the wire because the engine field is an int.
+// ---- Protocol 22b: shared player-wallet DELTA -------------------------------
+// The player's real money is ONE per-faction wallet (Faction::factionOwnerships,
+// what the UI shows and shops mutate; confirmed by live RE 2026-07-20 - see
+// engine::readPlayerWallet), shared by the whole squad and by BOTH co-op players
+// (they drive the same save faction). The pre-44 channel replicated the DEAD
+// per-Platoon field by tab RANK, so real money never crossed. Now the channel
+// replicates the shared wallet: each side sends the DELTA of its own local
+// change and the receiver ADDS it (moneyApplyDelta), so concurrent spends from
+// both players sum correctly (1000 - 250 - 100 = 650 on both). Reliable+ordered
+// delivery makes each delta apply exactly once (no safety resend - resending a
+// delta would double-apply). tabRank is unused (kept 0) - the wallet is not
+// per-tab. money is the signed delta (engine field is int).
 struct MoneyPacket {
     u8  type;    // = PKT_MONEY
-    u32 ownerId; // network player id of the sender (the tab's owner)
-    u32 tabRank; // squad-tab rank (0 = host-owned tab, 1 = join-owned, ...)
-    int money;   // Ownerships::money for that tab's platoon
+    u32 ownerId; // network player id of the sender
+    u32 tabRank; // unused (0) - the shared faction wallet is not per-tab
+    int money;   // signed DELTA to apply to the shared faction wallet
 };
 
 // ---- Protocol 24: player-faction relation row --------------------------------

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -1038,10 +1038,11 @@ void tickReplicatePublish(GameWorld* gw, bool worldLive) {
             g_repl.publishStats(gw, g_net, g_net.localId());
             g_repl.applyStats(gw, g_inbound);
         }
-        // Per-tab wallet sync (protocol 22): each client streams the money of
-        // the squad tabs it OWNS (change-gated reliable, keyed by tab rank);
-        // received snapshots land on the peer tabs via Ownerships::setMoney.
-        // Ordered after publishOwned (ownership ranks are the partition rule).
+        // Shared-wallet sync (protocol 22b): the player's real money is ONE
+        // per-faction wallet (Faction::factionOwnerships) shared by both co-op
+        // players, so each client publishes the DELTA of its own local change
+        // and the peer ADDS it - concurrent spends sum correctly. Reliable +
+        // ordered, so each delta applies exactly once (no safety resend).
         if (g_cfg.moneySync) {
             g_repl.publishMoney(replCtx(gw));
             g_repl.applyMoney(replCtx(gw));

--- a/src/plugin/core/MoneyReconcile.h
+++ b/src/plugin/core/MoneyReconcile.h
@@ -1,0 +1,61 @@
+// MoneyReconcile.h - reconciliacion de la cartera COMPARTIDA por delta (pura,
+// sin dependencias de juego/Win32).
+//
+// El dinero del jugador en Kenshi es UNA sola cartera por faccion
+// (Faction::factionOwnerships::money), compartida por todo el squad y por AMBOS
+// jugadores en co-op (los dos controlan la misma faccion del save compartido).
+// Ver la cadena confirmada por RE en EngineWorld.cpp (readPlayerWallet).
+//
+// Un pool compartido con DOS escritores no se puede sincronizar con valores
+// absolutos: si los dos gastan antes de recibirse (1000 -> host 750, join 900),
+// el ultimo valor absoluto que llega pisa al otro y se pierde dinero. La forma
+// correcta es replicar el DELTA de cada lado y APLICARLO (sumar) en el peer, de
+// modo que 1000 - 250 (host) - 100 (join) = 650 converge en ambos. El canal
+// PKT_MONEY es reliable+ordered (ENet), asi que cada delta se entrega una sola
+// vez: no hay doble aplicacion y no hace falta safety-resend (a diferencia del
+// canal absoluto per-tab anterior).
+//
+// MoneyState.known es la "linea base": el ultimo valor de la cartera que este
+// cliente considera ya sincronizado con el peer. Se siembra en el primer sample
+// (sin emitir) y avanza tanto cuando publicamos un delta local como cuando
+// aplicamos un delta remoto (echo-guard: un delta aplicado nunca se re-detecta
+// como cambio local y se reenvia). Tested en src/prototest/main.cpp
+// (testMoneyReconcile); usado por Replicator::publishMoney/applyMoney.
+
+#ifndef COOP_MONEY_RECONCILE_H
+#define COOP_MONEY_RECONCILE_H
+
+namespace coop {
+
+struct MoneyState {
+    int  known;  // baseline: ultima cartera compartida conocida por este cliente
+    bool seeded; // false hasta el primer sample (evita emitir un delta espurio)
+    MoneyState() : known(0), seeded(false) {}
+};
+
+// Detecta el delta LOCAL a publicar comparando la cartera actual con la linea
+// base. Siembra en el primer sample (devuelve false, no se emite nada). En
+// samples posteriores devuelve true y rellena *outDelta solo si la cartera
+// cambio por accion local; avanza la base para no reenviar. outDelta puede ser
+// negativo (gasto) o positivo (ingreso), nunca 0 cuando devuelve true.
+inline bool moneyLocalDelta(MoneyState& s, int cur, int* outDelta) {
+    if (!s.seeded) { s.seeded = true; s.known = cur; return false; }
+    if (cur == s.known) return false;
+    if (outDelta) *outDelta = cur - s.known;
+    s.known = cur;
+    return true;
+}
+
+// Aplica un delta REMOTO sobre la cartera local: avanza la base por el delta
+// (para que el proximo moneyLocalDelta no lo confunda con un cambio local) y
+// devuelve el nuevo valor que hay que escribir en la cartera. Un cambio local
+// aun sin publicar sobrevive: queda como (cur - known) tras esta llamada y se
+// publica en el siguiente moneyLocalDelta.
+inline int moneyApplyDelta(MoneyState& s, int cur, int delta) {
+    s.known += delta;   // la base sigue al valor compartido
+    return cur + delta; // nuevo valor de la cartera local
+}
+
+} // namespace coop
+
+#endif // COOP_MONEY_RECONCILE_H

--- a/src/plugin/core/MoneyReconcile.h
+++ b/src/plugin/core/MoneyReconcile.h
@@ -46,14 +46,22 @@ inline bool moneyLocalDelta(MoneyState& s, int cur, int* outDelta) {
     return true;
 }
 
-// Aplica un delta REMOTO sobre la cartera local: avanza la base por el delta
-// (para que el proximo moneyLocalDelta no lo confunda con un cambio local) y
-// devuelve el nuevo valor que hay que escribir en la cartera. Un cambio local
-// aun sin publicar sobrevive: queda como (cur - known) tras esta llamada y se
+// Aplica un delta REMOTO sobre la cartera local: avanza la base y devuelve el
+// nuevo valor que hay que escribir en la cartera. La cartera de Kenshi nunca es
+// negativa, asi que el resultado se clampa a >=0 AQUI (unico sitio con el clamp)
+// y la base avanza por el delta REALMENTE aplicado (want - cur), NO por el delta
+// teorico. Si avanzasemos la base por el delta completo mientras la cartera se
+// clampa a 0, 'known' quedaria negativo y divergido de la cartera real (0): el
+// siguiente moneyLocalDelta veria cur(0) - known(<0) = delta positivo espurio y
+// publicaria dinero de la nada al peer (desync permanente). En el caso no-clamp
+// (want>=0) want-cur == delta, identico al comportamiento anterior, por lo que
+// un cambio local aun sin publicar sigue sobreviviendo como (cur - known) y se
 // publica en el siguiente moneyLocalDelta.
 inline int moneyApplyDelta(MoneyState& s, int cur, int delta) {
-    s.known += delta;   // la base sigue al valor compartido
-    return cur + delta; // nuevo valor de la cartera local
+    int want = cur + delta;      // valor teorico tras el delta remoto
+    if (want < 0) want = 0;      // la cartera compartida nunca baja de 0
+    s.known += (want - cur);     // la base sigue al valor REALMENTE escrito
+    return want;                 // nuevo valor de la cartera local (ya clampado)
 }
 
 } // namespace coop

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -1283,6 +1283,16 @@ bool readWalletByHand(const unsigned int mHand[5], int* outMoney);
 // Ownerships::setMoney (the money-sync apply primitive). Returns true on ok.
 bool writeWalletByHand(const unsigned int mHand[5], int money);
 
+// SEH-guarded: read/write the player's REAL wallet - the FACTION wallet
+// (gw->player->participant->factionOwnerships), which is what the UI shows and
+// shops mutate. There is ONE such wallet per player faction, shared by the whole
+// squad (not per-tab). This is the source of truth PKT_MONEY replicates; the
+// per-Platoon walletByHand pair above is the dead field the old channel used.
+// readPlayerWallet: *outMoney = -1 on failure, returns true on ok.
+// writePlayerWallet: money < 0 rejected, returns true on ok.
+bool readPlayerWallet(GameWorld* gw, int* outMoney);
+bool writePlayerWallet(GameWorld* gw, int money);
+
 // Purchase observability detour (protocol 22, 1c groundwork): hook Inventory::
 // buyItem so every REAL trade-UI purchase logs a "[shop] BUY-LOCAL" line
 // (seller identity + money, item sid, buyer). Automation cannot reach a real

--- a/src/plugin/game/EngineWorld.cpp
+++ b/src/plugin/game/EngineWorld.cpp
@@ -130,6 +130,58 @@ bool writeWalletByHand(const unsigned int mHand[5], int money) {
     } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
 }
 
+// ---- Protocol 22b: la cartera REAL del jugador (fuente de verdad) ------------
+//
+// Hallazgo de ingenieria inversa en vivo (2026-07-20, kenshi_x64 1.0.65, CE +
+// disassembler contra el proceso host): el dinero que la UI muestra ("Dinero:
+// c.1.000") y que las tiendas mutan NO vive en Platoon::ownerships.money (la
+// cartera per-squad-tab que readWalletByHand/writeWalletByHand tocan - esa esta
+// a 0 y sin uso). Character::getMoney desensamblado hace la cadena:
+//     PlayerInterface (singleton) -> participant (Faction*, +0x2A0)
+//        -> factionOwnerships (Ownerships*, +0x80) -> money (+0x88)
+// Es decir: el dinero del jugador es UNA sola cartera POR FACCION, compartida
+// por todo el squad (todos los tabs). Prueba dura: escribir 31337 en ese
+// Ownerships::money cambio el texto de la UI en el acto; escribir el campo
+// per-Platoon no lo movio. walletOf() (Platoon) es por tanto el campo MUERTO
+// que el canal PKT_MONEY sincronizaba - de ahi que el dinero "no se comparta".
+//
+// playerFactionWallet: el Ownerships de la faccion del jugador local, via el
+// PlayerInterface que cuelga del GameWorld (gw->player, +0x580). Todos los
+// punteros son propiedad del engine; el caller mantiene SEH.
+namespace {
+Ownerships* playerFactionWallet(GameWorld* gw) {
+    if (!gw || !gw->player) return 0;
+    Faction* f = gw->player->participant;  // 0x2A0: la faccion que el jugador controla
+    if (!f) return 0;
+    return f->factionOwnerships;           // 0x80: la cartera compartida del squad
+}
+} // namespace
+
+// SEH-guarded: lee la cartera REAL del jugador (Faction::factionOwnerships).
+// *outMoney = -1 en fallo. Devuelve true si pudo leer.
+bool readPlayerWallet(GameWorld* gw, int* outMoney) {
+    if (outMoney) *outMoney = -1;
+    if (!gw || !outMoney || !g_ownGetMoneyFn) return false;
+    __try {
+        Ownerships* ow = playerFactionWallet(gw);
+        if (!ow) return false;
+        *outMoney = g_ownGetMoneyFn(ow);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+}
+
+// SEH-guarded: escribe la cartera REAL del jugador via Ownerships::setMoney (el
+// mismo accesor que la UI/tiendas usan). money < 0 se rechaza. Devuelve true ok.
+bool writePlayerWallet(GameWorld* gw, int money) {
+    if (!gw || money < 0 || !g_ownSetMoneyFn) return false;
+    __try {
+        Ownerships* ow = playerFactionWallet(gw);
+        if (!ow) return false;
+        g_ownSetMoneyFn(ow, money);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+}
+
 // ---- Protocol 23 phase 0: recruitment probe ---------------------------------
 
 int probeRecruit(GameWorld* gw, bool runtimeSubject,

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -25,6 +25,7 @@
 #include "Interp.h"
 #include "../../netproto/Wire.h"
 #include "../core/Inbound.h"
+#include "../core/MoneyReconcile.h"
 #include "../net/NetLink.h"
 #include "SyncContext.h" // Phase 6: per-tick channel call environment
 #include "SyncTuning.h"  // Phase 6d: owned per-channel send-cadence tunables
@@ -287,16 +288,16 @@ public:
     // fights accumulate locally (the owner's stream overwrites it).
     void applyStats(GameWorld* gw, Inbound& in);
 
-    // AFTER publishOwned (protocol 22, both clients): stream the WALLET
-    // (Ownerships::money) of every squad tab this client OWNS, keyed by tab
-    // RANK - change-gated on the reliable channel with a ~1 Hz floor and a
-    // periodic safety resend (the publishStats pacing). Kenshi's wallet is
-    // per-Platoon; nothing else about money is on the wire (shop_probe).
+    // AFTER publishOwned (protocol 22b, both clients): publish the DELTA of our
+    // local change to the SHARED player-faction wallet (the real UI/shop wallet,
+    // engine::readPlayerWallet) on the reliable channel. Delta-based so two
+    // concurrent spenders sum correctly; no safety resend (reliable+ordered
+    // delivery applies each delta exactly once). Silent when the wallet is idle.
     void publishMoney(const SyncContext& ctx);
 
-    // BEFORE engine (protocol 22): drain received wallet snapshots and write
-    // each PEER-owned tab's money onto our local copy of that tab's platoon
-    // via Ownerships::setMoney. Never writes a rank we own.
+    // BEFORE engine (protocol 22b): drain received wallet deltas and ADD each to
+    // our local copy of the shared faction wallet (engine::writePlayerWallet),
+    // advancing the baseline so the delta is not re-detected as a local change.
     void applyMoney(const SyncContext& ctx);
 
     // Per-tab wallet sync master enable (KENSHICOOP_MONEY_SYNC).
@@ -1285,13 +1286,11 @@ private:
     // RESEND_MS names to these fields, so behavior is unchanged - this is the one
     // place their cadence now lives. See SyncTuning.h.
     SyncTuning tuning_;
-    // Protocol 22: per OWNED tab rank, the last SENT wallet value + send time
-    // (change gate + safety resend). A settled economy is silent.
-    struct MoneyPub {
-        int lastSent; unsigned long lastSendMs;
-        MoneyPub() : lastSent(-1), lastSendMs(0) {}
-    };
-    std::map<unsigned int, MoneyPub> moneyPub_;
+    // Protocol 22b: the SHARED player-faction wallet reconciled by delta (see
+    // MoneyReconcile.h). One baseline for the whole session - the wallet is
+    // per-faction, not per-tab. seeded on the first sample, advanced on every
+    // local delta published and every remote delta applied.
+    MoneyState factionMoney_;
     bool moneySync_;
     // Protocol 24 faction-relation sync state, per faction sid.
     // known      = our current baseline (seeded on first sight, updated on every

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -515,8 +515,9 @@ void Replicator::applyMoney(const SyncContext& ctx) {
         if (delta == 0) continue;
         int cur = -1;
         if (!engine::readPlayerWallet(gw, &cur) || cur < 0) continue;
+        // moneyApplyDelta clamps the wallet to >=0 AND keeps the baseline in
+        // sync with the clamped value (no spurious phantom delta next publish).
         int want = coop::moneyApplyDelta(factionMoney_, cur, delta);
-        if (want < 0) want = 0; // never drive the engine wallet negative
         bool ok = engine::writePlayerWallet(gw, want);
         char b[112];
         _snprintf(b, sizeof(b) - 1, "[money] RECV delta=%d was=%d now=%d ok=%d",

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -482,39 +482,23 @@ unsigned int Replicator::tabRepresentatives(GameWorld* gw, unsigned int rankHand
 void Replicator::publishMoney(const SyncContext& ctx) {
     GameWorld* gw = ctx.gw; NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
     if (!moneySync_) return;
-    const unsigned long RESEND_MS   = tuning_.moneyResendMs;  // safety resend (a lost write self-heals)
-    const unsigned long MIN_SEND_MS = tuning_.moneyMinSendMs; // wallets move in bursts; ~1 Hz is plenty
-    const unsigned int  MAX_RANKS   = 8;
-    unsigned long now = nowMs();
-    unsigned int rankHand[MAX_RANKS][5];
-    unsigned int nRanks = tabRepresentatives(gw, rankHand, MAX_RANKS);
-    for (unsigned int r = 0; r < nRanks; ++r) {
-        // Own-tabs only (the same partition rule as publishOwned's entity filter).
-        bool owned = ownRanks_.empty() ? (r == 0u) : (ownRanks_.count(r) != 0);
-        if (!owned || rankHand[r][0] == 0xFFFFFFFFu) continue;
-        int money = -1;
-        if (!engine::readWalletByHand(rankHand[r], &money) || money < 0) continue;
-        MoneyPub& mp = moneyPub_[r];
-        bool changed = (money != mp.lastSent);
-        // Money has no silent seed step, so a never-sent row is resend-due: a
-        // fresh wallet still streams once. (resendUnsent = true.)
-        if (!sync::gateShouldSend(changed, now, mp.lastSendMs, MIN_SEND_MS,
-                                  RESEND_MS, /*resendUnsent*/ true))
-            continue;
-        mp.lastSent = money; mp.lastSendMs = now;
-        MoneyPacket pkt;
-        memset(&pkt, 0, sizeof(pkt));
-        pkt.type    = (u8)PKT_MONEY;
-        pkt.ownerId = ownerId;
-        pkt.tabRank = r;
-        pkt.money   = money;
-        net.queueMoney(pkt);
-        if (changed) { // resends stay silent; the change is the signal
-            char b[96];
-            _snprintf(b, sizeof(b) - 1, "[money] SEND rank=%u cats=%d", r, money);
-            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
-        }
-    }
+    // The SHARED player-faction wallet (the real UI/shop wallet). Read it, detect
+    // our local delta vs the baseline, and publish only that delta. Both clients
+    // run this; each replicates its own spends/earnings onto the one shared pool.
+    int cur = -1;
+    if (!engine::readPlayerWallet(gw, &cur) || cur < 0) return;
+    int delta = 0;
+    if (!coop::moneyLocalDelta(factionMoney_, cur, &delta)) return; // seed or idle
+    MoneyPacket pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    pkt.type    = (u8)PKT_MONEY;
+    pkt.ownerId = ownerId;
+    pkt.tabRank = 0;      // unused - the wallet is per-faction, not per-tab
+    pkt.money   = delta;  // signed delta to apply on the peer
+    net.queueMoney(pkt);
+    char b[96];
+    _snprintf(b, sizeof(b) - 1, "[money] SEND delta=%d cats=%d", delta, cur);
+    b[sizeof(b) - 1] = '\0'; coop::logLine(b);
 }
 
 void Replicator::applyMoney(const SyncContext& ctx) {
@@ -523,28 +507,20 @@ void Replicator::applyMoney(const SyncContext& ctx) {
     in.drainMoney(got);
     if (got.empty()) return;
     if (!moneySync_) return;
-    const unsigned int MAX_RANKS = 8;
-    unsigned int rankHand[MAX_RANKS][5];
-    unsigned int nRanks = 0;
-    bool haveRanks = false;
+    // Apply each received delta to the shared faction wallet, advancing the
+    // baseline so our next publishMoney does not echo it back. Reliable+ordered
+    // delivery means every delta lands exactly once - no idempotence key needed.
     for (std::deque<InboundMoney>::iterator it = got.begin(); it != got.end(); ++it) {
-        const MoneyPacket& p = it->pkt;
-        unsigned int r = p.tabRank;
-        // Never write a tab we own - our engine is that wallet's authority.
-        bool owned = ownRanks_.empty() ? (r == 0u) : (ownRanks_.count(r) != 0);
-        if (owned || p.money < 0) continue;
-        if (!haveRanks) { // one census per drain (cheap; usually 1 packet anyway)
-            nRanks = tabRepresentatives(gw, rankHand, MAX_RANKS);
-            haveRanks = true;
-        }
-        if (r >= nRanks || rankHand[r][0] == 0xFFFFFFFFu) continue;
+        int delta = it->pkt.money;
+        if (delta == 0) continue;
         int cur = -1;
-        engine::readWalletByHand(rankHand[r], &cur);
-        if (cur == p.money) continue; // already converged (resend or echo)
-        bool ok = engine::writeWalletByHand(rankHand[r], p.money);
+        if (!engine::readPlayerWallet(gw, &cur) || cur < 0) continue;
+        int want = coop::moneyApplyDelta(factionMoney_, cur, delta);
+        if (want < 0) want = 0; // never drive the engine wallet negative
+        bool ok = engine::writePlayerWallet(gw, want);
         char b[112];
-        _snprintf(b, sizeof(b) - 1, "[money] RECV rank=%u cats=%d was=%d ok=%d",
-                  r, p.money, cur, ok ? 1 : 0);
+        _snprintf(b, sizeof(b) - 1, "[money] RECV delta=%d was=%d now=%d ok=%d",
+                  delta, cur, want, ok ? 1 : 0);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 }
@@ -1305,9 +1281,10 @@ void Replicator::onPeerConnected(NetLink& net, u32 ownerId) {
     for (std::map<Key, StatsPub>::iterator it = statsPub_.begin();
          it != statsPub_.end(); ++it)
         if (it->second.lastSendMs != 0) { it->second.lastSendMs = 1; ++nStats; }
-    for (std::map<unsigned int, MoneyPub>::iterator it = moneyPub_.begin();
-         it != moneyPub_.end(); ++it)
-        if (it->second.lastSendMs != 0) { it->second.lastSendMs = 1; ++nMoney; }
+    // Money (protocol 22b) is delta-reconciled on a reliable+ordered channel, so
+    // there is no per-row safety-resend cache to age here: a late joiner loads
+    // the same coordinated save (identical starting wallet) and both sides then
+    // apply each other's deltas as they happen. nMoney stays 0 by design.
     for (std::map<Key, InvPub>::iterator it = invPub_.begin();
          it != invPub_.end(); ++it)
         if (it->second.lastSendMs != 0) { it->second.lastSendMs = 1; ++nInv; }

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -223,7 +223,7 @@ void Replicator::resetSession() {
     medRecv_.clear();
     medNpc_.clear();
     statsPub_.clear();
-    moneyPub_.clear();
+    factionMoney_ = coop::MoneyState(); // re-seed the shared-wallet baseline on load
     stealthPub_.clear();
     pinOwned_.clear();
     pinPeer_.clear();

--- a/src/plugin/test/ScenarioProbes.cpp
+++ b/src/plugin/test/ScenarioProbes.cpp
@@ -428,49 +428,35 @@ private:
         c[sizeof(c) - 1] = '\0'; coop::logLine(c);
     }
 
-    // One WALLET line per distinct squad tab (keyed by RANK, the cross-client
-    // stable tab identity): the money series the oracle diffs host-vs-join.
+    // ONE WALLET line for the SHARED player-faction wallet (the real UI/shop
+    // wallet). It is per-faction, not per-tab, so rank is always 0 - kept in the
+    // log format the oracle already parses. This is the series host-vs-join must
+    // CONVERGE on (protocol 22b: a shared pool, both sides end equal).
     void logWallets(const ScenarioContext& ctx) {
-        EntityState sq[MAX_SQUAD];
-        unsigned int n = engine::captureSquad(ctx.gw, false, sq, MAX_SQUAD);
-        for (unsigned int rank = 0; rank < 4; ++rank) {
-            int li = tabLeaderIdx(sq, n, rank);
-            if (li < 0) continue;
-            unsigned int h[5];
-            handFromEntity(sq[li], h);
-            int money = -1;
-            if (engine::readWalletByHand(h, &money)) ++walletReads_;
-            char b[96];
-            _snprintf(b, sizeof(b) - 1, "SCENARIO WALLET rank=%u money=%d t=%lu",
-                      rank, money, ctx.elapsedMs);
-            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
-        }
+        int money = -1;
+        if (engine::readPlayerWallet(ctx.gw, &money)) ++walletReads_;
+        char b[96];
+        _snprintf(b, sizeof(b) - 1, "SCENARIO WALLET rank=0 money=%d t=%lu",
+                  money, ctx.elapsedMs);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 
-    // Wallet-write leg: set the OWNED tab's wallet to a side-distinct sentinel
-    // via the engine accessor (host 5000, join 7000). Proves writeWallet works
-    // (the 1b apply primitive) and, on the peer's WALLET series, whether ANY
-    // wallet state crosses today (expected: it does not - the 1b gap evidence).
+    // Wallet-write leg: each side ADDS a side-distinct amount to the SHARED
+    // faction wallet (host +HOST_ADD, join +JOIN_ADD) via the real engine
+    // accessor. On the peer, protocol 22b must carry the delta across, so BOTH
+    // sides' pools converge to base + HOST_ADD + JOIN_ADD (the shared-pool proof;
+    // with money sync OFF - shop_probe - neither delta crosses, the baseline).
     void doWalletSet(const ScenarioContext& ctx) {
-        EntityState sq[MAX_SQUAD];
-        unsigned int n = engine::captureSquad(ctx.gw, false, sq, MAX_SQUAD);
-        unsigned int rank = ctx.isHost ? 0u : 1u;
-        int li = tabLeaderIdx(sq, n, rank);
-        if (li < 0) { li = tabLeaderIdx(sq, n, 0u); rank = 0u; }
         int before = -1, after = -1, ok = 0;
-        int target = ctx.isHost ? 5000 : 7000;
-        if (li >= 0) {
-            unsigned int h[5];
-            handFromEntity(sq[li], h);
-            engine::readWalletByHand(h, &before);
-            ok = engine::writeWalletByHand(h, target) ? 1 : 0;
-            engine::readWalletByHand(h, &after);
+        int add = ctx.isHost ? HOST_ADD : JOIN_ADD;
+        if (engine::readPlayerWallet(ctx.gw, &before) && before >= 0) {
+            ok = engine::writePlayerWallet(ctx.gw, before + add) ? 1 : 0;
+            engine::readPlayerWallet(ctx.gw, &after);
         }
-        char b[144];
+        char b[160];
         _snprintf(b, sizeof(b) - 1,
-                  "SCENARIO WALLETSET who=%s rank=%u target=%d ok=%d before=%d after=%d t=%lu",
-                  ctx.isHost ? "host" : "join", rank, target, ok, before, after,
-                  ctx.elapsedMs);
+                  "SCENARIO WALLETSET who=%s rank=0 add=%d ok=%d before=%d after=%d t=%lu",
+                  ctx.isHost ? "host" : "join", add, ok, before, after, ctx.elapsedMs);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 
@@ -521,6 +507,8 @@ private:
     static const unsigned long DURATION_MS    = 40000;
     static const unsigned int  MAX_VENDORS    = 8;
     static const unsigned int  MAX_SQUAD      = 32;
+    static const int           HOST_ADD       = 4000; // host adds to the shared pool
+    static const int           JOIN_ADD       = 6000; // join adds to the shared pool
     static const float         VENDOR_RADIUS;
 
     bool          probe_;
@@ -580,8 +568,16 @@ public:
     }
 
 private:
-    // One WALLET + one TINV line per distinct squad tab (keyed by rank).
+    // The SHARED faction WALLET (rank 0, one pool) + one TINV line per distinct
+    // squad tab. The wallet is the buyer-side debit's target; the inventory is
+    // where the bought item lands.
     void logSeries(const ScenarioContext& ctx) {
+        int money = -1;
+        if (engine::readPlayerWallet(ctx.gw, &money)) ++walletReads_;
+        char w[96];
+        _snprintf(w, sizeof(w) - 1, "SCENARIO WALLET rank=0 money=%d t=%lu",
+                  money, ctx.elapsedMs);
+        w[sizeof(w) - 1] = '\0'; coop::logLine(w);
         EntityState sq[MAX_SQUAD];
         unsigned int n = engine::captureSquad(ctx.gw, false, sq, MAX_SQUAD);
         for (unsigned int rank = 0; rank < 4; ++rank) {
@@ -589,12 +585,6 @@ private:
             if (li < 0) continue;
             unsigned int h[5];
             handFromEntity(sq[li], h);
-            int money = -1;
-            if (engine::readWalletByHand(h, &money)) ++walletReads_;
-            char b[96];
-            _snprintf(b, sizeof(b) - 1, "SCENARIO WALLET rank=%u money=%d t=%lu",
-                      rank, money, ctx.elapsedMs);
-            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
             InvItemEntry items[INV_ITEMS_MAX];
             unsigned int hash = 0;
             unsigned int cnt = engine::captureContainerContents(
@@ -606,7 +596,8 @@ private:
         }
     }
 
-    // The tab this side owns: host rank 0, join rank 1 (leader fallback).
+    // The tab this side owns: host rank 0, join rank 1 (leader fallback). Used
+    // for the INVENTORY leg (the bought item lands in this tab leader's bag).
     bool ownLeaderHand(const ScenarioContext& ctx, unsigned int h[5],
                        unsigned int* outRank) {
         EntityState sq[MAX_SQUAD];
@@ -621,13 +612,17 @@ private:
     }
 
     void doSeed(const ScenarioContext& ctx) {
-        unsigned int h[5]; unsigned int rank = 0;
-        int ok = 0, target = ctx.isHost ? SEED_HOST : SEED_JOIN;
-        if (ownLeaderHand(ctx, h, &rank))
-            ok = engine::writeWalletByHand(h, target) ? 1 : 0;
-        char b[112];
-        _snprintf(b, sizeof(b) - 1, "SCENARIO TRADESEED who=%s rank=%u target=%d ok=%d t=%lu",
-                  ctx.isHost ? "host" : "join", rank, target, ok, ctx.elapsedMs);
+        // Seed the SHARED faction wallet by ADDING a side-distinct amount (host
+        // +SEED_HOST_ADD, join +SEED_JOIN_ADD); protocol 22b carries each delta.
+        int add = ctx.isHost ? SEED_HOST_ADD : SEED_JOIN_ADD;
+        int before = -1, after = -1, ok = 0;
+        if (engine::readPlayerWallet(ctx.gw, &before) && before >= 0) {
+            ok = engine::writePlayerWallet(ctx.gw, before + add) ? 1 : 0;
+            engine::readPlayerWallet(ctx.gw, &after);
+        }
+        char b[128];
+        _snprintf(b, sizeof(b) - 1, "SCENARIO TRADESEED who=%s rank=0 add=%d ok=%d before=%d after=%d t=%lu",
+                  ctx.isHost ? "host" : "join", add, ok, before, after, ctx.elapsedMs);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 
@@ -636,14 +631,16 @@ private:
         int w0 = -1, w1 = -1, added = 0;
         unsigned int cnt0 = 0, cnt1 = 0, hash = 0;
         char sid[48]; sid[0] = '\0';
+        // Wallet debit hits the SHARED faction pool; the item lands in this
+        // side's owned tab-leader bag (inventory leg).
+        engine::readPlayerWallet(ctx.gw, &w0);
         if (ownLeaderHand(ctx, h, &rank)) {
             InvItemEntry items[INV_ITEMS_MAX];
-            engine::readWalletByHand(h, &w0);
             cnt0 = engine::captureContainerContents(ctx.gw, h, items, INV_ITEMS_MAX, &hash);
             // The two buyer-side mutations of one purchase, same tick.
             added = engine::addTestItemsToContainer(ctx.gw, h, 1, sid, sizeof(sid));
-            if (w0 >= PRICE) engine::writeWalletByHand(h, w0 - PRICE);
-            engine::readWalletByHand(h, &w1);
+            if (w0 >= PRICE) engine::writePlayerWallet(ctx.gw, w0 - PRICE);
+            engine::readPlayerWallet(ctx.gw, &w1);
             cnt1 = engine::captureContainerContents(ctx.gw, h, items, INV_ITEMS_MAX, &hash);
         }
         tradeOk_ = (added > 0) && (w1 >= 0) && (w0 - w1 == PRICE);
@@ -662,8 +659,8 @@ private:
     static const unsigned long JOIN_TRADE_AT_MS = 22000;
     static const unsigned long DURATION_MS      = 40000;
     static const unsigned int  MAX_SQUAD        = 32;
-    static const int           SEED_HOST        = 5000;
-    static const int           SEED_JOIN        = 7000;
+    static const int           SEED_HOST_ADD    = 4000; // host adds to the shared pool
+    static const int           SEED_JOIN_ADD    = 6000; // join adds to the shared pool
     static const int           PRICE            = 250;
 
     bool          seeded_;

--- a/src/plugin/test/ScenarioSession.cpp
+++ b/src/plugin/test/ScenarioSession.cpp
@@ -197,19 +197,14 @@ private:
     }
 
     void doMoneyMutation(const ScenarioContext& ctx) {
-        EntityState sq[MAX_SQUAD];
-        unsigned int n = engine::captureSquad(ctx.gw, false, sq, MAX_SQUAD);
-        int idx = tabLeaderIdx(sq, n, 0u); // host owns tab rank 0
+        // Bump the SHARED player-faction wallet (the real one); protocol 22b
+        // carries the +MONEY_BUMP delta to the join, which the census verifies.
         int before = -1, after = -1, ok = 0;
-        if (idx >= 0) {
-            unsigned int h[5];
-            handFromEntity(sq[idx], h);
-            if (engine::readWalletByHand(h, &before)) {
-                int want = before + MONEY_BUMP;
-                if (engine::writeWalletByHand(h, want)) {
-                    engine::readWalletByHand(h, &after);
-                    ok = (after == want) ? 1 : 0;
-                }
+        if (engine::readPlayerWallet(ctx.gw, &before) && before >= 0) {
+            int want = before + MONEY_BUMP;
+            if (engine::writePlayerWallet(ctx.gw, want)) {
+                engine::readPlayerWallet(ctx.gw, &after);
+                ok = (after == want) ? 1 : 0;
             }
         }
         moneyOk_ = (ok == 1);
@@ -285,21 +280,17 @@ private:
                 b[sizeof(b) - 1] = '\0'; coop::logLine(b);
             }
         }
-        // Wallets: both tab leaders.
-        EntityState sq[MAX_SQUAD];
-        unsigned int n = engine::captureSquad(ctx.gw, false, sq, MAX_SQUAD);
-        for (unsigned int rank = 0; rank < 2; ++rank) {
-            int idx = tabLeaderIdx(sq, n, rank);
-            if (idx < 0) continue;
-            unsigned int h[5];
-            handFromEntity(sq[idx], h);
+        // Wallet: the SHARED player-faction wallet (rank 0 = the one pool). Both
+        // sides must read the same value once the host's bump delta has crossed.
+        {
             int money = -1;
-            if (!engine::readWalletByHand(h, &money)) continue;
-            char b[128];
-            _snprintf(b, sizeof(b) - 1,
-                      "SCENARIO LJMONEYROW rank=%u money=%d t=%lu",
-                      rank, money, ctx.elapsedMs);
-            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            if (engine::readPlayerWallet(ctx.gw, &money)) {
+                char b[128];
+                _snprintf(b, sizeof(b) - 1,
+                          "SCENARIO LJMONEYROW rank=0 money=%d t=%lu",
+                          money, ctx.elapsedMs);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            }
         }
         ++censusLogged_;
     }

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -1403,6 +1403,40 @@ static void testMoneyReconcile() {
     CHECK_EQ("B converges to 650", bFinal, 650);
     CHECK("A/B baselines agree",   a.known == b.known);
     CHECK("baselines are 650",     a.known == 650);
+
+    // THE CLAMP FIX (2026-07-21): a remote delta that would drive the wallet
+    // negative is clamped to 0, and the baseline MUST follow the clamped value
+    // (0), NOT the theoretical delta. Otherwise 'known' goes negative, diverges
+    // from the real wallet, and the NEXT moneyLocalDelta reads cur(0)-known(<0)
+    // as a positive spurious delta - money printed from nothing, permanent desync.
+    //
+    // Repro: shared pool at 1000. This client (join) spends 800 locally (wallet
+    // 1000->200, baseline follows to 200 after publishing -800). Meanwhile the
+    // host spent 1000; that -1000 delta arrives here: 200 + (-1000) = -800 ->
+    // clamp to 0. Pre-fix, known landed at -800 (200 + (-1000)); post-fix it must
+    // land at 0 (the value actually written to the wallet).
+    {
+        MoneyState j; int jd = 0;
+        moneyLocalDelta(j, 1000, &jd);                 // seed at the shared 1000
+        CHECK("clamp: local spend of 800 detected", moneyLocalDelta(j, 200, &jd));
+        CHECK_EQ("clamp: local spend delta = -800", (long long)jd + 1000, 200); // jd == -800
+        CHECK("clamp: baseline followed local spend", j.known == 200);
+
+        // Host's -1000 arrives; 200 + (-1000) = -800 -> clamp to 0.
+        int applied = moneyApplyDelta(j, 200, -1000);
+        CHECK_EQ("clamp: wallet clamped to 0", applied, 0);
+        // THE ASSERTION THAT FAILS PRE-FIX: known must equal the real wallet (0),
+        // not the un-clamped theoretical baseline (-800).
+        CHECK("clamp: baseline follows clamped wallet (0), not theoretical (-800)",
+              j.known == 0);
+
+        // The decisive property: a subsequent publish must NOT fabricate a delta.
+        // Pre-fix, moneyLocalDelta(cur=0, known=-800) returned true with a +800
+        // spurious delta (money from nothing). Post-fix, cur==known==0 -> silent.
+        int spurious = 0;
+        CHECK("clamp: next publish emits NO phantom delta",
+              !moneyLocalDelta(j, 0, &spurious));
+    }
 }
 
 int main() {

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -34,6 +34,7 @@
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
+#include "../plugin/core/MoneyReconcile.h" // Phase 6/22b: shared-wallet delta reconcile
 
 #include <set>
 
@@ -207,7 +208,7 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v44: bulk channel + session epoch)", (int)PROTOCOL_VERSION, 44);
+    CHECK_EQ("PROTOCOL_VERSION (v44: bulk channel + session epoch + shared-wallet delta 22b)", (int)PROTOCOL_VERSION, 44);
 }
 
 // ---- 2. readPacket / packetType round-trips -----------------------------------
@@ -1355,6 +1356,55 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- 11. Shared-wallet delta reconciliation (MoneyReconcile.h) ------------------
+// Guards the money-sync fix (2026-07-20): the player's real wallet is ONE shared
+// per-faction pool, so the channel replicates DELTAS and the peer ADDS them.
+// This locks: seed-is-silent, idle-is-silent, local delta detection + baseline
+// advance, remote delta apply + baseline advance (echo-guard), and the decisive
+// property - two CONCURRENT spends converge to the same total on both clients
+// (which absolute-value sync would corrupt).
+static void testMoneyReconcile() {
+    std::printf("== shared-wallet delta reconciliation (MoneyReconcile.h) ==\n");
+
+    // First sample seeds silently (no spurious delta at connect).
+    MoneyState s; int d = 12345;
+    CHECK("first sample seeds (no send)", !moneyLocalDelta(s, 1000, &d));
+    CHECK("seed sets baseline",           s.known == 1000);
+
+    // No change -> nothing to publish.
+    CHECK("idle wallet is silent", !moneyLocalDelta(s, 1000, &d));
+
+    // A local spend publishes a negative delta and advances the baseline.
+    CHECK("local spend detected",  moneyLocalDelta(s, 750, &d));
+    CHECK_EQ("spend delta = -250", (long long)d + 1000, 750); // d == -250
+    CHECK("baseline followed spend", s.known == 750);
+    CHECK("same wallet now idle",  !moneyLocalDelta(s, 750, &d));
+
+    // A remote delta is applied by ADDING it, and the baseline advances so the
+    // next local check does NOT echo it back.
+    int now = moneyApplyDelta(s, 750, -100); // peer spent 100
+    CHECK_EQ("apply subtracts",    now, 650);
+    CHECK("baseline followed apply", s.known == 650);
+    CHECK("applied delta not echoed", !moneyLocalDelta(s, 650, &d));
+
+    // The crux: two concurrent spends from a shared 1000 pool converge to 650 on
+    // BOTH clients (absolute-value sync would land one side on 750, the other on
+    // 900, losing money). A: local -250, then receives B's -100. B: local -100,
+    // then receives A's -250. Both must end at 650 with matching baselines.
+    MoneyState a; MoneyState b;
+    int da = 0, db = 0;
+    moneyLocalDelta(a, 1000, &da); // seed A
+    moneyLocalDelta(b, 1000, &db); // seed B
+    CHECK("A publishes its spend", moneyLocalDelta(a, 750, &da));  // da = -250
+    CHECK("B publishes its spend", moneyLocalDelta(b, 900, &db));  // db = -100
+    int aFinal = moneyApplyDelta(a, 750, db); // A applies B's -100
+    int bFinal = moneyApplyDelta(b, 900, da); // B applies A's -250
+    CHECK_EQ("A converges to 650", aFinal, 650);
+    CHECK_EQ("B converges to 650", bFinal, 650);
+    CHECK("A/B baselines agree",   a.known == b.known);
+    CHECK("baselines are 650",     a.known == 650);
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1377,6 +1427,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testMoneyReconcile();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
Flagging up front: this is the riskiest of the batch — it bumps the protocol version and rewrites the publish/apply pair rather than a contained patch. I get that's a bigger ask to review than the others. But money sync is currently just silently broken (details below), so I wanted to hand over a real fix rather than just a bug report.

### What this fixes

Money sync doesn't work — the channel publishes/applies `Platoon::ownerships.money`, but that's not where the player's actual cats live. Confirmed live: UI shows 1000, the synced field reads 0 on both sides for a whole session; writing straight into that field doesn't move the UI either. A real in-session purchase (paid for with real money) never touched the channel at all.

Traced the real chain via live RE (Cheat Engine + x64dbg on a running instance, cross-checked against KenshiLib headers): `PlayerInterface -> participant (Faction*) +0x2A0 -> factionOwnerships +0x80 -> money +0x88`. Money is a single **per-faction** wallet, not per-squad-tab. Since both co-op players are the same faction, that means it's one shared pool with two writers, not two separate wallets like I'd assumed going in (worth flagging: your own spike 29 notes assumed the same wrong layer).

### How

- `readPlayerWallet`/`writePlayerWallet` now resolve the real chain above instead of the dead `Platoon` field.
- New pure header `MoneyReconcile.h` (same style as the other three): reconciles by **delta**, not absolute snapshot. Two players spending concurrently against a shared pool would stomp each other with absolute values (1000 -> 750 and 1000 -> 900 published close together, last writer wins, 100 vanishes); deltas apply cleanly (1000 - 250 - 100 = 650 on both sides regardless of order).
- `publishMoney`/`applyMoney` rewritten around this; protocol bumped 43 -> 44 since the wire semantics changed (snapshot -> delta).

### Testing

- Built with the real toolchain (VS2010 v100 x64), 0 errors.
- Unit: `testMoneyReconcile` — seed-quiet, echo-guard, convergence under concurrent spends. 306/306 total prototest checks pass.
- Live smoke, host+join real session: host publishes delta +4000 (cats 1000->5000), join sees it and independently publishes delta +6000 (cats 5000->11000), host converges to the same 11000. Cross-verified both directions, `MONEY-SYNC PASS crossed=2/2`, full gate suite green.
- Not run against my other four fix branches yet (found and fixed after those were already combined and reviewed) — no reason to expect interaction (money channel is fully separate from faction/door/carry/jail state), but flagging that the combined smoke hasn't specifically re-run with this one in the mix.

### What was NOT tested

Late-join after money deltas were missed entirely (no coordinating save) isn't covered — in practice this shouldn't come up since a join always starts from the save the host streams over, but I haven't gone out of my way to break that specific edge.