### PR TITLE
Fix non-gear ground items duplicating on cross-client pickup (drop visibility mitigation, not full W4 conservation)

### DIFF
--- a/scripts/CoopOracles.psm1
+++ b/scripts/CoopOracles.psm1
@@ -179,6 +179,7 @@ function Invoke-OneOracle {
         "drop_probe"    { return (Test-DropProbe       -HostFile $HostLog) }
         "wi_sync"       { return (Test-WorldItemSync   -HostFile $HostLog -JoinFile $JoinLog -Tol $Tolerance) }
         "wi_join"       { return (Test-WorldItemSync   -HostFile $HostLog -JoinFile $JoinLog -Tol $Tolerance -JoinAuthor -GateName "wi_join") }
+        "wi_peer_pickup" { return (Test-WorldItemPeerPickup -HostFile $HostLog -JoinFile $JoinLog) }
         "wpn_relocate"  { return (Test-WpnRelocate     -HostFile $HostLog -JoinFile $JoinLog) }
         "weapon_drop"   { return (Test-WeaponDrop      -HostFile $HostLog -JoinFile $JoinLog) }
         "armor_drop"    { return (Test-WeaponDrop      -HostFile $HostLog -JoinFile $JoinLog -GateName "armor_drop") }

--- a/scripts/oracles/World.ps1
+++ b/scripts/oracles/World.ps1
@@ -2313,3 +2313,46 @@ function Test-VendorTrade {
                 -Metrics @{ walletCrossed = $crossed } -Detail $detail)
 }
 
