### PR TITLE
Fix on-stop foot-slide: time-align interpolation locomotion to the render-delayed position

### DIFF
--- a/src/plugin/sync/Interp.cpp
+++ b/src/plugin/sync/Interp.cpp
@@ -36,6 +36,13 @@ const EntityInterp::Snap& EntityInterp::at(int i) const {
     return ring_[idx];
 }
 
+void EntityInterp::copyLoco(EntityState* out, const Snap& s) {
+    // Dumps the time-aligned locomotion from snapshot 's' onto 'out'.
+    out->cSpeed  = s.cSpeed;
+    out->cMotionX = s.cMotionX; out->cMotionY = s.cMotionY; out->cMotionZ = s.cMotionZ;
+    out->cMoving = s.cMoving;
+}
+
 void EntityInterp::push(const EntityState& e, unsigned long nowMs, unsigned long arrivalMs) {
     // Wire v35 (send-stamped snapshots): a re-sent capture carries the SAME
     // stamp and a reordered datagram an OLDER one - recording either would
@@ -84,6 +91,12 @@ void EntityInterp::push(const EntityState& e, unsigned long nowMs, unsigned long
     Snap s;
     s.t = nowMs;
     s.x = e.x; s.y = e.y; s.z = e.z; s.heading = e.heading;
+    // Time-stamp the locomotion alongside the transform (see Snap in Interp.h):
+    // this lets sample() return the motion state of the snapshot that matches the
+    // render-delay position, instead of the newest one (the foot-slide fix).
+    s.cSpeed  = e.cSpeed;
+    s.cMotionX = e.cMotionX; s.cMotionY = e.cMotionY; s.cMotionZ = e.cMotionZ;
+    s.cMoving = e.cMoving;
     ring_[head_] = s;
     head_ = (head_ + 1) % CAP;
     if (count_ < CAP) ++count_;
@@ -162,6 +175,7 @@ bool EntityInterp::sample(unsigned long nowMs, const InterpConfig& cfg, EntitySt
     if (count_ == 1) {
         out->x = newest.x; out->y = newest.y; out->z = newest.z;
         out->heading = newest.heading;
+        copyLoco(out, newest);
         lastMode_ = SM_SINGLE;
         return true;
     }
@@ -172,6 +186,7 @@ bool EntityInterp::sample(unsigned long nowMs, const InterpConfig& cfg, EntitySt
     if (renderTime <= oldest.t) {
         out->x = oldest.x; out->y = oldest.y; out->z = oldest.z;
         out->heading = oldest.heading;
+        copyLoco(out, oldest); // oldest position -> its own motion state
         lastMode_ = SM_CLAMP_OLD;
         return true;
     }
@@ -195,6 +210,7 @@ bool EntityInterp::sample(unsigned long nowMs, const InterpConfig& cfg, EntitySt
         if (seg <= 0.0f || (sdx * sdx + sdy * sdy + sdz * sdz) > cfg.snapDistSq) {
             out->x = newest.x; out->y = newest.y; out->z = newest.z;
             out->heading = newest.heading;
+            copyLoco(out, newest);
             return true;
         }
         float k = (float)ahead / seg; // extrapolation factor along last segment
@@ -202,6 +218,9 @@ bool EntityInterp::sample(unsigned long nowMs, const InterpConfig& cfg, EntitySt
         out->y = newest.y + sdy * k;
         out->z = newest.z + sdz * k;
         out->heading = lerpAngle(prev.heading, newest.heading, 1.0f + k);
+        // Extrapolating over the newest segment: the newest snapshot's motion
+        // state is the one that matches this projected position.
+        copyLoco(out, newest);
         return true;
     }
 
@@ -216,6 +235,7 @@ bool EntityInterp::sample(unsigned long nowMs, const InterpConfig& cfg, EntitySt
             if (dx * dx + dy * dy + dz * dz > cfg.snapDistSq) {
                 out->x = s1.x; out->y = s1.y; out->z = s1.z;
                 out->heading = s1.heading;
+                copyLoco(out, s1); // snap to the newer end -> its motion state
                 lastMode_ = SM_SEG_SNAP;
                 return true;
             }
@@ -225,6 +245,17 @@ bool EntityInterp::sample(unsigned long nowMs, const InterpConfig& cfg, EntitySt
             out->y = lerpf(s0.y, s1.y, a);
             out->z = lerpf(s0.z, s1.z, a);
             out->heading = lerpAngle(s0.heading, s1.heading, a);
+            // Time-aligned locomotion: continuous speed/motion interpolate within
+            // the segment; the moving FLAG follows the segment's START, so a body
+            // still crossing the last segment before stopping reads "moving"
+            // (matching its still-gliding position) and only flips to idle once
+            // render time crosses into the already-stopped segment. This is the
+            // time alignment that removes foot-slide on stopping.
+            out->cSpeed  = lerpf(s0.cSpeed,  s1.cSpeed,  a);
+            out->cMotionX = lerpf(s0.cMotionX, s1.cMotionX, a);
+            out->cMotionY = lerpf(s0.cMotionY, s1.cMotionY, a);
+            out->cMotionZ = lerpf(s0.cMotionZ, s1.cMotionZ, a);
+            out->cMoving = s0.cMoving;
             lastMode_ = SM_LERP;
             return true;
         }
@@ -233,6 +264,7 @@ bool EntityInterp::sample(unsigned long nowMs, const InterpConfig& cfg, EntitySt
     // Fallback (shouldn't hit): newest pose.
     out->x = newest.x; out->y = newest.y; out->z = newest.z;
     out->heading = newest.heading;
+    copyLoco(out, newest);
     lastMode_ = SM_LERP;
     return true;
 }

--- a/src/plugin/sync/Interp.cpp
+++ b/src/plugin/sync/Interp.cpp
@@ -251,6 +251,14 @@ bool EntityInterp::sample(unsigned long nowMs, const InterpConfig& cfg, EntitySt
             // (matching its still-gliding position) and only flips to idle once
             // render time crosses into the already-stopped segment. This is the
             // time alignment that removes foot-slide on stopping.
+            // Trade-off (start of motion, symmetric): a body that BEGINS moving
+            // mid-segment (s0.cMoving=0, s1.cMoving=1) reads idle for that whole
+            // segment even as its position starts translating - a one-segment
+            // idle-slide mirroring the stop-slide this fixes. Accepted because the
+            // consumer (ReplicatorDrive.cpp:242) gates on cMoving!=0 || cSpeed>
+            // MOVE_EPS, and cSpeed interpolates up from 0 here, so the start case
+            // still animates 'moving' almost immediately. Do NOT 'fix' the start by
+            // interpolating the flag or ORing s1's - that reintroduces stop-slide.
             out->cSpeed  = lerpf(s0.cSpeed,  s1.cSpeed,  a);
             out->cMotionX = lerpf(s0.cMotionX, s1.cMotionX, a);
             out->cMotionY = lerpf(s0.cMotionY, s1.cMotionY, a);

--- a/src/plugin/sync/Interp.h
+++ b/src/plugin/sync/Interp.h
@@ -93,12 +93,25 @@ private:
     struct Snap {
         unsigned long t;
         float x, y, z, heading;
+        // Locomotion captured at the SAME instant as this transform. sample()
+        // renders the body in the PAST (render delay), so the motion state that
+        // matches the render POSITION is THIS snapshot's, NOT the newest one's.
+        // Copying the newest cMoving/cSpeed onto a delayed position is the
+        // "foot-slide" bug: on stopping, the newest already says cMoving=0 while
+        // the delayed position is still gliding toward the stop point, so the
+        // engine plays idle on a body that's still translating.
+        float         cSpeed, cMotionX, cMotionY, cMotionZ;
+        unsigned char cMoving;
     };
 
     static const int CAP = 16;
 
     const Snap& at(int i) const;     // i in [0, count_): 0 = oldest
     unsigned long renderDelay(const InterpConfig& cfg) const;
+    // Writes the time-aligned locomotion (cSpeed/cMotion/cMoving) from snapshot 's'
+    // into 'out', so the returned motion state matches the render position (not
+    // the newest snapshot's).
+    static void copyLoco(EntityState* out, const Snap& s);
 
     Snap          ring_[CAP];
     int           count_;

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -574,6 +574,16 @@ static EntityState entAt(float x) {
     return e;
 }
 
+// Same base body, but with an explicit locomotion state (the fields the
+// foot-slide fix time-aligns): moving flag, speed, and world-space motion.
+static EntityState entLoco(float x, unsigned char moving, float speed) {
+    EntityState e = entAt(x);
+    e.cMoving = moving;
+    e.cSpeed  = speed;
+    e.cMotionX = speed; e.cMotionY = 0.0f; e.cMotionZ = 0.0f;
+    return e;
+}
+
 static void testInterp() {
     std::printf("== interpolation buffer (Interp.cpp) ==\n");
     InterpConfig cfg; // min 50 / max 200 delay, extrap 250, snap 50u, stale 2000
@@ -670,6 +680,39 @@ static void testInterp() {
         EntityState out;
         bool ok = it.sample(1030, cfg, &out);
         CHECK("identity+state passthrough", ok && out.bodyState == BODY_DOWN && out.cMoving == 1 && out.task == 42 && out.hIndex == 1);
+    }
+
+    // Time-aligned locomotion (foot-slide fix, commit 0191d73): the moving FLAG
+    // and speed sample() returns must match the RENDER-DELAY position, not the
+    // newest snapshot. Feed a body walking x=0->3 over 1000..1150ms that is
+    // STOPPED at the newest snapshot. With a one-interval (50ms) render delay the
+    // buffer is still gliding through the last MOVING segment while the newest
+    // snapshot already reads idle - the exact on-stop foot-slide case. Loco must
+    // come from the segment START (still moving), not the newest (already idle).
+    // These CHECKs go RED if commit 0191d73 is reverted (loco falls back to the
+    // newest snapshot): mid.cMoving reads 0 and mid.cSpeed reads 0.
+    {
+        EntityInterp it;
+        it.push(entLoco(0.0f, 1, 10.0f), 1000); // moving
+        it.push(entLoco(1.0f, 1, 10.0f), 1050); // moving
+        it.push(entLoco(2.0f, 1, 10.0f), 1100); // moving: START of the stopping segment
+        it.push(entLoco(3.0f, 0,  0.0f), 1150); // STOPPED (newest): flag idle, speed 0
+
+        // nowMs=1175 -> renderTime=1125: mid of the [1100,1150] segment. Position
+        // still gliding (x~2.5); read s0 (moving,10) lerped toward s1 (idle,0).
+        EntityState mid;
+        bool okMid = it.sample(1175, cfg, &mid);
+        CHECK("stopping LERP still reads moving", okMid && mid.cMoving == 1);
+        CHECK("stopping LERP speed interpolated (not the stopped newest)",
+              okMid && mid.cSpeed > 4.9f && mid.cSpeed < 5.1f);
+        CHECK("stopping LERP position still gliding", okMid && mid.x > 2.4f && mid.x < 2.6f);
+
+        // nowMs=1225 -> renderTime=1175 >= newest.t: render has crossed onto the
+        // already-stopped newest, so the flag now correctly reads idle.
+        EntityState done;
+        bool okDone = it.sample(1225, cfg, &done);
+        CHECK("crossed onto stopped newest reads idle", okDone && done.cMoving == 0);
+        CHECK("crossed onto stopped newest speed zero", okDone && done.cSpeed < 0.1f);
     }
 }
 


### PR DESCRIPTION
Credit where it's due: this is inspired by a fix in a public fork (CTRL-ALT-E/KENSHI-CO-OP) — most of what's in that fork is already superseded by your own work, but this one specific issue was still present.

Rebased on top of your `98e48ba` modularization, which includes your own teleport-guard fix in the same function (`sample()`'s EXTRAP branch). The two fixes are complementary — yours guards against extrapolating past a teleport, mine fixes which snapshot's locomotion gets reported — and now coexist in the same branch (verified by reading the merged code, not just trusting the auto-merge).

### What this fixes

`sample()` renders a body at a delayed position (render delay), but copies the locomotion (cSpeed/cMotion/cMoving) from the NEWEST snapshot rather than the one matching the render position. On stopping, the newest snapshot already says `cMoving=0` while the delayed render position is still gliding toward the stop point — the engine plays an idle pose on a body that's still visibly translating (foot-slide).

### How

Time-stamp locomotion alongside each transform in the interpolation ring (`Interp.h`/`Interp.cpp`), and return the locomotion that matches the render position instead of always the newest: clamp-old and single-sample paths use their own snapshot's locomotion, extrapolation and segment-snap use the newer end's (already time-coincident with the projected/snapped position — including your teleport-guard's held pose), and the LERP path interpolates speed/motion continuously within the segment while the moving flag follows the segment start.

### Testing

- Built with the real toolchain (VS2010 v100 x64), 0 errors.
- Unit: prototest 426/426, including discriminant checks for both fixes coexisting in the EXTRAP branch (your teleport guard holding on overshoot, and locomotion still coming from the correct snapshot in that same branch).

### What was NOT tested

No live repro of the visual foot-slide itself (would need a stop/start scenario in a real session) — this is a logic-level fix to the interpolation buffer's data model, and the interpolation unit tests exercise every return path, but I don't have visual confirmation from an actual play session.