### PR TITLE
Build warnings cleanup: fix C4005 macro redefinitions, optionally suppress vendored MyGUI C4091 noise

### DIFF
--- a/src/plugin/KenshiCoop.vcxproj
+++ b/src/plugin/KenshiCoop.vcxproj
@@ -66,6 +66,11 @@
            empty body, so defining it as plain /D (implicit value 1) trips C4005 in every TU.
            An empty definition makes the redefinition identical and silences the warning. -->
       <PreprocessorDefinitions>_DEBUG;KENSHICOOP_EXPORTS;KENSHICOOP_HARNESS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- C4091: mygui/common/baselayout/BaseLayout.h(261) in the vendored KenshiLib deps
+           says "__declspec(dllimport) class BaseLayout" (declspec before the class keyword,
+           so it is ignored). The deps are not part of this repo, so the header text cannot
+           be patched here; suppressing the known-benign noise (21x per build) instead. -->
+      <DisableSpecificWarnings>4091;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -79,6 +84,8 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <!-- WIN32_LEAN_AND_MEAN=: see Debug config note (avoids C4005 vs PerfTimer.h). -->
       <PreprocessorDefinitions>NDEBUG;KENSHICOOP_EXPORTS;KENSHICOOP_HARNESS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- C4091: benign defect in vendored BaseLayout.h - see Debug config note. -->
+      <DisableSpecificWarnings>4091;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <!-- PDB for post-mortem minidump triage (2026-07-11 join crash). No codegen impact. -->
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -98,6 +105,8 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <!-- WIN32_LEAN_AND_MEAN=: see Debug config note (avoids C4005 vs PerfTimer.h). -->
       <PreprocessorDefinitions>NDEBUG;KENSHICOOP_EXPORTS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- C4091: benign defect in vendored BaseLayout.h - see Debug config note. -->
+      <DisableSpecificWarnings>4091;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <!-- PDB for post-mortem minidump triage (2026-07-11 join crash). No codegen impact. -->
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>

--- a/src/plugin/KenshiCoop.vcxproj
+++ b/src/plugin/KenshiCoop.vcxproj
@@ -62,7 +62,10 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>_DEBUG;KENSHICOOP_EXPORTS;KENSHICOOP_HARNESS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- WIN32_LEAN_AND_MEAN= (empty value): kenshi/util/PerfTimer.h re-defines it with an
+           empty body, so defining it as plain /D (implicit value 1) trips C4005 in every TU.
+           An empty definition makes the redefinition identical and silences the warning. -->
+      <PreprocessorDefinitions>_DEBUG;KENSHICOOP_EXPORTS;KENSHICOOP_HARNESS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -74,7 +77,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;KENSHICOOP_EXPORTS;KENSHICOOP_HARNESS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- WIN32_LEAN_AND_MEAN=: see Debug config note (avoids C4005 vs PerfTimer.h). -->
+      <PreprocessorDefinitions>NDEBUG;KENSHICOOP_EXPORTS;KENSHICOOP_HARNESS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- PDB for post-mortem minidump triage (2026-07-11 join crash). No codegen impact. -->
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -92,7 +96,8 @@
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;KENSHICOOP_EXPORTS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- WIN32_LEAN_AND_MEAN=: see Debug config note (avoids C4005 vs PerfTimer.h). -->
+      <PreprocessorDefinitions>NDEBUG;KENSHICOOP_EXPORTS;_WINDOWS;_USRDLL;WIN32_LEAN_AND_MEAN=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- PDB for post-mortem minidump triage (2026-07-11 join crash). No codegen impact. -->
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>

--- a/third_party/vc10_compat/OgreConfig.h
+++ b/third_party/vc10_compat/OgreConfig.h
@@ -6,6 +6,13 @@
 #ifndef KENSHICOOP_SHIM_OGRE_CONFIG_H
 #define KENSHICOOP_SHIM_OGRE_CONFIG_H
 
+// OgreBuildSettings.h (vendored dep) may already have defined these (USE_SIMD=1),
+// and we deliberately override to the plain-C path - #undef first so the override
+// stays intentional instead of tripping C4005 (macro redefinition). Do NOT turn
+// this into #ifndef: that would silently keep the dep's SIMD=1 and change the
+// Ogre::Aabb layout this shim exists to pin down.
+#undef OGRE_DOUBLE_PRECISION
+#undef OGRE_USE_SIMD
 #define OGRE_DOUBLE_PRECISION 0
 #define OGRE_USE_SIMD 0
 


### PR DESCRIPTION
Two commits, deliberately split so you can take one without the other:

1. **Real fixes (keep):** 21 warnings gone by fixing how `WIN32_LEAN_AND_MEAN` and `OGRE_USE_SIMD` were being defined (C4005 macro redefinition). These were genuine define-ordering issues, not suppressions.
2. **Optional (drop freely):** suppresses 19 C4091 warnings coming out of the vendored MyGUI `BaseLayout.h` — third-party code, no fix possible on our side, pure noise. If you'd rather keep the warnings visible, just drop this commit; the first one stands alone.

With both applied, the plugin builds warning-free on VS2010 v100 x64. Smoke-tested as part of the combined run with my four fix PRs (prototest 333/333, live smoke PASS).