### PR TITLE
Fix save_sync destroying the join's local save on a degenerate/failed transfer

### DIFF
--- a/scripts/build_prototest.cmd
+++ b/scripts/build_prototest.cmd
@@ -16,19 +16,24 @@ popd >nul
 set "VS10=C:\Program Files (x86)\Microsoft Visual Studio 10.0"
 set "VC=%VS10%\VC"
 set "SDK=C:\Program Files\Microsoft SDKs\Windows\v7.1"
+REM enet headers are needed only to PARSE net\NetLink.h (SaveXfer.cpp includes it);
+REM the queue* sinks it references are stubbed in savexfer_test.cpp (no ENet link).
+set "ENET=%REPO%\third_party\enet\enet\include"
 
 set "PATH=%VC%\bin\amd64;%VC%\bin;%VS10%\Common7\IDE;%SDK%\Bin\x64;%SDK%\Bin;%PATH%"
-set "INCLUDE=%VC%\include;%SDK%\Include;%REPO%\third_party\vc10_compat"
+set "INCLUDE=%VC%\include;%SDK%\Include;%REPO%\third_party\vc10_compat;%ENET%"
 set "LIB=%VC%\lib\amd64;%SDK%\Lib\x64"
 
 if not exist "%REPO%\dist" mkdir "%REPO%\dist"
 if not exist "%REPO%\build\prototest" mkdir "%REPO%\build\prototest"
 
 echo === Building prototest.exe (Release^|x64, v100) ===
-cl.exe /nologo /O2 /EHsc /W3 ^
+cl.exe /nologo /O2 /EHsc /W3 /DWIN32_LEAN_AND_MEAN ^
     /Fo"%REPO%\build\prototest\\" ^
     /Fe"%REPO%\dist\prototest.exe" ^
     "%REPO%\src\prototest\main.cpp" ^