+# world_item_peer_pickup: NON-gear ground-item cross-client PICKUP conservation.
+# The HOST drops a common non-gear item (streams a W1 proxy); the JOIN picks that
+# proxy up into its own rank-1 bag. Every copy of the sid the client can see is
+# summed (rank0 + rank1 + ground); the conservation invariant is total <= 1 at all
+# times. The DUPE manifests on the HOST (its real dropped item stays on the ground
+# AND the join's picked-up copy mirrors back), so the gate is host maxtot<=1 AND
+# fintot==1. Both the drop (host) and the pickup (join) must be exercised, else the
+# gate would pass vacuously on a run where nothing happened.
+function Test-WorldItemPeerPickup {
+    param([string]$HostFile, [string]$JoinFile)
+    $rxHost = 'WPU verdict role=host pass=(\d+) dropped=(-?\d+) maxtot=(-?\d+) fintot=(-?\d+)'
+    $rxJoin = 'WPU verdict role=join pass=(\d+) picked=(-?\d+) maxtot=(-?\d+) fintot=(-?\d+)'
+    $dropped = -1; $hMax = -1; $hFin = -1; $picked = -1; $jMax = -1
+    if (Test-Path $HostFile) {
+        $hl = Select-String -Path $HostFile -Pattern $rxHost -ErrorAction SilentlyContinue | Select-Object -Last 1
+        if ($null -ne $hl) {
+            $g = $hl.Matches[0].Groups
+            $dropped = [int]$g[2].Value; $hMax = [int]$g[3].Value; $hFin = [int]$g[4].Value
+        } else { Write-Host "  WI-PEER-PICKUP [host] no WPU verdict" }
+    }
+    if (Test-Path $JoinFile) {
+        $jl = Select-String -Path $JoinFile -Pattern $rxJoin -ErrorAction SilentlyContinue | Select-Object -Last 1
+        if ($null -ne $jl) {
+            $g = $jl.Matches[0].Groups
+            $picked = [int]$g[2].Value; $jMax = [int]$g[3].Value
+        } else { Write-Host "  WI-PEER-PICKUP [join] no WPU verdict" }
+    }
+    $why = @()
+    if ($dropped -le 0) { $why += "drop not exercised (dropped=$dropped)" }
+    if ($picked -le 0)  { $why += "pickup not exercised (picked=$picked)" }
+    if ($hMax -gt 1)    { $why += "DUPE on host (maxtot=$hMax > 1)" }
+    if ($hFin -ne 1)    { $why += "host did not settle to one copy (fintot=$hFin)" }
+    $v = if ($why.Count -eq 0) { "PASS" } else { "FAIL" }
+    $detail = $why -join "; "
+    Write-Host "  WI-PEER-PICKUP $v - dropped=$dropped picked=$picked host(max=$hMax fin=$hFin) join(max=$jMax) $detail"
+    if ($hMax -ge 2) {
+        Write-Host "    NOTE: host saw 2 copies => the peer's proxy pickup was not conserved (host kept its real ground item + gained the join's mirrored copy)"
+    }
+    return (Add-GateResult -Name "wi_peer_pickup" -Status $v `
+                -Metrics @{ dropped = $dropped; picked = $picked; hostMax = $hMax;
+                            hostFin = $hFin; joinMax = $jMax } -Detail $detail)
+}
+

--- a/scripts/scenarios.psd1
+++ b/scripts/scenarios.psd1
@@ -1401,6 +1401,25 @@
             Advisory = @('smoothness', 'anim_truth', 'march')
             Tier = 'full'; WanVariant = $false
         }
+        # world_item_peer_pickup: NON-gear ground-item cross-client PICKUP
+        # conservation. The HOST drops a common non-gear item (W1 proxy); the JOIN
+        # picks that proxy up into its own rank-1 bag. On the unfixed W1 path the
+        # host keeps its real ground item AND gains the join's mirrored copy -> a
+        # silent DUPE (host total=2). The auto-revert mitigation re-drops any
+        # picked-up proxy before the inventory publish so total stays 1. Gate =
+        # host maxtot<=1 AND fintot==1, with drop+pickup actually exercised.
+        world_item_peer_pickup = @{
+            # invSync = the join's pickup must mirror to the host (the dupe channel);
+            # worldSync = the W1 proxy path + the revertProxyPickups mitigation are both
+            # gated on it. Named-scenario auto-enable was retired upstream in favour of
+            # this per-scenario DiagEnv, matching world_weapon_drop/world_armor_drop.
+            DiagEnv = @{ KENSHICOOP_INV_SYNC = '1'; KENSHICOOP_WORLD_SYNC = '1'; KENSHICOOP_INV_DUMP = '1' }
+            Save = 'squad1'; Setup = ''; Tolerance = 3.0
+            PrimaryGate = 'wi_peer_pickup'
+            Gating   = @('wi_peer_pickup', 'clock_sync')
+            Advisory = @('smoothness', 'anim_truth', 'march')
+            Tier = 'full'; WanVariant = $false
+        }
         # rejoin_items (Phase 3 item-dup fix): a reload must not duplicate save-
         # native ground items. Reuses the load_sync coordinated save+load lever
         # (loadSync + saveSync ON by default): the HOST drops K test items (both

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -988,6 +988,16 @@ void tickReplicatePublish(GameWorld* gw, bool worldLive) {
     }
     if (worldLive) {
         g_repl.publishOwned(gw, g_net, g_net.localId());
+        // Auto-revert (W1 non-gear pickup dupe mitigation): a NON-gear ground proxy is
+        // a real, pickable object; if a local character grabbed a peer's proxy, retaining
+        // it duplicates the authoring client's still-held real item (which mirrors back
+        // over the inventory channel below). Re-drop any picked-up proxy to the ground
+        // BEFORE publishInventories, so the pickup never becomes a published/persisted
+        // second copy. Gated on worldSync (proxies only exist when it is on). NOT pickup
+        // conservation (Phase W4) - the peer still cannot TAKE non-gear drops; the dupe
+        // is simply closed while the drop stays visible.
+        if (g_cfg.worldSync)
+            g_repl.revertProxyPickups(gw);
         // Both clients stream the contents of every squad member they OWN (host tab 0,
         // join tab 1) on content-change - bidirectional, disjoint by the same tab
         // partition as positional sync. Gated on invSync so ordinary co-op sessions add

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -718,6 +718,15 @@ unsigned int captureWeaponPtrs(GameWorld* gw, const unsigned int cHand[5],
 // relocateWeaponToGround. Returns 1 on success. `item` must be a still-live tracked object.
 int addItemPtrToInventory(GameWorld* gw, const unsigned int targetHand[5], void* item);
 
+// SEH-guarded (auto-revert mitigation, W1 non-gear pickup): a ground proxy that a
+// PEER picked up (it now sits in some character's inventory) must NOT be retained -
+// the authoring client still holds the real object, so keeping the picked-up proxy
+// duplicates it. Re-drop the proxy back onto the ground at (x,y,z) via the engine's
+// own Inventory::dropItem (a clean bag->ground move, NEVER a destroy). Returns 1 if
+// the object was in an inventory and got dropped, else 0 (already on the ground /
+// stale / not in an inventory).
+int dropProxyItemToGround(GameWorld* gw, void* item, float x, float y, float z);
+
 // ---- Equipped-gear (armour/weapon slot) test hooks (inv_equip scenario) ----
 // SEH-guarded: report the first EQUIPPED item worn by the object at cHand (its
 // template stringID + itemType) and the total count of worn items. Returns 1 if any

--- a/src/plugin/game/EngineInventory.cpp
+++ b/src/plugin/game/EngineInventory.cpp
@@ -1400,6 +1400,40 @@ int relocateWeaponToGround(GameWorld* gw, const unsigned int ownerHand[5],
     return dropped;
 }
 
+// SEH-guarded (auto-revert mitigation, W1 non-gear pickup): re-drop a ground proxy
+// that a PEER picked up back onto the GROUND at (x,y,z). The peer must not RETAIN a
+// non-gear W1 proxy (the authoring client still holds the real object - retaining
+// the picked-up copy duplicates it), so we move it bag->ground via the engine's own
+// Inventory::dropItem (the same virtual the drop hook wraps) - a clean relocation,
+// NEVER a destroy. Then reposition the exact object to the tracked ground spot (the
+// vanilla drop lands it at the character's feet). Returns 1 if it was in an inventory
+// and got dropped, else 0.
+int dropProxyItemToGround(GameWorld* gw, void* item, float x, float y, float z) {
+    if (!gw || !item) return 0;
+    int ok = 0;
+    __try {
+        Item* it = reinterpret_cast<Item*>(item);
+        if (!it->isInInventory) return 0;    // still on the ground - nobody picked it up
+        // The PARENT inventory holding this item. NOTE: Item::getInventory() returns the
+        // item's OWN inventory (a container item's) - null for a plain item - so resolve
+        // the holding character from _whosInventoryWeAreIn and take ITS inventory.
+        const hand& h = it->_whosInventoryWeAreIn;
+        unsigned int cHand[5];
+        cHand[0] = (unsigned int)h.type; cHand[1] = h.container; cHand[2] = h.containerSerial;
+        cHand[3] = h.index; cHand[4] = h.serial;
+        RootObject* holder = resolveObjectByHand(cHand);
+        if (!holder) return 0;
+        Inventory* inv = holder->getInventory(); // the inventory currently holding it
+        if (!inv) return 0;
+        inv->dropItem(it);                   // virtual Inventory::dropItem: clean bag -> ground
+        Ogre::Vector3 pos(x, y, z);
+        Ogre::Quaternion rot = Ogre::Quaternion::IDENTITY;
+        it->setPositionRotation(pos, rot, /*fixedPosition*/true);
+        ok = 1;
+    } __except (EXCEPTION_EXECUTE_HANDLER) { ok = 0; }
+    return ok;
+}
+
 // SEH-guarded (Phase W3): capture the WEAPON items the object at cHand currently holds, with
 // their REAL Item* handles. The drop detector remembers these per tick so that when a weapon
 // leaves the bag (drop), the prior tick's handle IS the now-grounded object - trackable for a

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -211,6 +211,12 @@ public:
     // reconcile local proxies - spawn a proxy for a new (ownerId, netId), move it if it
     // changed, destroy it on cull. netId spaces are per-sender, culls owner-scoped.
     void applyWorldItems(GameWorld* gw, Inbound& in);
+    // Auto-revert mitigation (W1 non-gear pickup dupe): if a PEER picked up one of
+    // our tracked ground proxies (a real, unowned, pickable object), re-drop it to
+    // the ground before the inventory publish so the peer never retains (and never
+    // mirrors back) a second copy of the authoring client's real item. NOT full
+    // pickup conservation (Phase W4) - it prevents the dupe + keeps the drop visible.
+    void revertProxyPickups(GameWorld* gw);
 
     // BEFORE engine (Phase W2/W3, runs on EVERY client): diff each OWNED character's WEAPON
     // census. A sustained count DECREASE is a DROP (the weapon left the bag; we never mutate

--- a/src/plugin/sync/ReplicatorItems.cpp
+++ b/src/plugin/sync/ReplicatorItems.cpp
@@ -361,6 +361,12 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
             // its own drop); authoring it here too would duplicate the proxy. World
             // NPC (class 0) and our own squad (class 1) drops still stream.
             if (ownerClassForHand(de[i].ownerHand) == 2) continue;
+            // The auto-revert re-drops a peer-picked-up proxy via Inventory::dropItem,
+            // which trips this same drop hook. Never re-author OUR OWN proxy as a fresh
+            // ground item - it would bounce back to the authoring client as a duplicate.
+            if (!proxyObjs.empty() &&
+                proxyObjs.count(engine::resolveObjectByHand(de[i].itemHand)) != 0)
+                continue; // our proxy re-dropped by the revert - not ours to publish
             Key k; k.t = de[i].itemHand[0]; k.c = de[i].itemHand[1]; k.cs = de[i].itemHand[2];
             k.i = de[i].itemHand[3]; k.s = de[i].itemHand[4];
             if (worldTrack_.find(k) != worldTrack_.end()) continue; // already tracked
@@ -514,6 +520,33 @@ void Replicator::applyWorldItems(GameWorld* gw, Inbound& in) {
             if (dumpWi) { char b2[128]; _snprintf(b2, sizeof(b2) - 1,
                 "[wi] CULL owner=%u netId=%u", b->ownerId, *id);
                 b2[sizeof(b2) - 1] = '\0'; coop::logLine(b2); }
+        }
+    }
+}
+
+void Replicator::revertProxyPickups(GameWorld* gw) {
+    if (worldProxies_.empty()) return;
+    static int dumpWi = -1;
+    if (dumpWi < 0) { const char* e = getenv("KENSHICOOP_INV_DUMP"); dumpWi = (e && e[0] == '1') ? 1 : 0; }
+    // Each of our proxies is a real, unowned, PICKABLE ground object. If a local
+    // character grabbed one (isInInventory now true), retaining it would duplicate
+    // the authoring client's real item (that client's liveness only tracks its own
+    // object, so it never culls - the peer ends up with a second copy that mirrors
+    // back over the inventory channel). Re-drop it to its tracked ground spot BEFORE
+    // the inventory publish, so the pickup never becomes a persisted/streamed copy.
+    // dropProxyItemToGround is a no-op for proxies still on the ground, so this scan
+    // is cheap in the common (nothing picked up) case. NOT pickup conservation
+    // (Phase W4) - the item cannot be TAKEN by the peer yet; the dupe is just closed.
+    for (std::map<std::pair<u32, u32>, WorldProxy>::iterator pi = worldProxies_.begin();
+         pi != worldProxies_.end(); ++pi) {
+        WorldProxy& wp = pi->second;
+        if (!wp.obj) continue;
+        int r = engine::dropProxyItemToGround(gw, wp.obj, wp.x, wp.y, wp.z);
+        if (r && dumpWi) {
+            char b[176]; _snprintf(b, sizeof(b) - 1,
+                "[wi] REVERT-PICKUP owner=%u netId=%u pos=%.2f,%.2f,%.2f (re-dropped a peer-picked-up proxy)",
+                pi->first.first, pi->first.second, wp.x, wp.y, wp.z);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
         }
     }
 }

--- a/src/plugin/test/ScenarioWorldItems.cpp
+++ b/src/plugin/test/ScenarioWorldItems.cpp
@@ -777,7 +777,221 @@ const char* const RejoinItemsScenario::SAVE_NAME = "coopresume";
 
 } // namespace
 
+// world_item_peer_pickup (W1 non-gear cross-client PICKUP conservation): the
+// dupe gate for a peer picking up a NON-GEAR ground item the other player
+// dropped. The HOST (owns rank 0) seeds ONE common non-gear item into its
+// leader's bag and DROPS it - it streams to the JOIN as a W1 template proxy
+// (a real, unowned, pickable ground object). The JOIN (owns rank 1) then PICKS
+// UP that proxy into its OWN rank-1 character (engine::pickupWorldItemIntoInventory
+// - the same relocate-into-bag a player order performs). Both clients census the
+// TOTAL number of that sid they can see = rank0 bag + rank1 bag + free ground.
+// CONSERVATION invariant: exactly ONE copy exists in the world at all times, so
+// total must NEVER exceed 1 on either client. On the UNFIXED W1 path the host
+// keeps its real dropped item on the ground (its liveness only checks its OWN
+// object, untouched by the join grabbing a proxy) AND the join's picked-up copy
+// mirrors back via the inventory channel -> the HOST sees total=2 (a silent
+// DUPE), while the join still sees 1. The auto-revert mitigation
+// (Replicator::revertProxyPickups) re-drops any picked-up proxy before the
+// inventory publish, so the host never sees the second copy and total stays 1.
+// Gate = wi_peer_pickup (Test-WorldItemPeerPickup): host maxtot<=1 AND fintot==1
+// AND the drop+pickup were actually exercised (dropped>0, picked>0).
+class WorldItemPeerPickupScenario : public Scenario {
+public:
+    WorldItemPeerPickupScenario()
+        : passed_(false), haveRanks_(false), isHost_(false), step_(0),
+          lastLogMs_(0), probeType_(0), dropped_(0), picked_(0),
+          maxTot_(0), finTot_(0) {
+        for (int i = 0; i < 5; ++i) { rank0_[i] = 0; rank1_[i] = 0; }
+        probeSid_[0] = '\0';
+    }
+    virtual const char* name() const { return "world_item_peer_pickup"; }
+
+    virtual void onStart(const ScenarioContext& ctx) {
+        isHost_ = ctx.isHost;
+        // Deterministic common non-gear test template (same gamedata -> same sid
+        // on both clients), so the join can target the ground proxy by sid.
+        haveRanks_ = engine::commonTestItemSid(ctx.gw, probeSid_, sizeof(probeSid_), &probeType_) != 0;
+        // rank 0 = host-owned leader bag (drop source); rank 1 = join-owned bag
+        // (pickup destination). Resolved from the shared squad partition.
+        bool r0 = resolveRankContainer(ctx.gw, 0, rank0_);
+        bool r1 = resolveRankContainer(ctx.gw, 1, rank1_);
+        haveRanks_ = haveRanks_ && r0 && r1;
+        char b[220];
+        _snprintf(b, sizeof(b) - 1,
+            "SCENARIO WPU anchor host=%d have=%d sid='%s' type=%u r0=%u,%u,%u,%u,%u r1=%u,%u,%u,%u,%u",
+            isHost_ ? 1 : 0, haveRanks_ ? 1 : 0, probeSid_[0] ? probeSid_ : "(none)", probeType_,
+            rank0_[0], rank0_[1], rank0_[2], rank0_[3], rank0_[4],
+            rank1_[0], rank1_[1], rank1_[2], rank1_[3], rank1_[4]);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
+
+    virtual bool onTick(const ScenarioContext& ctx) {
+        if (!haveRanks_) { if (ctx.elapsedMs >= 6000) { passed_ = false; return true; } return false; }
+
+        // ---- HOST: seed one non-gear item into rank 0, then drop it ----------
+        if (isHost_) {
+            if (step_ == 0 && ctx.elapsedMs >= 6000) {
+                step_ = 1;
+                int added = engine::addItemsToContainerBySid(ctx.gw, rank0_, probeSid_,
+                                                             probeType_, 1, 0, "", "");
+                char b[160]; _snprintf(b, sizeof(b) - 1,
+                    "SCENARIO WPU SEED added=%d sid='%s' type=%u", added, probeSid_, probeType_);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            }
+            if (step_ == 1 && ctx.elapsedMs >= 9000) {
+                step_ = 2;
+                dropped_ = engine::dropItemFromInventory(ctx.gw, rank0_, probeSid_, probeType_, 1);
+                char b[160]; _snprintf(b, sizeof(b) - 1,
+                    "SCENARIO WPU DROP dropped=%d", dropped_);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            }
+        }
+
+        // ---- JOIN: pick up the host's ground proxy into rank 1 ---------------
+        if (!isHost_) {
+            if (step_ == 0 && ctx.elapsedMs >= 16000) {
+                step_ = 1;
+                // Relocate the free ground proxy (the only ground copy of the sid
+                // on the join) into the join-owned rank-1 bag - the conservation
+                // pickup a player order performs. Generous radius: rank 0 and rank 1
+                // are the same squad, co-located at the drop site.
+                picked_ = engine::pickupWorldItemIntoInventory(ctx.gw, rank1_, probeSid_,
+                                                               probeType_, 80.0f);
+                char b[160]; _snprintf(b, sizeof(b) - 1,
+                    "SCENARIO WPU PICKUP picked=%d", picked_);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            }
+        }
+
+        // ---- Both: census total copies of the sid every 500 ms --------------
+        if (ctx.elapsedMs - lastLogMs_ >= 500 || lastLogMs_ == 0) {
+            lastLogMs_ = ctx.elapsedMs;
+            int r0 = countInContainer(ctx.gw, rank0_, probeSid_, probeType_);
+            int r1 = countInContainer(ctx.gw, rank1_, probeSid_, probeType_);
+            int grnd = engine::countFreeGroundItemsNear(ctx.gw, rank0_, probeSid_, probeType_, 80.0f);
+            int total = r0 + r1 + grnd;
+            // Only track the max AFTER the drop has happened (the pre-seed total is
+            // a legitimate 1 in rank 0; we care about duplication post-drop).
+            bool afterDrop = isHost_ ? (step_ >= 2) : (ctx.elapsedMs >= 12000);
+            if (afterDrop && total > maxTot_) maxTot_ = total;
+            finTot_ = total;
+            char b[200]; _snprintf(b, sizeof(b) - 1,
+                "SCENARIO WPU %s t=%lu r0=%d r1=%d grnd=%d total=%d",
+                isHost_ ? "HOST" : "JOIN", (unsigned long)ctx.elapsedMs, r0, r1, grnd, total);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        }
+
+        unsigned long dur = isHost_ ? HOST_DURATION_MS : JOIN_DURATION_MS;
+        if (ctx.elapsedMs >= dur) {
+            if (isHost_) {
+                // Conserved iff the host never observed a second copy and the world
+                // settled back to exactly one (the dropped item on the ground).
+                passed_ = (dropped_ > 0) && (maxTot_ <= 1) && (finTot_ == 1);
+                char b[200]; _snprintf(b, sizeof(b) - 1,
+                    "WPU verdict role=host pass=%d dropped=%d maxtot=%d fintot=%d",
+                    passed_ ? 1 : 0, dropped_, maxTot_, finTot_);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            } else {
+                // The join stays locally conserved (bag<->ground); its verdict just
+                // proves the pickup was exercised (else the host gate is vacuous).
+                passed_ = (picked_ > 0) && (maxTot_ <= 1);
+                char b[200]; _snprintf(b, sizeof(b) - 1,
+                    "WPU verdict role=join pass=%d picked=%d maxtot=%d fintot=%d",
+                    passed_ ? 1 : 0, picked_, maxTot_, finTot_);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    virtual bool passed() const { return passed_; }
+
+private:
+    static const unsigned long HOST_DURATION_MS = 30000; // outlive the join + the dupe window
+    static const unsigned long JOIN_DURATION_MS = 24000;
+    static const unsigned int  MAX_SQUAD        = 32;
+
+    // Count copies of (sid,type) held in the container at `hand` (0 if unresolved).
+    int countInContainer(GameWorld* gw, const unsigned int hand[5],
+                         const char* sid, unsigned int type) {
+        if (hand[0] == 0 && hand[1] == 0 && hand[3] == 0 && hand[4] == 0) return 0;
+        InvItemEntry it[INV_ITEMS_MAX];
+        unsigned int n = engine::captureContainerContents(gw, hand, it, INV_ITEMS_MAX, 0);
+        int c = 0;
+        for (unsigned int i = 0; i < n; ++i)
+            if (it[i].itemType == type && strcmp(it[i].stringID, sid) == 0) {
+                int q = it[i].quantity; if (q < 1) q = 1; c += q;
+            }
+        return c;
+    }
+
+    // Resolve the container of the squad member in the requested ownership rank
+    // (0 = host leader, 1 = join). Mirrors the Replicator's tab partition, so it
+    // agrees on both clients from the shared save. (Same logic as the inventory
+    // scenarios' local helper.)
+    static bool resolveRankContainer(GameWorld* gw, unsigned int rank, unsigned int out[5]) {
+        for (int i = 0; i < 5; ++i) out[i] = 0;
+        EntityState sq[MAX_SQUAD];
+        unsigned int n = engine::captureSquad(gw, /*leaderOnly*/ false, sq, MAX_SQUAD);
+        if (n == 0) return false;
+        int best = -1;
+        for (unsigned int i = 0; i < n; ++i) {
+            int cr = containerRankOf(sq, n, i);
+            if (cr < 0 || (unsigned int)cr != rank) continue;
+            if (best < 0 || handLess(sq[i], sq[best])) best = (int)i;
+        }
+        if (best < 0) return false;
+        out[0] = sq[best].hType; out[1] = sq[best].hContainer;
+        out[2] = sq[best].hContainerSerial; out[3] = sq[best].hIndex; out[4] = sq[best].hSerial;
+        return true;
+    }
+    static bool handLess(const EntityState& a, const EntityState& b) {
+        if (a.hType != b.hType) return a.hType < b.hType;
+        if (a.hContainer != b.hContainer) return a.hContainer < b.hContainer;
+        if (a.hContainerSerial != b.hContainerSerial) return a.hContainerSerial < b.hContainerSerial;
+        if (a.hIndex != b.hIndex) return a.hIndex < b.hIndex;
+        return a.hSerial < b.hSerial;
+    }
+    static bool ctnrLess(const EntityState& a, const EntityState& b) {
+        if (a.hContainer != b.hContainer) return a.hContainer < b.hContainer;
+        return a.hContainerSerial < b.hContainerSerial;
+    }
+    static bool ctnrEq(const EntityState& a, const EntityState& b) {
+        return a.hContainer == b.hContainer && a.hContainerSerial == b.hContainerSerial;
+    }
+    static int containerRankOf(const EntityState* sq, unsigned int n, unsigned int i) {
+        EntityState distinct[MAX_SQUAD]; unsigned int dn = 0;
+        for (unsigned int a = 0; a < n; ++a) {
+            bool seen = false;
+            for (unsigned int b = 0; b < dn; ++b) if (ctnrEq(distinct[b], sq[a])) { seen = true; break; }
+            if (!seen && dn < MAX_SQUAD) distinct[dn++] = sq[a];
+        }
+        for (unsigned int a = 1; a < dn; ++a)
+            for (unsigned int b = a; b > 0 && ctnrLess(distinct[b], distinct[b-1]); --b) {
+                EntityState t = distinct[b]; distinct[b] = distinct[b-1]; distinct[b-1] = t;
+            }
+        for (unsigned int b = 0; b < dn; ++b) if (ctnrEq(distinct[b], sq[i])) return (int)b;
+        return -1;
+    }
+
+    bool          passed_;
+    bool          haveRanks_;
+    bool          isHost_;
+    int           step_;
+    unsigned long lastLogMs_;
+    unsigned int  probeType_;
+    int           dropped_;
+    int           picked_;
+    int           maxTot_;
+    int           finTot_;
+    unsigned int  rank0_[5];
+    unsigned int  rank1_[5];
+    char          probeSid_[48];
+};
+
 Scenario* makeWorldItemScenario(const std::string& name) {
+    if (name == "world_item_peer_pickup") return new WorldItemPeerPickupScenario();
     if (name == "drop_probe")   return new DropProbeScenario();
     if (name == "world_item_sync") return new WorldItemSyncScenario();
     if (name == "world_item_drop") return new WorldItemDropScenario();


### PR DESCRIPTION
### What this fixes

A non-gear item (food, materials, stacks — not weapons/armor, those already conserve fine) dropped by one player and picked up by the other duplicates. The dropper's liveness check only watches their own real item (`groundItemLiveness`), which stays untouched because the peer grabbed a separately-spawned proxy on their own machine — so the dropper's copy never gets culled while the picker's copy gets reflected back through the inventory channel. Net result: two copies of the same item across the two clients.

Confirmed live with a real repro scenario against a clean `main` build (not assumed): `host(max=2 fin=2)` — a real dupe, not a theoretical one.

### How

`revertProxyPickups` (new, runs pre-publish in `Plugin.cpp`): if a local character has picked up a world-item proxy, it re-drops it to the ground via `Inventory::dropItem` — a real move, never a destroy — before `publishInventories` runs. The peer never retains or reflects a second copy. This is a deliberate mitigation, not full conservation: the drop stays visible in both directions (matches the README claim), but you still can't walk off with a non-gear item your squadmate dropped — that's proper Phase-4 conservation work, still not started, same as the gear path got before it was moved off W1.

### Testing

- Built with the real toolchain (VS2010 v100 x64), 0 errors.
- New scenario + oracle (`ScenarioWorldItems.cpp` / `scripts/oracles/World.ps1`): FAIL on clean `main` (`host(max=2 fin=2)`, dupe reproduced), PASS with the fix (`host(max=1 fin=1)`, `[wi] REVERT-PICKUP` fires exactly once).
- Regression: `world_item_sync` (non-gear drop → proxy → cull) and `world_weapon_drop` (gear conservation) both still PASS.

### What was NOT tested

Not run against my other five fix branches yet (found after those were combined/reviewed) — no reason to expect interaction (this touches the world-item channel only), but the combined smoke hasn't been re-run with this one in the mix.