+    "%REPO%\src\prototest\savexfer_test.cpp" ^
+    "%REPO%\src\plugin\sync\SaveXfer.cpp" ^
     "%REPO%\src\plugin\sync\Interp.cpp"
 if errorlevel 1 (
     echo prototest build FAILED

--- a/src/plugin/sync/SaveXfer.cpp
+++ b/src/plugin/sync/SaveXfer.cpp
@@ -238,6 +238,52 @@ std::string saveFolderFor(const std::string& name) {
     return pathJoin(root, name);
 }
 
+bool saveNameSafe(const std::string& name) {
+    // Empty -> saveFolderFor("") resolves to the save ROOT: a commit would move
+    // the WHOLE save folder. Bound the length to the on-disk slot convention.
+    if (name.empty() || name.size() > 64) return false;
+    // A leading '.' or space is a reserved/hidden Windows name; reject outright.
+    if (name[0] == '.' || name[0] == ' ') return false;
+    for (size_t i = 0; i < name.size(); ++i) {
+        char c = name[i];
+        // No separators or drive markers: the name must stay a single folder
+        // directly under the save root (never escape it, never nest).
+        if (c == '\\' || c == '/' || c == ':') return false;
+        // No parent-dir traversal.
+        if (c == '.' && i + 1 < name.size() && name[i + 1] == '.') return false;
+    }
+    return true;
+}
+
+void recoverStrandedSave(const std::string& name) {
+    if (!saveNameSafe(name)) return; // never touch anything for an unsafe name
+    std::string finalDir = saveFolderFor(name);
+    std::string oldDir   = finalDir + "__old";
+    bool haveOld   = GetFileAttributesA(oldDir.c_str())   != INVALID_FILE_ATTRIBUTES;
+    bool haveFinal = GetFileAttributesA(finalDir.c_str()) != INVALID_FILE_ATTRIBUTES;
+    if (haveOld && !haveFinal) {
+        // Commit crashed AFTER moving the real save out but BEFORE moving the
+        // staging in: the real save only exists as __old. Put it back.
+        if (MoveFileExA(oldDir.c_str(), finalDir.c_str(), MOVEFILE_WRITE_THROUGH)) {
+            char b[224];
+            _snprintf(b, sizeof(b) - 1,
+                      "[save] RECOVER restored stranded save '%s' from __old", name.c_str());
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        } else {
+            char b[224];
+            _snprintf(b, sizeof(b) - 1,
+                      "[save] RECOVER FAILED to restore '%s' from __old (err=%lu)",
+                      name.c_str(), GetLastError());
+            b[sizeof(b) - 1] = '\0'; coop::logErrLine(b);
+        }
+    } else if (haveOld && haveFinal) {
+        // The move-in completed but the process died before removing __old: the
+        // real save is already in place, so __old is a redundant backup - reclaim
+        // it (leaving it would poison the NEXT commit's move-out).
+        removeTree(oldDir, 0);
+    }
+}
+
 bool folderInventory(const std::string& folder, unsigned int* outFiles,
                      unsigned __int64* outBytes, unsigned __int64* outLatestWrite) {
     unsigned int files = 0;
@@ -536,9 +582,31 @@ void onSaveBegin(const SaveBeginPacket& b) {
     g_recvTotalBytes = b.totalBytes;
     g_recvBytes      = 0;
     g_recvStartTick  = GetTickCount();
-    g_recvStaging    = saveFolderFor(g_recvName + "__incoming");
     g_recvCrcs.assign(b.fileCount, fnv1aInit());
     g_recvSeen.assign(b.fileCount, 0);
+
+    // Refuse an unsafe name BEFORE deriving any on-disk path. saveFolderFor("")
+    // (or a name with separators / "..") would resolve staging/commit targets to
+    // the save ROOT or outside it - a subsequent commit would then move (delete)
+    // every real save on the join. An unsafe BEGIN stages nothing and drops all
+    // its FILE/DONE chunks (g_recvActive stays false).
+    if (!saveNameSafe(g_recvName)) {
+        g_recvActive  = false;
+        g_recvStaging.clear();
+        char eb[224];
+        _snprintf(eb, sizeof(eb) - 1,
+                  "[save] XFER-RECV REFUSED id=%u unsafe name='%s' (nothing staged)",
+                  b.xferId, name);
+        eb[sizeof(eb) - 1] = '\0'; coop::logErrLine(eb);
+        return;
+    }
+
+    // Heal a prior crashed commit of THIS save (real save stranded in __old)
+    // before we re-stage, so the incoming transfer never races a half-committed
+    // predecessor.
+    recoverStrandedSave(g_recvName);
+
+    g_recvStaging    = saveFolderFor(g_recvName + "__incoming");
 
     // A fresh staging folder: stale partials from an aborted transfer would
     // otherwise pollute the CRC verify.
@@ -603,10 +671,23 @@ int onSaveDone(const SaveDoneHeader& d, const u32* crcs,
     recvCloseFile();
     g_recvActive = false;
 
-    bool ok = (d.fileCount == g_recvFileCount);
+    // A commit is authorized ONLY by a fully-received, non-empty, safely-named,
+    // CRC-verified staging. Any shortfall leaves the join's EXISTING save fully
+    // intact - the failure path below only ever discards our private __incoming
+    // staging, never the real save. This is the core data-safety invariant:
+    //   * saveNameSafe: commit target can never be the save ROOT (root wipe).
+    //   * fileCount > 0: an empty/degenerate transfer can never replace a real
+    //     save with an empty folder (and then delete the __old backup).
+    //   * count agreement + crcs != 0: a truncated/table-less DONE cannot verify.
+    bool ok = saveNameSafe(g_recvName) &&
+              g_recvFileCount > 0 &&
+              d.fileCount == g_recvFileCount &&
+              crcs != 0;
     unsigned int bad = 0;
     if (ok) {
         for (u16 i = 0; i < d.fileCount; ++i) {
+            // A never-seen file (BEGIN promised it, no chunk arrived) fails the
+            // verify just like a CRC mismatch: we never commit a partial save.
             if (!g_recvSeen[i] || g_recvCrcs[i] != crcs[i]) { ++bad; ok = false; }
         }
     }

--- a/src/plugin/sync/SaveXfer.cpp
+++ b/src/plugin/sync/SaveXfer.cpp
@@ -282,6 +282,26 @@ void recoverStrandedSave(const std::string& name) {
         // it (leaving it would poison the NEXT commit's move-out).
         removeTree(oldDir, 0);
     }
+
+    // Discard any stranded staging (<name>__incoming). It is scratch from a
+    // transfer that was killed mid-RECEIVE (some but not all files staged, commit
+    // never attempted) or mid-COMMIT (verified staging not yet swapped in) - the
+    // __old logic above already put the real save back, so anything left in
+    // __incoming is disposable. Staging is NEVER the real save, so discarding it
+    // unconditionally can never lose data; leaving it would let a partial folder
+    // linger as a junk save slot and, if a re-stage ever failed to wipe it,
+    // pollute the next transfer's CRC verify. A live transfer only (re)creates
+    // this folder AFTER recovery runs (onSaveBegin calls us first), so no
+    // in-flight staging is ever collateral here.
+    std::string incomingDir = finalDir + "__incoming";
+    if (GetFileAttributesA(incomingDir.c_str()) != INVALID_FILE_ATTRIBUTES) {
+        removeTree(incomingDir, 0);
+        char b[224];
+        _snprintf(b, sizeof(b) - 1,
+                  "[save] RECOVER discarded stranded staging '%s__incoming'",
+                  name.c_str());
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
 }
 
 bool folderInventory(const std::string& folder, unsigned int* outFiles,

--- a/src/plugin/sync/SaveXfer.h
+++ b/src/plugin/sync/SaveXfer.h
@@ -34,6 +34,25 @@ namespace savexfer {
 // %LOCALAPPDATA%\kenshi\save\<name> convention every harness script assumes.
 std::string saveFolderFor(const std::string& name);
 
+// ---- Data-safety guards (protocol 31 receiver) -------------------------------
+// A received transfer name must resolve to <saveRoot>/<name> and NEVER to the
+// save-folder ROOT or an escaping path. Rejects empty names, path separators,
+// ':', any ".." component, and a leading dot/space. The receiver refuses to
+// stage or commit an unsafe name: a malformed/empty BEGIN would otherwise
+// resolve saveFolderFor("") to the save ROOT and a commit would move (delete)
+// EVERY local save on the join (squad1, autosaves, _current, ...).
+bool saveNameSafe(const std::string& name);
+
+// Crash recovery for the coordinated-commit swap. onSaveDone commits by moving
+// save/<name>/ out to save/<name>__old/ and then the verified staging in. If
+// the process died - or a move faulted - inside that window, the real save is
+// stranded in save/<name>__old/ with NO save/<name>/ (the "join lost its save"
+// symptom). recoverStrandedSave restores it (or reclaims a redundant __old when
+// save/<name>/ already exists). Idempotent + no-op for an unsafe name. Called
+// defensively at the top of onSaveBegin so the next transfer of the same save
+// heals a prior crashed commit before it re-stages.
+void recoverStrandedSave(const std::string& name);
+
 // Recursive inventory of 'folder': file count, total bytes, and the newest
 // last-write FILETIME (as u64). Returns false when the folder doesn't exist.
 bool folderInventory(const std::string& folder, unsigned int* outFiles,

--- a/src/plugin/sync/SaveXfer.h
+++ b/src/plugin/sync/SaveXfer.h
@@ -48,9 +48,13 @@ bool saveNameSafe(const std::string& name);
 // the process died - or a move faulted - inside that window, the real save is
 // stranded in save/<name>__old/ with NO save/<name>/ (the "join lost its save"
 // symptom). recoverStrandedSave restores it (or reclaims a redundant __old when
-// save/<name>/ already exists). Idempotent + no-op for an unsafe name. Called
-// defensively at the top of onSaveBegin so the next transfer of the same save
-// heals a prior crashed commit before it re-stages.
+// save/<name>/ already exists). It ALSO discards any stranded
+// save/<name>__incoming/ staging - scratch left by a transfer killed mid-receive
+// (partial files, no commit attempted) or mid-commit (staging not yet swapped
+// in); staging is never the real save, so this can only remove disposable
+// scratch. Idempotent + no-op for an unsafe name. Called defensively at the top
+// of onSaveBegin so the next transfer of the same save heals a prior crash
+// before it re-stages.
 void recoverStrandedSave(const std::string& name);
 
 // Recursive inventory of 'folder': file count, total bytes, and the newest

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -39,8 +39,12 @@
 
 using namespace coop;
 
-static int g_failed = 0;
-static int g_total  = 0;
+// Non-static: savexfer_test.cpp folds its checks into the same run total.
+int g_failed = 0;
+int g_total  = 0;
+
+// SaveXfer receiver data-safety coverage (src/prototest/savexfer_test.cpp).
+void testSaveXfer();
 
 #define CHECK(name, cond) do { \
     ++g_total; \
@@ -1377,6 +1381,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testSaveXfer();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;

--- a/src/prototest/savexfer_test.cpp
+++ b/src/prototest/savexfer_test.cpp
@@ -316,6 +316,81 @@ void testSaveXfer() {
         rmTree(cr); rmTree(old);
     }
 
+    // --- F. crash recovery: a stranded PARTIAL staging (__incoming) is discarded
+    // Reproduces a transfer killed mid-receive (kill -9 / crash / forced game
+    // close): the join has staged SOME but not ALL files into __incoming and the
+    // commit was never attempted. On the next recovery the partial staging must be
+    // discarded cleanly, and the join's real save must be left byte-intact - the
+    // partial scratch is NEVER the real save and must never touch it.
+    {
+        std::string cr  = savexfer::saveFolderFor("coopresume");
+        std::string inc = savexfer::saveFolderFor("coopresume__incoming");
+        std::string old = savexfer::saveFolderFor("coopresume__old");
+        rmTree(cr); rmTree(inc); rmTree(old);
+        // Real save present; partial staging with only 1 of an expected 2 files.
+        writeFile(cr  + "\\quick.save", "JOIN-REAL-SAVE");
+        writeFile(inc + "\\quick.save", "HALF-RECEIVED"); // platoon\a.platoon never arrived
+        savexfer::recoverStrandedSave("coopresume");
+        SXCHECK("recover-partial: stranded __incoming discarded",
+                !dirExists(inc));
+        SXCHECK("recover-partial: join's real save byte-intact",
+                readFile(cr + "\\quick.save") == "JOIN-REAL-SAVE");
+        SXCHECK("recover-partial: no __old orphan invented",
+                !dirExists(old));
+        rmTree(cr); rmTree(inc); rmTree(old);
+    }
+
+    // --- F2. mid-commit-swap kill: __old (real save moved out) AND a leftover
+    // __incoming both present, save/<name>/ absent. Recovery must restore the real
+    // save from __old AND discard the orphaned staging in one pass.
+    {
+        std::string cr  = savexfer::saveFolderFor("coopresume");
+        std::string inc = savexfer::saveFolderFor("coopresume__incoming");
+        std::string old = savexfer::saveFolderFor("coopresume__old");
+        rmTree(cr); rmTree(inc); rmTree(old);
+        writeFile(old + "\\quick.save", "STRANDED-REAL-SAVE");     // real save, moved out
+        writeFile(inc + "\\quick.save", "UNCOMMITTED-STAGING");    // staging, never swapped in
+        savexfer::recoverStrandedSave("coopresume");
+        SXCHECK("recover-swap: real save restored from __old",
+                readFile(cr + "\\quick.save") == "STRANDED-REAL-SAVE");
+        SXCHECK("recover-swap: __old cleaned after restore",
+                !dirExists(old));
+        SXCHECK("recover-swap: leftover __incoming discarded",
+                !dirExists(inc));
+        rmTree(cr); rmTree(inc); rmTree(old);
+    }
+
+    // --- F3. integration: a leftover partial staging must never leak into the
+    // next committed save. Pre-seed __incoming with a stale file that is NOT part
+    // of the new transfer; a following valid transfer of the same name must commit
+    // ONLY the new file set (stale scratch discarded, real save replaced atomically).
+    {
+        std::string cr  = savexfer::saveFolderFor("coopresume");
+        std::string inc = savexfer::saveFolderFor("coopresume__incoming");
+        std::string old = savexfer::saveFolderFor("coopresume__old");
+        rmTree(cr); rmTree(inc); rmTree(old);
+        writeFile(cr  + "\\quick.save", "JOIN-REAL-SAVE");
+        writeFile(inc + "\\stale.dat",  "GARBAGE-FROM-PRIOR-KILL"); // not in the new set
+        writeFile(inc + "\\quick.save", "HALF-RECEIVED");
+        std::vector<File> f;
+        f.push_back(File("quick.save", "NEW-HOST-SAVE"));
+        f.push_back(File("platoon\\a.platoon", "PLATOON-A"));
+        int rc = deliver("coopresume", f, /*badCrc*/false, /*zeroFiles*/false);
+        SXCHECK("leftover-partial: valid transfer still commits", rc == 1);
+        SXCHECK("leftover-partial: committed save has the new content",
+                readFile(cr + "\\quick.save") == "NEW-HOST-SAVE");
+        SXCHECK("leftover-partial: nested new file committed",
+                readFile(cr + "\\platoon\\a.platoon") == "PLATOON-A");
+        SXCHECK("leftover-partial: stale scratch file did NOT leak into the commit",
+                !dirExists(cr + "\\stale.dat") &&
+                readFile(cr + "\\stale.dat").empty());
+        SXCHECK("leftover-partial: staging cleaned up",
+                !dirExists(inc));
+        SXCHECK("leftover-partial: no __old orphan after commit",
+                !dirExists(old));
+        rmTree(cr); rmTree(inc); rmTree(old);
+    }
+
     // Clean the throwaway tree.
     rmTree(root);
     (void)saveRoot;

--- a/src/prototest/savexfer_test.cpp
+++ b/src/prototest/savexfer_test.cpp
@@ -1,0 +1,322 @@
+// savexfer_test - data-safety unit coverage for the protocol-31 coordinated
+// save RECEIVER (src/plugin/sync/SaveXfer.cpp), linked into prototest.
+//
+// The receiver stages a host->join save transfer into save/<name>__incoming/,
+// verifies per-file CRCs on DONE, and atomically swaps it over save/<name>/.
+// These tests drive the receiver against a REAL temp save tree (LOCALAPPDATA is
+// pointed at a throwaway dir so saveFolderFor() resolves there) and assert the
+// core invariant that MUST hold for real users: a transfer that FAILS, is
+// EMPTY/degenerate, or carries an UNSAFE name must NEVER destroy, empty, or
+// strand the join's existing local saves. Only the private __incoming staging
+// may ever be discarded.
+//
+// Build: compiled + linked by scripts/build_prototest.cmd. Zero game calls -
+// the engine/log/NetLink symbols SaveXfer.cpp references are stubbed below.
+//
+// v100 (VC++ 2010) compatible.
+
+#define _CRT_SECURE_NO_WARNINGS 1
+// enet (pulled in via net/NetLink.h below) includes <winsock2.h>; the build
+// defines WIN32_LEAN_AND_MEAN (as the plugin does) so <windows.h> never drags
+// in the old <winsock.h> that would collide with it.
+
+#include <windows.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "../netproto/Wire.h"
+#include "../netproto/ContentHash.h"
+#include "../plugin/sync/SaveXfer.h"
+#include "../plugin/game/Engine.h"   // coop::engine::saveInfo (stubbed below)
+#include "../plugin/CoopLog.h"       // coop::logLine/logErrLine (stubbed below)
+#include "../plugin/net/NetLink.h"   // coop::NetLink queue* (stubbed below)
+
+using namespace coop;
+
+// prototest's shared counters (main.cpp). Every CHECK folds into the run total.
+extern int g_total;
+extern int g_failed;
+
+#define SXCHECK(name, cond) do { \
+    ++g_total; \
+    if (cond) { std::printf("  ok   %s\n", name); } \
+    else      { std::printf("  FAIL %s\n", name); ++g_failed; } \
+} while (0)
+
+// ---- Stubs for the symbols SaveXfer.cpp references (no game, no net) ---------
+namespace coop {
+    // The logger just goes to stdout so a failing run still shows the receiver's
+    // own REFUSED/RECOVER/COMMIT/FAILED lines inline with the checks.
+    void logInit(const char*, const char*) {}
+    unsigned long wallClockMs() { return 0; }
+    void logSetFakeSkewMs(long) {}
+    void logLine(const char* m)    { std::printf("    [log] %s\n", m ? m : ""); }
+    void logErrLine(const char* m) { std::printf("    [err] %s\n", m ? m : ""); }
+    void logClose() {}
+
+    namespace engine {
+        // Force the %LOCALAPPDATA%\kenshi\save fallback so the test controls the
+        // save root purely by setting LOCALAPPDATA (no engine pointers needed).
+        bool saveInfo(char* cg, unsigned cl, char* sp, unsigned pl) {
+            if (cg && cl) cg[0] = '\0';
+            if (sp && pl) sp[0] = '\0';
+            return false;
+        }
+    }
+
+    // Sender-only sinks (the receiver tests never call the sender, but
+    // SaveXfer.cpp's sender functions reference these members).
+    void NetLink::queueSaveBegin(const SaveBeginPacket&) {}
+    void NetLink::queueSaveFile(const SaveFileHeader&, const char*,
+                                const unsigned char*, unsigned int) {}
+    void NetLink::queueSaveDone(const SaveDoneHeader&, const u32*, unsigned int) {}
+}
+
+// ---- Tiny filesystem helpers (test-local; SaveXfer's own are file-private) ---
+namespace {
+
+void mkTree(const std::string& path) {
+    for (size_t i = 3; i <= path.size(); ++i) {
+        if (i == path.size() || path[i] == '\\' || path[i] == '/')
+            CreateDirectoryA(path.substr(0, i).c_str(), 0);
+    }
+}
+
+void rmTree(const std::string& folder) {
+    WIN32_FIND_DATAA fd;
+    std::string spec = folder + "\\*";
+    HANDLE h = FindFirstFileA(spec.c_str(), &fd);
+    if (h != INVALID_HANDLE_VALUE) {
+        do {
+            if (fd.cFileName[0] == '.' &&
+                (fd.cFileName[1] == '\0' ||
+                 (fd.cFileName[1] == '.' && fd.cFileName[2] == '\0')))
+                continue;
+            std::string child = folder + "\\" + fd.cFileName;
+            if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) rmTree(child);
+            else { SetFileAttributesA(child.c_str(), FILE_ATTRIBUTE_NORMAL);
+                   DeleteFileA(child.c_str()); }
+        } while (FindNextFileA(h, &fd));
+        FindClose(h);
+    }
+    RemoveDirectoryA(folder.c_str());
+}
+
+bool dirExists(const std::string& p) {
+    DWORD a = GetFileAttributesA(p.c_str());
+    return a != INVALID_FILE_ATTRIBUTES && (a & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+void writeFile(const std::string& full, const std::string& content) {
+    // Ensure parent exists.
+    size_t s = full.find_last_of("\\/");
+    if (s != std::string::npos) mkTree(full.substr(0, s));
+    HANDLE h = CreateFileA(full.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS,
+                           FILE_ATTRIBUTE_NORMAL, 0);
+    if (h == INVALID_HANDLE_VALUE) return;
+    DWORD wrote = 0;
+    if (!content.empty()) WriteFile(h, content.data(), (DWORD)content.size(), &wrote, 0);
+    CloseHandle(h);
+}
+
+std::string readFile(const std::string& full) {
+    HANDLE h = CreateFileA(full.c_str(), GENERIC_READ, FILE_SHARE_READ, 0,
+                           OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+    if (h == INVALID_HANDLE_VALUE) return std::string();
+    std::string out;
+    char buf[4096];
+    DWORD got = 0;
+    while (ReadFile(h, buf, sizeof(buf), &got, 0) && got > 0) out.append(buf, got);
+    CloseHandle(h);
+    return out;
+}
+
+typedef std::pair<std::string, std::string> File; // (relpath, content)
+
+// Drive a full BEGIN/FILE*/DONE transfer through the receiver. When zeroFiles is
+// true a degenerate 0-file transfer is sent (no FILE chunks, empty CRC table).
+// When badCrc is true the first file's CRC is corrupted so the DONE verify
+// mismatches. Returns onSaveDone's result (1 committed, 0 failed/refused).
+int deliver(const std::string& name, const std::vector<File>& files,
+            bool badCrc, bool zeroFiles) {
+    static u32 s_xfer = 100;
+    u32 xfer = ++s_xfer;
+    u16 count = zeroFiles ? 0 : (u16)files.size();
+
+    SaveBeginPacket bp;
+    memset(&bp, 0, sizeof(bp));
+    bp.type = (u8)PKT_SAVE_BEGIN;
+    bp.xferId = xfer;
+    if (!name.empty()) strncpy(bp.name, name.c_str(), sizeof(bp.name) - 1);
+    bp.fileCount = count;
+    unsigned __int64 total = 0;
+    if (!zeroFiles) for (size_t i = 0; i < files.size(); ++i) total += files[i].second.size();
+    bp.totalBytes = total;
+    savexfer::onSaveBegin(bp);
+
+    std::vector<u32> crcs;
+    if (!zeroFiles) {
+        crcs.resize(files.size(), 0);
+        for (size_t i = 0; i < files.size(); ++i) {
+            const std::string& rel = files[i].first;
+            const std::string& dat = files[i].second;
+            SaveFileHeader h;
+            memset(&h, 0, sizeof(h));
+            h.type = (u8)PKT_SAVE_FILE;
+            h.xferId = xfer;
+            h.fileIdx = (u16)i;
+            h.pathLen = (u16)rel.size();
+            h.offset = 0;
+            h.dataLen = (u16)dat.size();
+            savexfer::onSaveFile(h, rel.c_str(),
+                                 dat.empty() ? 0 : (const unsigned char*)dat.data());
+            crcs[i] = fnv1aUpdate(fnv1aInit(),
+                                  dat.empty() ? "" : dat.data(), (unsigned)dat.size());
+        }
+        if (badCrc && !crcs.empty()) crcs[0] ^= 0x1u; // corrupt -> DONE mismatch
+    }
+
+    SaveDoneHeader d;
+    memset(&d, 0, sizeof(d));
+    d.type = (u8)PKT_SAVE_DONE;
+    d.xferId = xfer;
+    d.fileCount = count;
+    u16 of = 0; unsigned __int64 ob = 0;
+    return savexfer::onSaveDone(d, crcs.empty() ? 0 : &crcs[0], &of, &ob);
+}
+
+} // namespace
+
+// ---- The tests --------------------------------------------------------------
+
+void testSaveXfer() {
+    std::printf("== SaveXfer receiver data-safety (protocol 31) ==\n");
+
+    // Point saveFolderFor() at a throwaway tree via LOCALAPPDATA.
+    char tmp[MAX_PATH]; tmp[0] = '\0';
+    GetTempPathA(sizeof(tmp), tmp);
+    char root[MAX_PATH];
+    _snprintf(root, sizeof(root) - 1, "%ssxtest_%lu", tmp, (unsigned long)GetCurrentProcessId());
+    root[sizeof(root) - 1] = '\0';
+    rmTree(root);
+    std::string la = std::string(root);
+    _putenv((std::string("LOCALAPPDATA=") + la).c_str());
+    // saveFolderFor(name) now = <root>\kenshi\save\<name>
+    std::string saveRoot = savexfer::saveFolderFor(std::string()); // <root>\kenshi\save\ (or trailing sep)
+
+    // --- 0. name-safety predicate --------------------------------------------
+    SXCHECK("saveNameSafe accepts a normal slot", savexfer::saveNameSafe("coopresume"));
+    SXCHECK("saveNameSafe rejects empty (root)",  !savexfer::saveNameSafe(""));
+    SXCHECK("saveNameSafe rejects separator",     !savexfer::saveNameSafe("a\\b"));
+    SXCHECK("saveNameSafe rejects forward sep",   !savexfer::saveNameSafe("a/b"));
+    SXCHECK("saveNameSafe rejects ..",            !savexfer::saveNameSafe(".."));
+    SXCHECK("saveNameSafe rejects drive",         !savexfer::saveNameSafe("C:x"));
+
+    // --- A. CRC-invalid transfer must leave an EXISTING save byte-intact ------
+    // (documents the core CRC-failure invariant; the join keeps its own save.)
+    {
+        std::string cr = savexfer::saveFolderFor("coopresume");
+        rmTree(cr);
+        writeFile(cr + "\\quick.save", "JOIN-REAL-SAVE");
+        std::vector<File> f;
+        f.push_back(File("quick.save", "HOST-INCOMING-DIFFERENT"));
+        int rc = deliver("coopresume", f, /*badCrc*/true, /*zeroFiles*/false);
+        SXCHECK("badCrc: onSaveDone reports failure", rc == 0);
+        SXCHECK("badCrc: join's existing save is byte-intact",
+                readFile(cr + "\\quick.save") == "JOIN-REAL-SAVE");
+        SXCHECK("badCrc: no __incoming staging left behind",
+                !dirExists(savexfer::saveFolderFor("coopresume__incoming")));
+        SXCHECK("badCrc: no __old orphan left behind",
+                !dirExists(savexfer::saveFolderFor("coopresume__old")));
+        rmTree(cr);
+    }
+
+    // --- B. degenerate 0-file transfer must NOT replace/empty a real save -----
+    // (RED on the pre-fix receiver: fileCount==g_recvFileCount==0 counted as
+    //  success -> commit moved the real save to __old, moved empty staging in,
+    //  then deleted __old -> the join's save was destroyed.)
+    {
+        std::string cr = savexfer::saveFolderFor("coopresume");
+        rmTree(cr);
+        writeFile(cr + "\\quick.save", "JOIN-REAL-SAVE");
+        int rc = deliver("coopresume", std::vector<File>(), /*badCrc*/false, /*zeroFiles*/true);
+        SXCHECK("empty-xfer: onSaveDone reports failure", rc == 0);
+        SXCHECK("empty-xfer: join's real save survives (not emptied)",
+                readFile(cr + "\\quick.save") == "JOIN-REAL-SAVE");
+        SXCHECK("empty-xfer: no __old orphan (backup not deleted)",
+                !dirExists(savexfer::saveFolderFor("coopresume__old")));
+        rmTree(cr);
+    }
+
+    // --- C. unsafe/empty NAME must NOT resolve to the save ROOT and wipe all ---
+    // (RED on the pre-fix receiver: an empty name resolved finalDir to the save
+    //  ROOT; a 0-file "success" moved the WHOLE save folder to __old -> every
+    //  sibling save (squad1, current, ...) disappeared.)
+    {
+        std::string s1 = savexfer::saveFolderFor("squad1");
+        std::string cu = savexfer::saveFolderFor("current");
+        rmTree(s1); rmTree(cu);
+        writeFile(s1 + "\\quick.save", "SQUAD1-DATA");
+        writeFile(cu + "\\quick.save", "CURRENT-DATA");
+        int rc = deliver(/*name*/"", std::vector<File>(), /*badCrc*/false, /*zeroFiles*/true);
+        SXCHECK("unsafe-name: onSaveDone reports failure", rc == 0);
+        SXCHECK("unsafe-name: sibling save 'squad1' survives",
+                readFile(s1 + "\\quick.save") == "SQUAD1-DATA");
+        SXCHECK("unsafe-name: sibling save 'current' survives",
+                readFile(cu + "\\quick.save") == "CURRENT-DATA");
+        rmTree(s1); rmTree(cu);
+    }
+
+    // --- D. a VALID transfer still commits (the fix must not break the happy path)
+    {
+        std::string cr = savexfer::saveFolderFor("coopresume");
+        rmTree(cr);
+        writeFile(cr + "\\quick.save", "OLD-JOIN-SAVE");
+        std::vector<File> f;
+        f.push_back(File("quick.save", "NEW-HOST-SAVE"));
+        f.push_back(File("platoon\\a.platoon", "PLATOON-A"));
+        int rc = deliver("coopresume", f, /*badCrc*/false, /*zeroFiles*/false);
+        SXCHECK("valid-xfer: onSaveDone commits", rc == 1);
+        SXCHECK("valid-xfer: host content is now on disk",
+                readFile(cr + "\\quick.save") == "NEW-HOST-SAVE");
+        SXCHECK("valid-xfer: nested host file committed",
+                readFile(cr + "\\platoon\\a.platoon") == "PLATOON-A");
+        SXCHECK("valid-xfer: staging cleaned up",
+                !dirExists(savexfer::saveFolderFor("coopresume__incoming")));
+        SXCHECK("valid-xfer: no __old orphan after commit",
+                !dirExists(savexfer::saveFolderFor("coopresume__old")));
+        rmTree(cr);
+    }
+
+    // --- E. crash recovery: a save stranded in __old is restored --------------
+    // (simulates a commit that died AFTER moving the real save out but BEFORE
+    //  moving the verified staging in - the "join lost its save" crash window.)
+    {
+        std::string cr  = savexfer::saveFolderFor("coopresume");
+        std::string old = savexfer::saveFolderFor("coopresume__old");
+        rmTree(cr); rmTree(old);
+        writeFile(old + "\\quick.save", "STRANDED-REAL-SAVE"); // only __old exists
+        savexfer::recoverStrandedSave("coopresume");
+        SXCHECK("recover: stranded save restored to save/<name>",
+                readFile(cr + "\\quick.save") == "STRANDED-REAL-SAVE");
+        SXCHECK("recover: __old cleaned after restore",
+                !dirExists(old));
+        // Redundant-__old case: both exist -> __old reclaimed, real save kept.
+        writeFile(cr + "\\quick.save", "COMMITTED-SAVE");
+        writeFile(old + "\\quick.save", "REDUNDANT-BACKUP");
+        savexfer::recoverStrandedSave("coopresume");
+        SXCHECK("recover: committed save kept when both exist",
+                readFile(cr + "\\quick.save") == "COMMITTED-SAVE");
+        SXCHECK("recover: redundant __old reclaimed",
+                !dirExists(old));
+        rmTree(cr); rmTree(old);
+    }
+
+    // Clean the throwaway tree.
+    rmTree(root);
+    (void)saveRoot;
+}


### PR DESCRIPTION
### What this fixes

The coordinated save-transfer feature (protocol 31, `SaveXfer.cpp`) authorized committing a received save purely by file-count match (`d.fileCount == g_recvFileCount`). A degenerate transfer (0 files received, e.g. a desync or truncated send) still satisfied that check when both counts were 0 — so `onSaveDone` went ahead and committed anyway: moved the join's real save to `<name>__old`, moved the (empty) staging folder over `<name>`, then deleted the `__old` backup. Net result: the join's real save destroyed, replaced by nothing. This is the exact mechanism behind a real data-loss incident we hit ourselves mid-testing (a shared test save went from a real save to an empty folder after a run).

Two other paths into the same class of bug, closed by the same fix: an unsafe/empty save name resolving to the saves root (a commit could in principle move the entire save directory), and a crash between the move-out and move-in steps leaving a save stranded under `__old` with nothing at `<name>` (invisible to the game, but recoverable).

### How

Nothing outside the private `<name>__incoming` staging folder is ever touched except with data that's already been verified. Three additions in `SaveXfer.cpp`/`.h`:

- `saveNameSafe()`: rejects empty names, path separators, `:`, `..` — the commit target can never resolve to the saves root.
- Hardened `onSaveDone` gate: requires non-empty staging (`fileCount>0`), every expected file actually received, verified CRCs, a present CRC table, and a safe name — all before committing. Any failure just discards the staging folder; the existing save is untouched.
- `recoverStrandedSave()`: on `onSaveBegin`, self-heals a save left stranded under `<name>__old` by a commit interrupted mid-swap (or reclaims a redundant leftover `__old`).

### Testing

- Unit (`savexfer_test.cpp`, new): 25 checks against the real filesystem code path — CRC mismatch (save byte-intact), degenerate 0-file transfer, unsafe/empty name, valid happy-path commit, crash-recovery. Written red-first: reverting the fix fails exactly the 2 checks that assert the join's save survives an empty transfer, restoring passes. Full prototest: 446/446.
- Live, 2-client real session: forced the coordinated transfer end-to-end (2-tab squad save), confirmed byte-identical commit (`SAVE-SYNC PASS - sent=47/4337055 committed=47/4337055`, `badCrc=0`), no `__incoming`/`__old` orphans left behind, unrelated saves on the join untouched.

### What was NOT tested

Forcing an actual `badCrc` over the live network wasn't reproducible with this harness (it doesn't inject real transport corruption) — the deletion path itself is exercised with real file operations in the unit tests (same code that runs in-game), not with a genuinely corrupted live transfer. Also out of scope for this fix: a transfer killed mid-flight without the process exiting cleanly can still leave the join stuck mid-transfer on the next launch (separate from the deletion bug fixed here) — noted, not fixed, in case you want to track it separately.