### PR TITLE
Add bounty/crime sync (protocol 45, host-authoritative): joining player's bounties now actually cross to the host

### DIFF
--- a/resources/spikes/59-bounty-crime-probe.md
+++ b/resources/spikes/59-bounty-crime-probe.md
@@ -1,0 +1,112 @@
+# Spike 59 - Bounty/crime probe (first direct read of the bounty system)
+
+- Type: STATIC (headers) + code (RUN recipe)
+- Status: READY (code landed, not yet run)
+- Save: any with a wanted PC (a fresh crime works); clean saves stay quiet
+- Branch commit: <filled at commit>
+
+## Goal
+
+Give the bounty/crime "remaining edge" of gap 3 its first DIRECT observation
+channel. `SYNC_GAPS.md` currently records it as accepted with only indirect
+evidence:
+
+> bounties / crime state are a separate engine system (the `[fac] AFFECT`
+> detour keeps accumulating cause evidence)
+
+The `[fac] AFFECT` detour sees relation *consequences* of crimes, never the
+bounty state itself - there is no read lever anywhere in the plugin for what a
+client believes a character's bounty/crime state IS. Before any sync design
+(or even a decision that none is needed), we need the same thing every other
+gap got first: a per-body, per-client, read-only census of the real engine
+state, so a two-client run can show whether and how the two sides fork.
+
+## Method
+
+Read-only diagnostic, gated OFF by default - the jail/shackle probe contract
+(observe, log, measure, change nothing):
+
+- `KENSHICOOP_BOUNTY_PROBE=1` -> `[bounty]` observer in
+  [EngineCharState.cpp](../../src/plugin/game/EngineCharState.cpp)
+  (`bountyProbeTick`, called from the Plugin.cpp tick right after
+  `shackleDbgTick`). ~1 Hz over the local player squad + nearby world NPCs
+  (`listNpcs`; the sets are disjoint).
+
+### The read lever (why this is now possible)
+
+`Character::crimes` is an **inline `BountyManager` at `Character+0xF0`**
+(KenshiLib PDB layout - `kenshi/Character.h`: `BountyManager crimes; // 0xF0`;
+the offset was independently re-verified against an external RE offset map of
+the same PDB, not derived from any scanning in this repo). The struct we can
+read directly (`kenshi/BountyManager.h`):
+
+- `bounties` (+0x00) - `ogre_unordered_map<Faction*, Bounty>`: the actual
+  per-faction bounty table (`Bounty` = amount in cats + CrimeEnum bitmask +
+  claimed-once flag).
+- `me` (+0x40) - back-pointer to the owning Character. **Used as the probe's
+  validity sentinel**: `me != c` means the layout does not hold for this build,
+  one `SENTINEL-MISMATCH` tripwire line is logged and nothing is parsed.
+- `committingCrime` (+0x58), `crimeAgainstFaction` (+0x60), `crimeExpiry`
+  (+0x90), `prisonSentenceToServe` (+0xA0),
+  `_hadABountyAssignedForCurrentCrime` (+0xA4) - the live in-progress-crime
+  state machine.
+
+Field reads only - no engine function is called (the header also names the
+levers a future sync could use: `getActualBounty`, `assignBountyForCrimes`,
+`clearBounty`, `setCrime`, `notifyCrimeWitnessed`). The inline-member size is
+already load-bearing in this codebase: `isChained` (0x320) and `slaveOwner`
+(0x328) sit AFTER `crimes` and read correctly everywhere, so the 0xF0 layout
+is transitively exercised by every existing furniture/shackle read.
+
+### Log surface
+
+- `[bounty] STATE host= hand= crime= vs= expiry= sentence= had= rows=` - one
+  line per body with live state (committing a crime OR at least one bounty
+  row); quiet bodies are skipped so a clean save logs nothing.
+- `[bounty] ROW host= hand= fac=<sid> amount= crimes=0x.. claimed=` - one line
+  per per-faction bounty entry. Factions are keyed by GameData stringID
+  (`facSidOf`), which the faction probe already showed is cross-client stable -
+  so ROW lines from host.log and join.log diff directly.
+- `[bounty] SCAN host= n= valid= active=` - 10 s heartbeat; `valid == n` is
+  the layout-health signal even on a fully quiet run.
+- `[bounty] SENTINEL-MISMATCH ...` - once per session, the tripwire.
+
+All per-body reads are SEH-guarded; the bounties-map walk lives in an
+unguarded shim under the caller's SEH frame (the C2712 `factionBySidC`
+pattern).
+
+## Reproduce
+
+Manual two-client session (partitioned or not), both sides with the env set:
+
+```
+set KENSHICOOP_BOUNTY_PROBE=1
+```
+
+then commit a witnessed crime with one client's PC (steal in a shop, assault
+a guard), get caught / pay it off / serve a sentence, and diff the `[bounty]`
+timelines of host.log vs join.log per hand + faction sid.
+
+## What the run should answer
+
+1. **Do bounty rows fork cross-client?** (Expected: yes - everything about the
+   system is local; the only cross-client coupling seen so far is the relation
+   side effect via `[fac] AFFECT`.) The STATE/ROW diff per (hand, faction sid)
+   is the direct evidence either way.
+2. **Which fields move, and when**: does `committingCrime` pulse and clear, is
+   `crimeExpiry` wall-clock or game-clock, does `_hadABountyAssignedForCurrentCrime`
+   gate re-assignment - the change timeline tells us which of the fields a
+   minimal sync would even need to carry.
+3. **Whose bounty state matters**: PC-only, or do captured world NPCs carry
+   rows the peer's copy lacks (bounty-hunting gameplay: the join sells a
+   target the host's engine thinks is clean)?
+4. **Sentinel health across builds** (GOG vs Steam parity ran clean for every
+   other Character offset; `valid == n` in SCAN confirms it for +0xF0).
+
+## Non-goals
+
+No sync design is implied yet. If the run shows rows forking (expected), the
+candidate scope - owner-authoritative `Bounty` rows keyed by (owner hand,
+faction sid), applied via `setCrime`/`clearBounty` or direct row writes - is a
+protocol-24-shaped follow-up, but that decision belongs after the evidence,
+not before. The probe itself ships knob-gated OFF and changes no behavior.

--- a/resources/spikes/60-bounty-crime-sync-design.md
+++ b/resources/spikes/60-bounty-crime-sync-design.md
@@ -1,7 +1,10 @@
 # Spike 60 - Bounty/crime sync: authority model & channel design
 
 - Type: DESIGN (no runtime behavior; specifies the follow-up channel)
-- Status: DESIGN READY - blocked on the spike-59 live run before implementation
+- Status: AUTHORITY SETTLED - **H2 witness-local CONFIRMED** by the 2026-07-20
+  live run (two runs: host-owned Flashbox, then join-owned PC). Channel shape is
+  now fixed to the H2 reconciliation (host-authoritative row, published to the
+  owner); ready to implement.
 - Depends on: spike 59 (`59-bounty-crime-probe.md`, the read-only observer)
 - Precedent: protocol 24 (faction relations, `PKT_FACTION`) - the closest
   working detour+sample+apply channel; this design is that pattern re-keyed
@@ -98,7 +101,49 @@ host.log vs join.log for the SAME PC hand while that PC commits a witnessed
 crime, and watch which side's rows move first and whether `committingCrime`
 pulses on the owner or the witness. **Read the run before choosing H1 vs H2.**
 
-## Recommended channel (assuming H1; fall back to H2's reconciliation if the run shows the split)
+## LIVE RUN RESULT (2026-07-20) - H2 witness-local CONFIRMED
+
+Two live host+join sessions, `KENSHICOOP_BOUNTY_PROBE=1` on both clients.
+
+**Run A (control, host-owned Flashbox).** A HOST-owned PC committed the crime.
+Bounty row appeared on the host. Non-discriminating by construction: owner =
+witness = host, so it cannot separate H1 from H2 (documented in spike 59).
+
+**Run B (the discriminator, JOIN-owned PC).** The other PC - hand
+`1,3332275456`, **confirmed JOIN-owned**: the JOIN emits its `[stats] SEND`
+(`[13:28:40.872] [JOIN] [stats] SEND hand=1,3332275456 ...`) while the HOST
+never sends stats for it (host only sends `1,2637329152` and `2,3587646464`).
+This PC committed the on-screen crime ("Cometiendo un Crimen (20)", 0x20). The
+`[bounty]` timelines for that exact hand:
+
+- **HOST** (`E:\SteamLibrary\steamapps\common\Kenshi\KenshiCoop_host.log`) - the
+  row EXISTS and persists, from first sight to end of capture:
+  - `[13:27:58.894] [HOST] [bounty] STATE host=1 hand=1,3332275456 crime=5 vs=11624-Dialogue (10).mod expiry=20.0 had=1 rows=1/1`
+  - `[13:29:40.894] [HOST] [bounty] ROW host=1 hand=1,3332275456 fac=11624-Dialogue (10).mod amount=500 crimes=0x20 claimed=0`
+  - crime state field is `crime=5` on every one of the 186 host samples for this hand.
+- **JOIN** (`C:\Users\Zero\Kenshi-Join\KenshiCoop_join.log`) - the OWNER stays
+  completely clean for the whole >3.5 min the crime is active:
+  - `[13:31:56.428] [JOIN] [bounty] STATE host=0 hand=1,3332275456 crime=3 vs=11624-Dialogue (10).mod expiry=20.0 had=0 rows=0/0`
+  - `had=0 rows=0/0` on every one of the 185 join samples for this hand; **zero
+    `[bounty] ROW` lines were ever emitted on the join for `1,3332275456`.**
+  - crime state field is `crime=3` on every join sample (the transient FSM also
+    forks: host sees `crime=5`, owner sees `crime=3`).
+
+**Verdict: H2.** The durable bounty row materialises SOLELY on the HOST's driven
+copy of a JOIN-owned character and never on the owner. Ownership does not move
+the row; the witness/guard simulation - which is host-side in this coop world -
+does. This is the same host-only outcome as the host-owned Flashbox run, but now
+with the owner on the OTHER side, which is exactly the discrimination Run A could
+not provide.
+
+*Red herring ruled out:* the join log also shows a durable row for hand
+`1,169067376` (`fac=defaultEmpireFactionSID amount=2910 crimes=0x0 crime=0`).
+That is NOT a counter-example to H2: it is a purely join-local NPC - the HOST log
+has **no record of that hand at all** and neither client emits `[stats] SEND`
+for it, so it is an ambient NPC in the join's local world, not a player-owned PC
+and not evidence of any owner-side crime->assign pipeline.
+
+## Recommended channel - H2 reconciliation (confirmed; the H1 owner-authoritative variant is NOT applicable)
 
 Re-key the protocol-24 pattern from per-player-faction to
 **per-(owner-character, faction)**.
@@ -128,12 +173,26 @@ cross-client stable); character by hand (index,serial), the key every other
 per-character channel uses. Both are already resolvable in `Engine.h`
 (`facSidOf`, `resolveCharByHand`, `readObjectHand`).
 
-### Publish (owner side) - mirror `Replicator::publishFactions`
+### Publish - HOST-authoritative, NOT owner-authoritative (settled by the H2 run)
 
-- New `Replicator::publishBounties(gw, net, ownerId)`, gated by a
-  `bountySync_` flag, called from the same tick site as `publishFactions`.
-- Subjects: the local player squad (`gw->player->playerCharacters`) - the
-  owner's own PCs only, exactly the probe's first subject set.
+**Direct answer to the design question:** `publishBounties` must be
+**host/witness-authoritative**, the OPPOSITE of the faction channel. Factions
+are owner-authoritative because the owning client's engine produces the relation
+delta; bounty is not - the H2 run proved the owner's engine never produces the
+bounty row at all (join stayed `had=0 rows=0/0` while its own PC was wanted). The
+HOST is the only engine that runs witness->`assignBountyForCrimes`, so the HOST
+must be the source of the row and publish it DOWN to the owning client (and any
+client that must display/enforce it). The channel is therefore host->clients,
+keyed per-character - reconciliation, not the one-directional protocol-24 mirror.
+
+- New `Replicator::publishBounties(gw, net)`, gated by a `bountySync_` flag,
+  called from the same tick site as `publishFactions`, but running **on the
+  host**.
+- Subjects: every character whose host-side `BountyManager` holds a row - i.e.
+  the host's driven copies of remote-owned PCs (this is where join-owned PCs'
+  bounties live) PLUS host-owned PCs. The per-character `ownerId`/hand in the
+  packet tells the receiver which of its characters the row belongs to; the
+  owning client applies it to its own (currently-clean) copy.
 - Sample ~1 Hz, plus an immediate sample when a **detour** flags a real
   mutation this tick (see below). Diff each (char hand, faction sid) row's
   `{amount, crimes, claimed}` against a silently-seeded baseline (both clients

--- a/resources/spikes/60-bounty-crime-sync-design.md
+++ b/resources/spikes/60-bounty-crime-sync-design.md
@@ -1,0 +1,196 @@
+# Spike 60 - Bounty/crime sync: authority model & channel design
+
+- Type: DESIGN (no runtime behavior; specifies the follow-up channel)
+- Status: DESIGN READY - blocked on the spike-59 live run before implementation
+- Depends on: spike 59 (`59-bounty-crime-probe.md`, the read-only observer)
+- Precedent: protocol 24 (faction relations, `PKT_FACTION`) - the closest
+  working detour+sample+apply channel; this design is that pattern re-keyed
+  per-character.
+
+## Where this stands (evidence in hand, 2026-07-20)
+
+1. **Zero bounty/crime coverage in the wire protocol.** `PacketType` in
+   `src/netproto/Wire.h` has 41 packet types (`PKT_HELLO`..`PKT_CAM_HINT`) and
+   `EventType` has 8 (`EVT_NONE`..`EVT_DROP_BODY`); none touch crime or bounty.
+   The only cross-client coupling that even brushes the system is the RELATION
+   side effect the `[fac] AFFECT` detour records - it sees relation
+   *consequences* of crimes, never the bounty/crime state itself. Bounty is a
+   whole feature with no sync path, not a partially-synced one.
+
+2. **The read lever is real and now compiles.** `Character::crimes` is an
+   inline `BountyManager` at `Character+0xF0`, confirmed directly against the
+   KenshiLib PDB headers vendored in this repo:
+   - `third_party/KenshiLib_deps/KenshiLib/Include/kenshi/Character.h:242`
+     -> `BountyManager crimes; // 0xF0 Member`
+   - `.../kenshi/BountyManager.h` -> `bounties` (0x00,
+     `ogre_unordered_map<Faction*, Bounty>`), `me` (0x40), `committingCrime`
+     (0x58), `crimeAgainstFaction` (0x60), `crimeAgainst` hand (0x70),
+     `crimeExpiry` (0x90), `prisonSentenceToServe` (0xA0),
+     `_hadABountyAssignedForCurrentCrime` (0xA4).
+   - `.../kenshi/Bounty.h` -> `Bounty{ int amount (0x0); unsigned int crimes
+     (0x4, CrimeEnum bitmask); bool bountyHasBeenClaimedOnce (0x8) }` and the
+     16-value `CrimeEnum` (CRIME_NONE..CRIME_UNIFORM_THEFT).
+
+   The spike-59 probe (`bountyProbeTick`, `KENSHICOOP_BOUNTY_PROBE=1`) that
+   reads all of the above **was dropped from the 2026-07-19 PR batch for fear
+   it would not compile. It compiles.** Built clean on this branch with the
+   real v100 toolchain (`scripts/build_plugin.cmd` -> `KenshiCoop.dll`, only the
+   pre-existing KenshiLib header warnings). It is now landed here and ready to
+   run.
+
+3. **The write levers exist** (`BountyManager.h`, all with RVAs in the PDB):
+   `setCrime(CrimeEnum, Faction* against, const hand&)`,
+   `notifyCrimeWitnessed(Faction*, const hand&, int expiry, CrimeEnum)`,
+   `assignBountyForCrimes(Faction* enforcer)`, `unfairAddToBounty(Faction*, int
+   amount)`, `clearBounty(Faction* enforcer)`, `getActualBounty(Faction*)`,
+   `getTotalBounty()`.
+
+## Why the design is written but NOT yet implemented
+
+The spike-59 probe has **not been run live** yet (a live run needs a two-client
+manual session with a player committing a witnessed crime - a human at the
+keyboard on both clients, not something the plugin can self-drive). The spike
+itself makes the sync decision contingent on that run: *"No sync design is
+implied yet ... that decision belongs after the evidence, not before."*
+
+The divergence question is effectively pre-answered - there is no sync path, so
+per-client bounty state **must** fork the moment one client commits a crime the
+other's engine does not independently simulate. What the live run actually
+decides is the **authority split** (see the open question below), and that
+split changes which of the two channel shapes below we build. Committing an
+engine-WRITE channel (calling `assignBountyForCrimes` / `unfairAddToBounty` /
+`clearBounty` / `setCrime` on a peer's driven copy) that has never run in a live
+session would be exactly the "forzar algo a medias o mal probado" this work was
+told to avoid, and the faction channel it copies needed real sessions to settle
+its echo/reciprocal guards. So: probe + design land now; the write channel lands
+after the run confirms the authority split.
+
+## The authority question the live run must settle
+
+Bounty state has two halves on each `BountyManager`:
+
+- **Durable bounty rows** - `bounties[faction] = {amount, crimes, claimed}`:
+  the accumulated wanted level per faction. This is the state gameplay cares
+  about (guards aggro, bounty-hunter payouts, gate access).
+- **Transient crime state machine** - `committingCrime`, `crimeAgainstFaction`,
+  `crimeAgainst`, `crimeExpiry`, `prisonSentenceToServe`,
+  `_hadABountyAssignedForCurrentCrime`: the "currently doing a crime / serving
+  time" scratch state that resolves INTO a durable row.
+
+A crime is committed by character A (owned by one client) but WITNESSED by an
+NPC guard. In this coop model world NPCs are host-simulated. So the open
+question is **which engine runs the witness->assign pipeline**:
+
+- **(H1) Owner-local assignment.** The owning client's engine runs the full
+  crime -> witness -> `assignBountyForCrimes` pipeline on its own PC, so the
+  bounty row appears on the OWNER's copy first. -> clean **owner-authoritative**
+  sync: owner broadcasts its rows, peer applies to the driven copy. One
+  direction, protocol-24 shaped.
+- **(H2) Witness-local assignment.** Only the host's guard simulation fires
+  `notifyCrimeWitnessed` on the host's DRIVEN copy of a join-owned PC, so the
+  bounty appears on the HOST first and the join's own PC stays clean. -> a
+  **split** needing bidirectional reconciliation (the host must publish
+  "bounty my witness assigned to your character" back to the owner), closer to
+  the money-pool reconciliation than to protocol 24.
+
+The spike-59 `[bounty] STATE`/`ROW` timeline answers this directly: diff
+host.log vs join.log for the SAME PC hand while that PC commits a witnessed
+crime, and watch which side's rows move first and whether `committingCrime`
+pulses on the owner or the witness. **Read the run before choosing H1 vs H2.**
+
+## Recommended channel (assuming H1; fall back to H2's reconciliation if the run shows the split)
+
+Re-key the protocol-24 pattern from per-player-faction to
+**per-(owner-character, faction)**.
+
+### Wire (protocol bump 43 -> 44, new `PKT_BOUNTY`)
+
+```c
+struct BountyPacket {
+    u8  type;        // = PKT_BOUNTY
+    u32 ownerId;     // network player id of the sender (the character's owner)
+    u32 seq;         // per-sender monotonic (stale-row guard, as PKT_FACTION)
+    u32 hIndex;      // owning character hand (index,serial) - the per-char key
+    u32 hSerial;
+    char sid[48];    // faction GameData stringID ("" never sent) - cross-client
+    int  amount;     // Bounty::amount (cats) for that (char, faction) row
+    u32  crimes;     // Bounty::crimes bitmask (CrimeEnum bits)
+    u8   claimed;    // Bounty::bountyHasBeenClaimedOnce
+    // Optional (decide from the run): u8 committing / f32 sentence if the
+    // prison-sentence state must cross so a captured PC serves time on both
+    // copies. Leave OUT of v1 unless the run shows it forking in a way that
+    // breaks gameplay - transient scratch is local simulation noise otherwise.
+};
+```
+
+Identity: faction by `facSidOf` sid (the faction probe already proved sids are
+cross-client stable); character by hand (index,serial), the key every other
+per-character channel uses. Both are already resolvable in `Engine.h`
+(`facSidOf`, `resolveCharByHand`, `readObjectHand`).
+
+### Publish (owner side) - mirror `Replicator::publishFactions`
+
+- New `Replicator::publishBounties(gw, net, ownerId)`, gated by a
+  `bountySync_` flag, called from the same tick site as `publishFactions`.
+- Subjects: the local player squad (`gw->player->playerCharacters`) - the
+  owner's own PCs only, exactly the probe's first subject set.
+- Sample ~1 Hz, plus an immediate sample when a **detour** flags a real
+  mutation this tick (see below). Diff each (char hand, faction sid) row's
+  `{amount, crimes, claimed}` against a silently-seeded baseline (both clients
+  loaded the same save -> shared baseline; stream only mid-session movement).
+  Monotonic `seq`, `RESEND_MS` safety resend - all as protocol 24.
+
+### Detour (immediacy + cause) - mirror the `affectRelations` detour
+
+`EngineWorld.cpp` already detours both `FactionRelations::affectRelations`
+overloads to log `[fac] AFFECT` and record a `FactionDelta` the Replicator
+drains for same-tick sampling. Do the same on the bounty assignment seam -
+`BountyManager::assignBountyForCrimes` and/or `notifyCrimeWitnessed` (RVAs in
+`BountyManager.h`) - to (a) get the `[bounty] AFFECT` cause line the way
+relations got theirs and (b) push a `BountyDelta` so the changed row crosses
+within a tick instead of up to a sample period later. This detour is also the
+cleanest place to learn H1-vs-H2 empirically if the probe run is ambiguous:
+whichever client's process the detour fires in IS the assigning engine.
+
+### Apply (peer side) - mirror `Replicator::applyFactions`
+
+- New `Replicator::applyBounties(gw, in)`: drain inbound, reject stale by seq,
+  resolve the character by hand and the faction by sid.
+- **Echo guard**: update the local baseline for that (char, faction) row
+  BEFORE writing, so the write's own mutation is not re-detected next sample
+  (the exact bug the faction channel's `fr.known = p.relation` line guards).
+- **Convergence-first**: if the driven copy's row already equals the target
+  (`getActualBounty`), skip (resend/echo). Otherwise write via the engine's own
+  levers, never a raw map poke:
+  - increase: `unfairAddToBounty(fac, target - current)` (additive, keeps
+    derived expiry/GUI consistent) - preferred over reconstructing via
+    `setCrime`+`assignBountyForCrimes`.
+  - clear/decrease to zero: `clearBounty(fac)`.
+  - `crimes` bitmask / `claimed` flag: fold in only if the run shows they
+    matter to gameplay on the peer; `unfairAddToBounty` already moves the
+    amount, which is what guards read.
+- SEH-guard every engine call (the whole plugin's write contract) and log
+  `[bounty] RECV char=.. fac=.. amount=.. was=.. ok=.. seq=..` symmetric to
+  `[fac] RECV`.
+
+### Testability
+
+Extract the pure decision (given last-known row + incoming row -> {skip |
+send} and {skip | write delta}) into a header-testable free function the way
+other channels keep their diff logic side-effect-free, so `build_prototest.cmd`
+can cover the seq/echo/convergence logic without a live engine. The engine
+read/write shims stay in `EngineCharState.cpp` behind SEH.
+
+## Verification plan (the part that needs a live game)
+
+1. Run spike 59 first: `set KENSHICOOP_BOUNTY_PROBE=1` on BOTH clients, commit a
+   witnessed crime with one PC, diff `[bounty]` timelines -> settle H1 vs H2 and
+   the minimal carry-set (which fields actually move).
+2. Implement the channel per the settled authority split.
+3. Live host+join session: one player commits a crime / gets a bounty in front
+   of a guard; verify the OTHER client's copy of that PC shows the same bounty
+   (`[bounty] RECV ok=1`, and in-game guards react to the driven copy). Pay it
+   off / serve the sentence; verify it clears on both.
+4. `build_prototest.cmd` green on the extracted decision logic.
+
+Nothing here is committed as engine-write code until step 3 passes.

--- a/scripts/manual_session.ps1
+++ b/scripts/manual_session.ps1
@@ -43,6 +43,14 @@ param(
     # "join me" hits. Use to validate recruit sync on a populated save that has
     # no dialog-hireable NPC (camp/squad1). 0 = off.
     [int]$AutoRecruit = 0,
+    # Host-only bounty helper (KENSHICOOP_AUTOCRIME=N seconds): N s after gameplay
+    # settles, the host ONCE programmatically assigns a test bounty (500) to the
+    # player-squad member at -AutoCrimeIndex via unfairAddToBounty. In -Inhabit
+    # mode a non-zero index is a JOIN-owned character's driven copy, so this
+    # reproduces the H2 witness-local state and validates protocol-44 sync
+    # deterministically (host publishes, join applies). 0 = off.
+    [int]$AutoCrime = 0,
+    [int]$AutoCrimeIndex = 1,
     # Inhabit mode: both clients load the SAME save (so NPC sync works) but each
     # OWNS a different subset of the shared squad. Default split: host owns the
     # leader (index 0), join inhabits everyone else (~0). Overridable via
@@ -295,6 +303,10 @@ function Set-CoopEnv {
     $env:KENSHICOOP_SETUP        = if ($Mode -eq "join") { "" } else { $SetupScene }
     # Host-only auto-recruit (N s after gameplay): recruit nearest world NPC.
     $env:KENSHICOOP_AUTORECRUIT  = if ($Mode -eq "join") { "" } else { "$AutoRecruit" }
+    # Host-only auto-crime (protocol 44 validation): inject a test bounty on a
+    # driven join-owned PC N s in, so the channel carries it to the owner.
+    $env:KENSHICOOP_AUTOCRIME       = if ($Mode -eq "join") { "" } else { "$AutoCrime" }
+    $env:KENSHICOOP_AUTOCRIME_INDEX = if ($Mode -eq "join") { "" } else { "$AutoCrimeIndex" }
     $env:KENSHICOOP_PROBE_RECRUIT = if ($Mode -eq "join" -and $ProbeRecruit) { "1" } else { "" }
     $env:KENSHICOOP_PROBE_AISUSPEND = if ($Mode -eq "join" -and $ProbeAiSuspend) { "1" } else { "" }
     # Inventory sync is bidirectional, so enable it on BOTH clients.

--- a/scripts/manual_session.ps1
+++ b/scripts/manual_session.ps1
@@ -123,6 +123,13 @@ param(
     # observing side (a diagnostic divergence, NOT a real desync). Do NOT use for
     # parity/visual A-B; use plain -JailProbe for that.
     [switch]$JailObserve,
+    # Bounty/crime probe (spike 59, KENSHICOOP_BOUNTY_PROBE=1 on BOTH clients):
+    # arms the read-only [bounty] observer (STATE/ROW per body with live crime or
+    # bounty state, + 10 s SCAN heartbeat) so a manual session that commits a
+    # witnessed crime captures whether the bounty/crime state forks host<->join
+    # and which fields move. Reads the inline BountyManager at Character+0xF0
+    # (me-sentinel guarded); read-only, zero behavior change, OFF by default.
+    [switch]$BountyProbe,
     # Manual sessions tile the two game windows side-by-side BY DEFAULT (host left,
     # join right; scripts\arrange_windows.ps1, re-pinned through the load screen) on
     # the ULTRAWIDE (widest monitor, 3440x1440): each client window is sized to half
@@ -309,6 +316,10 @@ function Set-CoopEnv {
     $env:KENSHICOOP_JAIL_PROBE   = if ($JailProbe) { "1" } else { "" }
     $env:KENSHICOOP_TASK_SPIKE   = if ($JailProbe) { "1" } else { "" }
     $env:KENSHICOOP_JAIL_OBSERVE = if ($JailObserve) { "1" } else { "" }
+    # Bounty/crime read-only probe on BOTH clients (spike 59, see -BountyProbe):
+    # bounties are a player-facing per-character system, so both squads are read
+    # on both sides - the fork evidence is the host-vs-join ROW diff per hand.
+    $env:KENSHICOOP_BOUNTY_PROBE = if ($BountyProbe) { "1" } else { "" }
     # Per-mode log next to the install so host/join don't clobber each other.
     $env:KENSHICOOP_LOG          = if ($Mode -eq "join") { "KenshiCoop_join.log" } else { "KenshiCoop_host.log" }
 }

--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -24,7 +24,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 44;
+const u16 PROTOCOL_VERSION = 45;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -68,7 +68,8 @@ enum PacketType {
     PKT_NPC_CENSUS       = 38,// RELIABLE wide-radius NPC existence list (protocol 36); NpcCensusHeader
     PKT_INV_XFER         = 39,// RELIABLE cross-owner transfer intent (protocol 37); InvXferPacket
     PKT_RESEARCH         = 40,// RELIABLE host-authoritative known-research row (protocol 38); ResearchPacket
-    PKT_CAM_HINT         = 41 // UNRELIABLE join camera center hint (protocol 43, join -> host); CamHintPacket
+    PKT_CAM_HINT         = 41,// UNRELIABLE join camera center hint (protocol 43, join -> host); CamHintPacket
+    PKT_BOUNTY           = 42 // RELIABLE host-authoritative bounty/crime row (protocol 45); BountyPacket
 };
 
 // One-shot transition events carried on the RELIABLE channel. Continuous state
@@ -1211,7 +1212,81 @@ struct TimePongPacket {
     u32 responderWallMs; // host's wallClockMs() at echo
 };
 
+// ---- Protocol 45: host-authoritative bounty/crime row ------------------------
+// ONE per-(character, faction) durable bounty row, keyed by the OWNING
+// character's save-stable hand (the per-character key every other per-character
+// channel uses - BountyManager is inline per-Character, NOT per-squad) plus the
+// faction's GameData stringID (cross-client stable, proven by the faction
+// probe). The HOST is the sole authority (H2 witness-local, settled by the
+// 2026-07-20 live run): only the host's guard simulation runs the
+// witness->assignBountyForCrimes pipeline, so the row lives on the host's
+// driven copy of a join-owned PC while the owner stays clean. The host diffs
+// each row's {amount, crimes, claimed} against a silently-seeded shared-save
+// baseline and streams movement DOWN to the clients; the owning client applies
+// it via the engine's own levers (unfairAddToBounty / clearBounty). Reliable
+// (a lost row would leave the wanted level diverged until the safety resend).
+struct BountyPacket {
+    u8  type;      // = PKT_BOUNTY
+    u32 ownerId;   // network player id of the sender (the HOST = the authority)
+    u32 seq;       // per-sender monotonic (stale-row guard, as PKT_FACTION)
+    u32 hand[5];   // owning character hand [type,container,containerSerial,index,serial]
+    char sid[48];  // faction GameData stringID ("" never sent) - cross-client identity
+    int  amount;   // Bounty::amount (cats) for that (char, faction) row
+    u32  crimes;   // Bounty::crimes bitmask (CrimeEnum bits)
+    u8   claimed;  // Bounty::bountyHasBeenClaimedOnce
+};
+
 #pragma pack(pop)
+
+// ---- Protocol 45: pure bounty decision logic (header-testable) ---------------
+// The side-effect-free core of the channel, extracted so prototest can lock the
+// authority + convergence rules without a live engine (the engine read/write
+// shims stay behind SEH in EngineCharState.cpp). One value triple per row.
+struct BountyVal {
+    int amount;      // Bounty::amount (cats)
+    u32 crimes;      // Bounty::crimes bitmask
+    int claimed;     // Bounty::bountyHasBeenClaimedOnce (0/1)
+};
+
+// HOST publish gate. Host-authoritative (H2): a NON-host caller NEVER publishes
+// its own bounty state (the join must not push its clean/forked copy upstream -
+// there is no echo path). On the host, a row streams only after its baseline is
+// seeded (both clients load the same save, so a bounty already present at load
+// is shared and silent) and either its value MOVED or a safety resend is due.
+// Returns 1 = queue the row, 0 = skip.
+inline int bountyShouldSend(int isHost, int seeded,
+                            const BountyVal* known, const BountyVal* cur,
+                            int resendDue) {
+    if (!isHost) return 0;   // unidirectional host->clients: the join never publishes
+    if (!seeded) return 0;   // first sight seeds the shared-save baseline silently
+    if (!known || !cur) return 0;
+    int changed = (known->amount != cur->amount) ||
+                  (known->crimes != cur->crimes) ||
+                  (known->claimed != cur->claimed);
+    return (changed || resendDue) ? 1 : 0;
+}
+
+// Receiver apply decision. Given the last-applied per-sender seq, the incoming
+// seq, and the target vs currently-live amount on the local (driven) copy,
+// decide what the engine lever must do. Drops stale rows, skips already-
+// converged rows (a resend or the echo of our own apply), else picks the lever:
+// a raise is an additive unfairAddToBounty(delta); a drop to <= 0 is clearBounty.
+enum BountyApplyAction {
+    BOUNTY_APPLY_SKIP_STALE     = 0, // incoming seq <= seqSeen: a newer row already landed
+    BOUNTY_APPLY_SKIP_CONVERGED = 1, // local already equals target: nothing to do
+    BOUNTY_APPLY_CLEAR          = 2, // target <= 0: clearBounty(fac)
+    BOUNTY_APPLY_ADD            = 3  // non-zero delta: unfairAddToBounty(fac, delta)
+};
+inline int bountyApplyDecision(u32 seqSeen, u32 incomingSeq,
+                               int targetAmount, int currentAmount,
+                               int* outDelta) {
+    if (outDelta) *outDelta = 0;
+    if (seqSeen != 0 && incomingSeq <= seqSeen) return BOUNTY_APPLY_SKIP_STALE;
+    if (targetAmount == currentAmount)          return BOUNTY_APPLY_SKIP_CONVERGED;
+    if (targetAmount <= 0)                      return BOUNTY_APPLY_CLEAR;
+    if (outDelta) *outDelta = targetAmount - currentAmount;
+    return BOUNTY_APPLY_ADD;
+}
 
 // Returns the packet type tag (first byte) of a received buffer, or 0 if empty.
 inline u8 packetType(const void* data, unsigned int len) {

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -1377,6 +1377,40 @@ void mainLoop_hook(GameWorld* gw, float dt) {
         }
     }
 
+    // Manual-validation helper (host only): KENSHICOOP_AUTOCRIME=N seconds -
+    // ONCE, N s after gameplay settles, programmatically assign a test bounty to
+    // a player-squad character (index = KENSHICOOP_AUTOCRIME_INDEX, default 1) via
+    // the engine's own unfairAddToBounty lever. On the host in inhabit mode a
+    // non-zero index is a JOIN-owned character's driven copy, so this reproduces
+    // the exact H2 witness-local state (a bounty on the host's copy of a join-owned
+    // PC) the protocol-45 channel must then carry to the owner - deterministic
+    // evidence without a hand-driven witnessed crime. OFF by default (0 = no-op).
+    if (g_cfg.isHost && g_gameStarted) {
+        static int  autoCrimeS    = -1;
+        static int  autoCrimeIdx  = -1;
+        static bool autoCrimeDone = false;
+        if (autoCrimeS < 0) {
+            const char* e = std::getenv("KENSHICOOP_AUTOCRIME");
+            autoCrimeS = e ? std::atoi(e) : 0;
+            const char* ei = std::getenv("KENSHICOOP_AUTOCRIME_INDEX");
+            autoCrimeIdx = ei ? std::atoi(ei) : 1;
+            if (autoCrimeIdx < 0) autoCrimeIdx = 1;
+        }
+        if (autoCrimeS > 0 && !autoCrimeDone &&
+            (GetTickCount() - g_gameStartTick) >= (DWORD)autoCrimeS * 1000u) {
+            autoCrimeDone = true;
+            unsigned int hand[5]; char sid[64];
+            bool ok = coop::engine::injectTestBounty(gw, (unsigned)autoCrimeIdx,
+                                                     500, hand, sid, sizeof(sid));
+            char b[192];
+            _snprintf(b, sizeof(b) - 1,
+                "[bounty] AUTOCRIME ok=%d idx=%d hand=%u,%u,%u,%u,%u fac='%s' amount=500",
+                ok ? 1 : 0, autoCrimeIdx, hand[0], hand[1], hand[2], hand[3], hand[4],
+                sid[0] ? sid : "-");
+            b[sizeof(b) - 1] = '\0'; coopLog(b);
+        }
+    }
+
     // Test-runner self-exit: quit cleanly after the configured duration so
     // unattended runs terminate on their own and flush their logs. Also a hard
     // backstop for a scenario that never reports completion.

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -1092,6 +1092,10 @@ void tickReplicatePublish(GameWorld* gw, bool worldLive) {
         // shackle/lock trace. No-op unless KENSHICOOP_DEBUG_SHACKLE=1, so it is
         // free to leave in the tick for manual-session characterization.
         coop::engine::shackleDbgTick(gw, g_cfg.isHost);
+        // Spike 59: env-gated ([bounty]) bounty/crime observer - direct reads
+        // of the Character+0xF0 inline BountyManager (sentinel-verified). No-op
+        // unless KENSHICOOP_BOUNTY_PROBE=1, so it is free to leave in the tick.
+        coop::engine::bountyProbeTick(gw, g_cfg.isHost);
         // Game-clock sync (protocol 25): the host broadcasts its absolute
         // in-game clock ~1 Hz; the join measures the offset and SLEWS - a
         // multiplier the speed layer's quiet writes fold in on top of the

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -1951,6 +1951,7 @@ void installEngineDetours() {
     g_repl.setHungerSync(g_cfg.hungerSync);
     g_repl.setProdSync(g_cfg.prodSync);
     g_repl.setResearchSync(g_cfg.researchSync);
+    g_repl.setBountySync(g_cfg.bountySync);
     // Protocol 34: the HOST authors every storage/machine container near the
     // interest centers (the ~1 Hz census inside publishInventories); the join
     // reconciles via the translated key. Host-only flag - the join must never

--- a/src/plugin/core/Config.cpp
+++ b/src/plugin/core/Config.cpp
@@ -230,6 +230,12 @@ void loadConfig(Config& c) {
     c.loadSync    = envOr("KENSHICOOP_LOAD_SYNC", "1") != "0";
     c.prodSync    = envOr("KENSHICOOP_PROD_SYNC", "1") != "0";
     c.researchSync = envOr("KENSHICOOP_RESEARCH_SYNC", "1") != "0";
+    c.bountySync = envOr("KENSHICOOP_BOUNTY_SYNC", "1") != "0";
+    // The bounty channel (protocol 45) coexists with the read-only spike-59
+    // probe (KENSHICOOP_BOUNTY_PROBE): the probe only READS, so both can run,
+    // but keep the write channel OFF while probing the unsynced baseline.
+    if (envOr("KENSHICOOP_BOUNTY_PROBE", "0") == "1") c.bountySync = false;
+
     c.storeSync   = envOr("KENSHICOOP_STORE_SYNC", "1") != "0";
     c.squadSync   = envOr("KENSHICOOP_SQUAD_SYNC", "1") != "0";
     c.latejoinSync = envOr("KENSHICOOP_LATEJOIN_SYNC", "1") != "0";

--- a/src/plugin/core/Config.h
+++ b/src/plugin/core/Config.h
@@ -422,6 +422,18 @@ struct Config {
     // escape hatch.
     bool          researchSync;
 
+    // KENSHICOOP_BOUNTY_SYNC (default ON): bounty/crime sync (protocol 45) -
+    // the HOST is the witness authority (H2, settled by the 2026-07-20 live
+    // run): it samples every durable bounty row on the bodies it carries (its
+    // driven copies of remote PCs, where a join-owned PC's bounty lives, plus
+    // host-owned PCs) ~1 Hz and streams change-gated PKT_BOUNTY rows keyed
+    // per-(character hand, faction sid); the owning client applies each row onto
+    // its own clean copy via the engine's own levers (unfairAddToBounty raise /
+    // clearBounty drop). Without it a character's wanted level is per-client:
+    // a crime one player commits leaves the peer's copy unwanted (spikes 59/60).
+    // Unidirectional host->clients (no echo path). "0" is the A/B escape hatch.
+    bool          bountySync;
+
     // KENSHICOOP_STORE_SYNC (default ON): storage/machine container sync
     // (protocol 34) - the HOST censuses container-bearing buildings (storage
     // chests + the machine classes) in the interest spheres ~1 Hz and

--- a/src/plugin/core/Inbound.h
+++ b/src/plugin/core/Inbound.h
@@ -206,6 +206,14 @@ struct InboundResearch {
     ResearchPacket pkt;
 };
 
+// One received bounty/crime row (protocol 45): the HOST's authoritative durable
+// bounty for a (character, faction) pair; the owning client applies it onto its
+// own (clean) copy via the BountyManager levers (unfairAddToBounty/clearBounty).
+struct InboundBounty {
+    u32          ownerId;
+    BountyPacket pkt;
+};
+
 // One received stealth detection-map snapshot (protocol 20): the detection
 // AUTHORITY (the host's world, where the sneaker is a driven copy) streams who
 // notices the sneaker; the sneaker's OWNER replays the entries between its
@@ -368,7 +376,7 @@ public:
         med_(worldReset_),        treat_(worldReset_),      speed_(worldReset_),
         stats_(worldReset_),      money_(worldReset_),      faction_(worldReset_),
         time_(worldReset_),       door_(worldReset_),       prod_(worldReset_),
-        research_(worldReset_),   buildPlace_(worldReset_), buildState_(worldReset_),
+        research_(worldReset_),   bounty_(worldReset_),     buildPlace_(worldReset_), buildState_(worldReset_),
         buildDoor_(worldReset_),  buildRemove_(worldReset_), stealth_(worldReset_, 512),
         spawnReq_(worldReset_),   spawnInfo_(worldReset_),  camHint_(worldReset_, 64) {
         InitializeCriticalSection(&cs_);
@@ -508,6 +516,11 @@ public:
     void pushResearch(u32 ownerId, const ResearchPacket& pkt) {
         InboundResearch ir; ir.ownerId = ownerId; ir.pkt = pkt;
         EnterCriticalSection(&cs_); research_.push_back(ir); LeaveCriticalSection(&cs_);
+    }
+    // NET thread: one received bounty/crime row (protocol 45), owner-tagged.
+    void pushBounty(u32 ownerId, const BountyPacket& pkt) {
+        InboundBounty ib; ib.ownerId = ownerId; ib.pkt = pkt;
+        EnterCriticalSection(&cs_); bounty_.push_back(ib); LeaveCriticalSection(&cs_);
     }
     // NET thread: one received placed-building announcement (protocol 27), owner-tagged.
     void pushBuildPlace(u32 ownerId, const BuildPlacePacket& pkt) {
@@ -653,6 +666,9 @@ public:
     void drainResearch(std::deque<InboundResearch>& out) {
         EnterCriticalSection(&cs_); out.swap(research_); LeaveCriticalSection(&cs_);
     }
+    void drainBounty(std::deque<InboundBounty>& out) {
+        EnterCriticalSection(&cs_); out.swap(bounty_); LeaveCriticalSection(&cs_);
+    }
     void drainBuildPlace(std::deque<InboundBuildPlace>& out) {
         EnterCriticalSection(&cs_); out.swap(buildPlace_); LeaveCriticalSection(&cs_);
     }
@@ -762,6 +778,9 @@ private:
     WorldQ<InboundDoor>            door_;
     WorldQ<InboundProd>            prod_;
     WorldQ<InboundResearch>        research_;
+    // Bounty/crime rows (protocol 45): reliable, so unbounded; world-state, so
+    // auto-cleared on a session reset (a bounty describes the CURRENT world).
+    WorldQ<InboundBounty>          bounty_;
     WorldQ<InboundBuildPlace>      buildPlace_;
     WorldQ<InboundBuildState>      buildState_;
     WorldQ<InboundBuildDoor>       buildDoor_;

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -1135,6 +1135,17 @@ struct BountyPubRow {
 // BountyManager::me sentinel is checked per body before any parse. Returns the
 // count written (rows only, bodies with no live bounty contribute none).
 unsigned int enumBountyRows(GameWorld* gw, BountyPubRow* out, unsigned int maxOut);
+// Manual-validation helper (host only, KENSHICOOP_AUTOCRIME): programmatically
+// assign a test bounty to the player-squad character at playerIndex via the
+// engine's OWN unfairAddToBounty lever, against the first real world faction.
+// On the host in inhabit mode a non-zero index is a JOIN-owned character's
+// DRIVEN copy, so this reproduces the exact H2 state (a bounty on the host's
+// copy of a join-owned PC) the replication channel must then carry to the owner
+// WITHOUT relying on a hand-driven witnessed crime. Fills outHand (readObjectHand
+// layout) + outSid (the enforcer faction). Returns true when the bounty landed.
+bool injectTestBounty(GameWorld* gw, unsigned int playerIndex, int amount,
+                      unsigned int outHand[5], char* outSid, unsigned int sidLen);
+
 // SEH-guarded: apply one received bounty row onto the local (owning) copy of
 // the character at hand, for the faction sid, via the engine's OWN levers -
 // unfairAddToBounty for a raise, clearBounty for a drop to zero (never a raw

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -1115,6 +1115,36 @@ bool shackleDbgOn();
 // when the env var is unset; SEH-guarded per body; zero behavior change.
 void bountyProbeTick(GameWorld* gw, bool isHost);
 bool bountyProbeOn();
+
+// Protocol 45: bounty/crime sync engine shims (the SEH-guarded read/write
+// levers the host-authoritative PKT_BOUNTY channel rides on).
+// ONE durable bounty row a host-side character carries (its own hand + the
+// faction sid + the Bounty value). Emitted per (character, faction) pair by the
+// enumeration below; the publisher keys the wire packet by these.
+struct BountyPubRow {
+    unsigned int hand[5];  // owning character hand (readObjectHand layout)
+    char         sid[48];  // faction GameData stringID (cross-client identity)
+    int          amount;   // Bounty::amount (cats)
+    unsigned int crimes;   // Bounty::crimes bitmask (CrimeEnum bits)
+    int          claimed;  // Bounty::bountyHasBeenClaimedOnce (0/1)
+};
+// SEH-guarded: enumerate every durable bounty row on the characters this engine
+// carries (the same subject set the probe scans - local player squad + nearby
+// world NPCs, which on the host includes its DRIVEN copies of join-owned PCs
+// where the H2 row lives). One BountyPubRow per (character, faction). The
+// BountyManager::me sentinel is checked per body before any parse. Returns the
+// count written (rows only, bodies with no live bounty contribute none).
+unsigned int enumBountyRows(GameWorld* gw, BountyPubRow* out, unsigned int maxOut);
+// SEH-guarded: apply one received bounty row onto the local (owning) copy of
+// the character at hand, for the faction sid, via the engine's OWN levers -
+// unfairAddToBounty for a raise, clearBounty for a drop to zero (never a raw
+// map poke, so derived expiry/GUI stay consistent). Convergence-first: a row
+// already equal to getActualBounty is a no-op. outBefore/outAfter capture the
+// (char, faction) amount around the write for the RECV log. Returns true when
+// the character + faction resolved locally and the lever ran (or was a no-op).
+bool applyBountyRow(GameWorld* gw, const unsigned int hand[5], const char* sid,
+                    int amount, unsigned int crimes, int claimed,
+                    int* outBefore, int* outAfter);
 // Place the local occupant into / remove it from the furniture at furnHand via
 // the engine's own setBedMode/setPrisonMode (kind: 1 bed, 2 cage) - pose,
 // attach and transform are engine-native. Idempotent: already in the desired

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -1103,6 +1103,18 @@ int readSlaveState(Character* c);
 // the env var is unset; SEH-guarded per body. `isHost` only tags the line.
 void shackleDbgTick(GameWorld* gw, bool isHost);
 bool shackleDbgOn();
+// Spike 59: env-gated ([bounty], KENSHICOOP_BOUNTY_PROBE) read-only observer
+// for the engine's bounty/crime system - the SYNC_GAPS gap-3 "remaining edge"
+// that so far only has indirect [fac] AFFECT cause evidence. Character::crimes
+// is an INLINE BountyManager at Character+0xF0 (KenshiLib PDB layout);
+// BountyManager::me points back at the owning Character and is checked as a
+// validity sentinel BEFORE any parse (a mismatch logs one SENTINEL-MISMATCH
+// tripwire and reads nothing). Enumerates the local player squad + nearby
+// world NPCs ~1 Hz and logs only bodies with live crime/bounty state, plus a
+// 10 s [bounty] SCAN heartbeat (valid==n is the layout-health signal). No-op
+// when the env var is unset; SEH-guarded per body; zero behavior change.
+void bountyProbeTick(GameWorld* gw, bool isHost);
+bool bountyProbeOn();
 // Place the local occupant into / remove it from the furniture at furnHand via
 // the engine's own setBedMode/setPrisonMode (kind: 1 bed, 2 cage) - pose,
 // attach and transform are engine-native. Idempotent: already in the desired

--- a/src/plugin/game/EngineCharState.cpp
+++ b/src/plugin/game/EngineCharState.cpp
@@ -492,6 +492,125 @@ void bountyProbeTick(GameWorld* gw, bool isHost) {
     }
 }
 
+// ---- Protocol 45: bounty/crime sync levers ---------------------------------
+// The channel's engine seam: read every durable bounty row on the bodies this
+// engine carries (enumBountyRows), and apply a received row onto the local
+// (owning) copy via the engine's own write levers (applyBountyRow). Both reuse
+// the spike-59 readBountyState reader (BountyManager::me sentinel + SEH) - the
+// probe proved that read compiles and holds; this adds the WRITE half the H2
+// run settled the authority for. Host-only publish / owner-side apply is
+// enforced by the caller (Replicator + Plugin tick), not here.
+
+unsigned int enumBountyRows(GameWorld* gw, BountyPubRow* out, unsigned int maxOut) {
+    if (!gw || !out || maxOut == 0) return 0;
+
+    // Subjects: the exact set the spike-59 probe scans - local player squad
+    // FIRST, then nearby world NPCs. On the HOST this set includes the driven
+    // copies of JOIN-owned PCs, which is precisely where the H2 witness-local
+    // bounty row lives (the owner's own copy stays clean). Capture the FULL
+    // hand (5 fields) per body - the wire keys the row per-character by hand.
+    static const unsigned int MAXN = 64;
+    Character*   chars[MAXN];
+    unsigned int hands[MAXN][5];
+    unsigned int n = 0;
+    __try {
+        if (gw->player) {
+            unsigned int pc = (unsigned int)gw->player->playerCharacters.size();
+            for (unsigned int i = 0; i < pc && n < MAXN; ++i) {
+                Character* c = gw->player->playerCharacters[i];
+                if (!c) continue;
+                unsigned int h[5];
+                if (!readObjectHand(static_cast<RootObject*>(c), h))
+                    continue; // no resolvable hand = the peer can't key it either
+                chars[n] = c;
+                for (unsigned int k = 0; k < 5; ++k) hands[n][k] = h[k];
+                ++n;
+            }
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    {
+        Character*  nchars[MAXN];
+        EntityState nst[MAXN];
+        unsigned int nn = listNpcs(gw, nchars, nst, MAXN);
+        for (unsigned int i = 0; i < nn && n < MAXN; ++i) {
+            chars[n] = nchars[i];
+            // EntityState hand layout == readObjectHand layout
+            // [type,container,containerSerial,index,serial].
+            hands[n][0] = nst[i].hType;
+            hands[n][1] = nst[i].hContainer;
+            hands[n][2] = nst[i].hContainerSerial;
+            hands[n][3] = nst[i].hIndex;
+            hands[n][4] = nst[i].hSerial;
+            ++n;
+        }
+    }
+
+    unsigned int written = 0;
+    for (unsigned int i = 0; i < n && written < maxOut; ++i) {
+        BountyRead br;
+        if (!readBountyState(chars[i], &br) || !br.valid) continue;
+        for (unsigned int r = 0; r < br.nRows && written < maxOut; ++r) {
+            if (br.rows[r].sid[0] == '\0') continue; // no faction sid = not addressable
+            BountyPubRow& o = out[written];
+            for (unsigned int k = 0; k < 5; ++k) o.hand[k] = hands[i][k];
+            strncpy(o.sid, br.rows[r].sid, sizeof(o.sid) - 1);
+            o.sid[sizeof(o.sid) - 1] = '\0';
+            o.amount  = br.rows[r].amount;
+            o.crimes  = br.rows[r].crimes;
+            o.claimed = br.rows[r].claimed;
+            ++written;
+        }
+    }
+    return written;
+}
+
+// std::string construction cannot share a frame with __try (C2712), so the
+// sid -> Faction* lookup lives in this unguarded shim (factionBySidGuarded holds
+// its own SEH). Mirrors the faction channel's factionBySidC helper.
+static Faction* bountyFactionBySid(GameWorld* gw, const char* sid) {
+    std::string s(sid);
+    return factionBySidGuarded(gw, &s);
+}
+
+bool applyBountyRow(GameWorld* gw, const unsigned int hand[5], const char* sid,
+                    int amount, unsigned int crimes, int claimed,
+                    int* outBefore, int* outAfter) {
+    (void)crimes; (void)claimed; // amount drives the levers; crimes/claimed derive
+    if (outBefore) *outBefore = -1;
+    if (outAfter)  *outAfter  = -1;
+    if (!gw || !hand || !sid || !sid[0]) return false;
+    if (!g_bountyGetFn || !g_bountyAddFn || !g_bountyClearFn) return false;
+    // Resolve the local (owning) copy of the character and the enforcer faction
+    // OUTSIDE the __try (both hold their own SEH; std::string forbids C2712).
+    Character* c = resolveCharByHand(hand[3], hand[4], hand[0], hand[1], hand[2]);
+    if (!c) return false; // not loaded here / out of interest - accepted edge
+    Faction* fac = bountyFactionBySid(gw, sid);
+    if (!fac) return false;
+    __try {
+        if (c->crimes.me != c) return false; // layout sentinel: never poke a bad frame
+        int cur = g_bountyGetFn(&c->crimes, fac);
+        if (outBefore) *outBefore = cur;
+        // Convergence-first: a row already at the target is a resend / the echo
+        // of our own earlier apply - do nothing.
+        if (cur != amount) {
+            if (amount <= 0) {
+                // Drop to zero: clear the whole (char, faction) row so derived
+                // expiry / GUI / guard aggro all reset natively.
+                g_bountyClearFn(&c->crimes, fac);
+            } else {
+                // Raise: additive so the engine keeps expiry/GUI consistent
+                // (preferred over reconstructing via setCrime+assign).
+                g_bountyAddFn(&c->crimes, fac, amount - cur);
+            }
+        }
+        if (outAfter) *outAfter = g_bountyGetFn(&c->crimes, fac);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        coop::logLine("[bounty] write SEH-except");
+        return false;
+    }
+}
+
 bool applyFurniture(GameWorld* gw, Character* occupant,
                     const unsigned int furnHand[5], int kind, bool on) {
     (void)gw;

--- a/src/plugin/game/EngineCharState.cpp
+++ b/src/plugin/game/EngineCharState.cpp
@@ -611,6 +611,94 @@ bool applyBountyRow(GameWorld* gw, const unsigned int hand[5], const char* sid,
     }
 }
 
+// SEH shims for injectTestBounty (each lever call in its own frame; the map-
+// touching read stays in readBountyState's own SEH). std::string forbids C2712,
+// so no such object shares these frames.
+static bool addBountySEH(Character* c, Faction* f, int amount) {
+    __try {
+        if (c->crimes.me != c) return false; // sentinel before poking Character+0xF0
+        g_bountyAddFn(&c->crimes, f, amount);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+}
+static void clearBountySEH(Character* c, Faction* f) {
+    __try { if (c->crimes.me == c) g_bountyClearFn(&c->crimes, f); }
+    __except (EXCEPTION_EXECUTE_HANDLER) {}
+}
+// Collect REAL world factions (not the player's, not notARealFaction) that carry
+// a readable GameData sid. Returns the count written.
+static unsigned int collectRealFactions(GameWorld* gw, Faction** out, unsigned int maxOut) {
+    unsigned int n = 0;
+    __try {
+        if (!gw->player || !gw->factionMgr) return 0;
+        Faction* pf = gw->player->getFaction();
+        lektor<Faction*>& all = gw->factionMgr->participants;
+        unsigned int total = all.size();
+        for (unsigned int i = 0; i < total && n < maxOut; ++i) {
+            Faction* f = all[i];
+            if (!f || f == pf || f->notARealFaction) continue;
+            char sidTmp[64]; sidTmp[0] = '\0';
+            facSidOf(f, sidTmp, sizeof(sidTmp));
+            if (sidTmp[0] == '\0') continue;
+            out[n++] = f;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    return n;
+}
+// Resolve the player-squad character at idx + its hand (readObjectHand layout).
+static Character* playerCharAt(GameWorld* gw, unsigned int idx, unsigned int outHand[5]) {
+    Character* c = 0;
+    if (outHand) for (int i = 0; i < 5; ++i) outHand[i] = 0;
+    __try {
+        if (!gw->player) return 0;
+        unsigned int pc = (unsigned int)gw->player->playerCharacters.size();
+        if (idx >= pc) return 0;
+        c = gw->player->playerCharacters[idx];
+        if (!c || c->crimes.me != c) return 0;
+        unsigned int h[5];
+        if (readObjectHand(static_cast<RootObject*>(c), h) && outHand)
+            for (int i = 0; i < 5; ++i) outHand[i] = h[i];
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+    return c;
+}
+
+bool injectTestBounty(GameWorld* gw, unsigned int playerIndex, int amount,
+                      unsigned int outHand[5], char* outSid, unsigned int sidLen) {
+    if (outHand) { for (int i = 0; i < 5; ++i) outHand[i] = 0; }
+    if (outSid && sidLen) outSid[0] = '\0';
+    if (!gw || !g_bountyAddFn || !g_bountyClearFn) return false;
+    unsigned int handTmp[5];
+    Character* c = playerCharAt(gw, playerIndex, handTmp);
+    if (!c) return false;
+    if (outHand) for (int i = 0; i < 5; ++i) outHand[i] = handTmp[i];
+
+    // The stored bounty faction is _getBountyFaction(enforcer), which can remap an
+    // arbitrary enforcer onto a sid-LESS internal faction - a row the channel
+    // rightly refuses to replicate (the peer can't name it). A real witnessed
+    // crime always lands on a proper law faction. So try real factions until the
+    // resulting row is ADDRESSABLE (readBountyState fills the sid via facSidOf),
+    // clearing the sid-less misses; report the actual stored sid.
+    Faction* cand[64];
+    unsigned int nf = collectRealFactions(gw, cand, 64);
+    for (unsigned int i = 0; i < nf; ++i) {
+        if (!addBountySEH(c, cand[i], amount)) continue;
+        BountyRead br;
+        if (readBountyState(c, &br) && br.valid) {
+            for (unsigned int r = 0; r < br.nRows; ++r) {
+                if (br.rows[r].sid[0]) {
+                    if (outSid && sidLen) {
+                        strncpy(outSid, br.rows[r].sid, sidLen - 1);
+                        outSid[sidLen - 1] = '\0';
+                    }
+                    return true; // an addressable bounty landed
+                }
+            }
+        }
+        clearBountySEH(c, cand[i]); // sid-less row: undo and try the next faction
+    }
+    return false;
+}
+
 bool applyFurniture(GameWorld* gw, Character* occupant,
                     const unsigned int furnHand[5], int kind, bool on) {
     (void)gw;

--- a/src/plugin/game/EngineCharState.cpp
+++ b/src/plugin/game/EngineCharState.cpp
@@ -317,6 +317,181 @@ void shackleDbgTick(GameWorld* gw, bool isHost) {
     }
 }
 
+// ---- Spike 59: bounty/crime probe (KENSHICOOP_BOUNTY_PROBE) ----------------
+// Read-only observer for the engine's bounty/crime system - the SYNC_GAPS
+// gap-3 "remaining edge" that so far only has indirect [fac] AFFECT cause
+// evidence. Character::crimes is an INLINE BountyManager at Character+0xF0
+// (KenshiLib PDB layout, independently re-verified against an external RE
+// offset map - not derived from scanning here). BountyManager::me (+0x40
+// inside it) points back at the owning Character, which gives the probe a
+// free validity sentinel: me != c means the layout does not hold for this
+// build and NOTHING else is parsed. All reads SEH-guarded; zero behavior
+// change - the same observe-only contract as the jail/shackle probes.
+
+// One per-faction bounty row (POD mirror of the engine's Bounty value).
+struct BountyRow {
+    Faction*     fac;      // engine pointer (session-local identity only)
+    char         sid[64];  // faction GameData stringID (cross-client identity)
+    int          amount;   // Bounty::amount (cats)
+    unsigned int crimes;   // Bounty::crimes bitmask (CrimeEnum bits)
+    int          claimed;  // Bounty::bountyHasBeenClaimedOnce
+};
+
+// POD snapshot of one character's BountyManager state.
+struct BountyRead {
+    int          valid;      // 1 = me-sentinel matched; 0 = layout drift, do not trust
+    int          committing; // BountyManager::committingCrime (CrimeEnum; 0 = none)
+    char         vsSid[64];  // crimeAgainstFaction sid ("" = null/unreadable)
+    float        expiry;     // BountyManager::crimeExpiry
+    float        sentence;   // BountyManager::prisonSentenceToServe
+    int          hadBounty;  // BountyManager::_hadABountyAssignedForCurrentCrime
+    unsigned int nRows;      // bounties-map entries captured (capped at 8)
+    unsigned int mapSize;    // bounties map size() as reported
+    BountyRow    rows[8];
+};
+
+// Unguarded shim: boost iterators cannot share a frame with __try (C2712),
+// so the bounties-map walk lives here and the CALLER holds the SEH frame
+// (the factionBySidC pattern). Read-only iteration of the engine-owned map.
+static unsigned int readBountyRows(Character* c, BountyRow* out, unsigned int maxOut,
+                                   unsigned int* outMapSize) {
+    typedef ogre_unordered_map<Faction*, Bounty>::type BMap;
+    const BMap& m = c->crimes.bounties;
+    if (outMapSize) *outMapSize = (unsigned int)m.size();
+    unsigned int n = 0;
+    for (BMap::const_iterator it = m.begin(); it != m.end() && n < maxOut; ++it) {
+        BountyRow& r = out[n];
+        r.fac     = it->first;
+        r.amount  = it->second.amount;
+        r.crimes  = it->second.crimes;
+        r.claimed = it->second.bountyHasBeenClaimedOnce ? 1 : 0;
+        r.sid[0]  = '\0'; // filled by the caller (facSidOf holds its own SEH)
+        ++n;
+    }
+    return n;
+}
+
+// SEH-guarded snapshot of one body's bounty/crime state. Returns false only
+// when the read FAULTED; a sentinel mismatch returns true with valid=0 so the
+// tick can log the tripwire instead of silently skipping.
+static bool readBountyState(Character* c, BountyRead* out) {
+    if (!c || !out) return false;
+    memset(out, 0, sizeof(*out));
+    __try {
+        // Validity sentinel FIRST: BountyManager's constructor stores the
+        // owning Character in `me`. A mismatch means Character+0xF0 does not
+        // hold for this build - report it, parse nothing.
+        if (c->crimes.me != c) return true; // valid stays 0
+        out->committing = (int)c->crimes.committingCrime;
+        out->expiry     = c->crimes.crimeExpiry;
+        out->sentence   = c->crimes.prisonSentenceToServe;
+        out->hadBounty  = c->crimes._hadABountyAssignedForCurrentCrime ? 1 : 0;
+        facSidOf(c->crimes.crimeAgainstFaction, out->vsSid, sizeof(out->vsSid));
+        out->nRows = readBountyRows(c, out->rows, 8, &out->mapSize);
+        for (unsigned int i = 0; i < out->nRows; ++i)
+            facSidOf(out->rows[i].fac, out->rows[i].sid, sizeof(out->rows[i].sid));
+        out->valid = 1;
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        out->valid = 0;
+        return false;
+    }
+}
+
+bool bountyProbeOn() {
+    static int on = -1;
+    if (on < 0) { const char* e = getenv("KENSHICOOP_BOUNTY_PROBE"); on = (e && e[0] == '1') ? 1 : 0; }
+    return on == 1;
+}
+
+void bountyProbeTick(GameWorld* gw, bool isHost) {
+    if (!bountyProbeOn() || !gw) return;
+    static unsigned long lastMs = 0;
+    unsigned long now = GetTickCount();
+    if (lastMs != 0 && (now - lastMs) < 1000) return;
+    lastMs = now;
+
+    // Subjects: the local player squad FIRST (bounties are a player-facing
+    // system - the PCs are who accrue them), then nearby world NPCs (bounty
+    // targets the player could capture). listNpcs never returns the local
+    // squad, so the two sets are disjoint.
+    static const unsigned int MAXN = 64;
+    Character*   chars[MAXN];
+    unsigned int hnd[MAXN][2]; // index,serial for the log key
+    unsigned int n = 0;
+    __try {
+        if (gw->player) {
+            unsigned int pc = (unsigned int)gw->player->playerCharacters.size();
+            for (unsigned int i = 0; i < pc && n < MAXN; ++i) {
+                Character* c = gw->player->playerCharacters[i];
+                if (!c) continue;
+                unsigned int h[5];
+                if (!readObjectHand(static_cast<RootObject*>(c), h)) { h[3] = 0; h[4] = 0; }
+                chars[n] = c; hnd[n][0] = h[3]; hnd[n][1] = h[4]; ++n;
+            }
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    {
+        Character*  nchars[MAXN];
+        EntityState nst[MAXN];
+        unsigned int nn = listNpcs(gw, nchars, nst, MAXN);
+        for (unsigned int i = 0; i < nn && n < MAXN; ++i) {
+            chars[n] = nchars[i]; hnd[n][0] = nst[i].hIndex; hnd[n][1] = nst[i].hSerial; ++n;
+        }
+    }
+
+    unsigned int nValid = 0, nActive = 0;
+    for (unsigned int i = 0; i < n; ++i) {
+        BountyRead br;
+        if (!readBountyState(chars[i], &br)) continue; // read faulted; SCAN still counts it via n
+        if (!br.valid) {
+            // Layout-drift tripwire: log at most once per session so a game
+            // patch that moves the member is loud, not a silent no-data run.
+            static int warned = 0;
+            if (!warned) {
+                warned = 1;
+                char b[176];
+                _snprintf(b, sizeof(b) - 1,
+                          "[bounty] SENTINEL-MISMATCH host=%d hand=%u,%u (Character+0xF0 "
+                          "did not self-verify; parsing disabled)",
+                          isHost ? 1 : 0, hnd[i][0], hnd[i][1]);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            }
+            continue;
+        }
+        ++nValid;
+        // Log only bodies with live crime/bounty state - a clean save stays quiet.
+        if (br.committing == 0 && br.nRows == 0) continue;
+        ++nActive;
+        char b[256];
+        _snprintf(b, sizeof(b) - 1,
+                  "[bounty] STATE host=%d hand=%u,%u crime=%d vs=%s expiry=%.1f "
+                  "sentence=%.1f had=%d rows=%u/%u",
+                  isHost ? 1 : 0, hnd[i][0], hnd[i][1], br.committing,
+                  br.vsSid[0] ? br.vsSid : "-", br.expiry, br.sentence,
+                  br.hadBounty, br.nRows, br.mapSize);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        for (unsigned int r = 0; r < br.nRows; ++r) {
+            _snprintf(b, sizeof(b) - 1,
+                      "[bounty] ROW host=%d hand=%u,%u fac=%s amount=%d crimes=0x%X claimed=%d",
+                      isHost ? 1 : 0, hnd[i][0], hnd[i][1],
+                      br.rows[r].sid[0] ? br.rows[r].sid : "-",
+                      br.rows[r].amount, br.rows[r].crimes, br.rows[r].claimed);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        }
+    }
+    // ~10 s heartbeat so a quiet run still proves the probe ran AND the
+    // sentinel held on every scanned body (valid == n is the health signal).
+    static unsigned long lastSumMs = 0;
+    if (lastSumMs == 0 || (now - lastSumMs) >= 10000) {
+        lastSumMs = now;
+        char b[128];
+        _snprintf(b, sizeof(b) - 1, "[bounty] SCAN host=%d n=%u valid=%u active=%u",
+                  isHost ? 1 : 0, n, nValid, nActive);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
+}
+
 bool applyFurniture(GameWorld* gw, Character* occupant,
                     const unsigned int furnHand[5], int kind, bool on) {
     (void)gw;

--- a/src/plugin/game/EngineInternal.cpp
+++ b/src/plugin/game/EngineInternal.cpp
@@ -1213,6 +1213,9 @@ RelGetFn         g_relGetFn       = 0; // protocol 24 relation read
 RelSetFn         g_relSetFn       = 0; // protocol 24 relation write
 RelBoolFn        g_relIsEnemyFn   = 0; // protocol 24 derived hostility flag
 RelBoolFn        g_relIsAllyFn    = 0; // protocol 24 derived alliance flag
+BountyAddFn      g_bountyAddFn    = 0; // protocol 45 bounty raise lever
+BountyClearFn    g_bountyClearFn  = 0; // protocol 45 bounty clear lever
+BountyGetFn      g_bountyGetFn    = 0; // protocol 45 bounty read lever
 
 // The faction's GameData stringID - the save-stable cross-client identity
 // (protocol 21 already round-trips it for proxy spawns). "" when unreadable.
@@ -1563,6 +1566,14 @@ void resolve() {
     g_relSetFn     = (RelSetFn)KenshiLib::GetRealAddress(&FactionRelations::setRelation);
     g_relIsEnemyFn = (RelBoolFn)KenshiLib::GetRealAddress(&FactionRelations::isEnemy);
     g_relIsAllyFn  = (RelBoolFn)KenshiLib::GetRealAddress(&FactionRelations::isAlly);
+    // Bounty/crime write levers (protocol 45 groundwork; non-fatal: unresolved
+    // -> applyBountyRow no-ops and the channel logs the gap on first apply).
+    g_bountyAddFn   = (BountyAddFn)KenshiLib::GetRealAddress(&BountyManager::unfairAddToBounty);
+    g_bountyClearFn = (BountyClearFn)KenshiLib::GetRealAddress(&BountyManager::clearBounty);
+    g_bountyGetFn   = (BountyGetFn)KenshiLib::GetRealAddress(&BountyManager::getActualBounty);
+    if (!g_bountyAddFn || !g_bountyClearFn || !g_bountyGetFn)
+        coop::logErrLine("engine: could not resolve bounty write levers (bounty sync off)");
+
     // Honest pose oracle reads (non-fatal).
     g_getBip01Fn   = (GetBip01Fn)KenshiLib::GetRealAddress(&Character::getPositionBip01);
     g_getBoneWorldFn = (GetBoneWorldPosFn)KenshiLib::GetRealAddress(&Character::getBoneWorldPosition);

--- a/src/plugin/game/EngineInternal.h
+++ b/src/plugin/game/EngineInternal.h
@@ -263,6 +263,11 @@ typedef void  (__fastcall* RelSetFn)(FactionRelations* self, Faction* who, float
 typedef bool  (__fastcall* RelBoolFn)(FactionRelations* self, Faction* c);
 typedef void (__fastcall* AffectRelEvFn)(FactionRelations* self, Faction* p, int e, float mult);
 typedef void (__fastcall* AffectRelAmtFn)(FactionRelations* self, Faction* p, float amount, float mult);
+// Protocol 45 bounty/crime write levers (BountyManager, inline at Character+0xF0;
+// non-virtual, resolved like every other engine call via GetRealAddress).
+typedef void (__fastcall* BountyAddFn)(BountyManager* self, Faction* enforcer, int amount);
+typedef void (__fastcall* BountyClearFn)(BountyManager* self, Faction* enforcer);
+typedef int  (__fastcall* BountyGetFn)(BountyManager* self, Faction* whosLooking);
 
 // honest-pose / body-state / combat reads
 typedef Ogre::Vector3* (__fastcall* GetBip01Fn)(Character* self, Ogre::Vector3* ret);
@@ -478,6 +483,9 @@ extern RelGetFn         g_relGetFn;
 extern RelSetFn         g_relSetFn;
 extern RelBoolFn        g_relIsEnemyFn;
 extern RelBoolFn        g_relIsAllyFn;
+extern BountyAddFn      g_bountyAddFn;   // protocol 45: unfairAddToBounty
+extern BountyClearFn    g_bountyClearFn; // protocol 45: clearBounty
+extern BountyGetFn      g_bountyGetFn;   // protocol 45: getActualBounty
 extern std::vector<FactionDeltaRec> g_facDeltas;
 extern AffectRelEvFn  g_affectEvOrig;
 extern AffectRelAmtFn g_affectAmtOrig;

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -207,6 +207,8 @@ void NetLink::queueProd(const ProdPacket& pkt) { pushLocked(outCs_, outProd_, pk
 
 void NetLink::queueResearch(const ResearchPacket& pkt) { pushLocked(outCs_, outResearch_, pkt); }
 
+void NetLink::queueBounty(const BountyPacket& pkt) { pushLocked(outCs_, outBounty_, pkt); }
+
 void NetLink::queueBuildPlace(const BuildPlacePacket& pkt) { pushLocked(outCs_, outBuildPlace_, pkt); }
 
 void NetLink::queueBuildState(const BuildStatePacket& pkt) { pushLocked(outCs_, outBuildState_, pkt); }
@@ -705,6 +707,14 @@ void NetLink::threadLoop() {
                         if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &rp)
                             && inbound_) {
                             inbound_->pushResearch(rp.ownerId, rp);
+                        }
+                    } else if (type == PKT_BOUNTY) {
+                        // Reliable host-authoritative bounty/crime row
+                        // (protocol 45), applied via the BountyManager levers.
+                        BountyPacket bp;
+                        if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &bp)
+                            && inbound_) {
+                            inbound_->pushBounty(bp.ownerId, bp);
                         }
                     } else if (type == PKT_BUILD_PLACE) {
                         // Reliable placed-building announcement (protocol 27):
@@ -1306,6 +1316,27 @@ void NetLink::threadLoop() {
         LeaveCriticalSection(&outCs_);
         for (size_t i = 0; i < researchPkts.size(); ++i) {
             ENetPacket* out = enet_packet_create(&researchPkts[i], sizeof(ResearchPacket),
+                                                 ENET_PACKET_FLAG_RELIABLE);
+            if (isHost_) {
+                enet_host_broadcast(enetHost_, CH_RELIABLE, out);
+            } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
+                enet_peer_send(serverPeer_, CH_RELIABLE, out);
+            } else {
+                enet_packet_destroy(out);
+            }
+        }
+
+        // Drain + send any queued bounty/crime rows on CH_RELIABLE (protocol
+        // 44). Host -> joins only (the Replicator only publishes on the host);
+        // change-gated + safety-resent by the caller, so a settled wanted level
+        // is near-silent. A lost row would leave a bounty diverged until the
+        // safety resend, so reliable is the right channel.
+        std::vector<BountyPacket> bountyPkts;
+        EnterCriticalSection(&outCs_);
+        bountyPkts.swap(outBounty_);
+        LeaveCriticalSection(&outCs_);
+        for (size_t i = 0; i < bountyPkts.size(); ++i) {
+            ENetPacket* out = enet_packet_create(&bountyPkts[i], sizeof(BountyPacket),
                                                  ENET_PACKET_FLAG_RELIABLE);
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -113,6 +113,9 @@ public:
     // MAIN thread: queue a reliable host-authoritative known-research row
     // (protocol 38). First-sight sent + safety-resent by the caller.
     void queueResearch(const ResearchPacket& pkt);
+    // MAIN thread: queue a reliable host-authoritative bounty/crime row
+    // (protocol 45). Change-gated + safety-resent by the caller (host only).
+    void queueBounty(const BountyPacket& pkt);
     void queueBuildPlace(const BuildPlacePacket& pkt);
     void queueBuildState(const BuildStatePacket& pkt);
     void queueBuildDoor(const BuildDoorPacket& pkt);
@@ -260,6 +263,8 @@ private:
     std::vector<ProdPacket>      outProd_;
     // Reliable known-research rows (protocol 38). Guarded by outCs_.
     std::vector<ResearchPacket>  outResearch_;
+    // Reliable bounty/crime rows (protocol 45). Guarded by outCs_.
+    std::vector<BountyPacket>    outBounty_;
     std::vector<BuildPlacePacket> outBuildPlace_;
     std::vector<BuildStatePacket> outBuildState_;
     std::vector<BuildDoorPacket>  outBuildDoor_;

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -452,7 +452,7 @@ public:
     void setResearchSync(bool v) { researchSync_ = v; }
 
     // Phase 6c: drive the change-gated SAMPLED channels (faction, doors, placed
-    // buildings, placed-building doors, production, research) from one
+    // buildings, placed-building doors, production, research, bounty) from one
     // channel-descriptor registry. Replaces the per-channel if-blocks the tick
     // used to inline: the table owns each channel's master enable, direction
     // (symmetric vs host-authoritative), and cadence ORDER (which must match the
@@ -461,6 +461,27 @@ public:
     // liveness. Money/recruit/squad/stealth/speed/time stay explicit (different
     // cadence positions / patterns).
     void driveSampledChannels(const SyncContext& ctx);
+
+    // BEFORE engine (protocol 45, HOST only - the witness authority settled by
+    // the H2 live run): enumerate every durable bounty row on the bodies this
+    // engine carries (its driven copies of remote PCs, where a join-owned PC's
+    // bounty lives, PLUS host-owned PCs), diff each (char hand, faction sid)
+    // row's {amount, crimes, claimed} against a silently-seeded shared-save
+    // baseline, and stream change-gated PKT_BOUNTY rows (per-sid safety resend).
+    // The join NEVER calls this (host-authoritative, unidirectional host->clients).
+    // Driven from the kCh[] registry (hostAuth row), like publishResearch.
+    void publishBounties(const SyncContext& ctx);
+
+    // BEFORE engine (protocol 45, client side): drain received bounty rows;
+    // each one that resolves to a local character + faction is applied onto the
+    // owning client's (clean) copy through the engine's own levers
+    // (unfairAddToBounty raise / clearBounty drop). The baseline updates BEFORE
+    // the write (echo-free); stale rows (per-key seq guard) and already-converged
+    // rows are skipped; unresolvable hands skip silently (out of interest).
+    void applyBounties(const SyncContext& ctx);
+
+    // Bounty/crime sync master enable (KENSHICOOP_BOUNTY_SYNC).
+    void setBountySync(bool v) { bountySync_ = v; }
 
     // Storage/machine container sync (protocol 34, KENSHICOOP_STORE_SYNC):
     // when set (HOST only - host-authoritative world containers), a ~1 Hz
@@ -1412,6 +1433,30 @@ private:
     u32           researchSeqOut_;
     unsigned long researchSampleMs_;
     bool          researchSync_;
+    // Protocol 45 bounty/crime rows, keyed by (owning-character hand, faction
+    // sid) - BountyManager is inline per-Character, so the key is per-character,
+    // NOT per-squad. HOST (the only publisher): known = the shared-save baseline
+    // (seeded silently on first sight, updated on every row we send - so a
+    // resend is not re-detected); lastSendMs = change gate + safety resend.
+    // CLIENT: seqSeen = stale-row guard (the client never publishes, so the send
+    // fields stay idle). The value triple mirrors the wire row.
+    struct BountyRow {
+        int knownAmount; u32 knownCrimes; int knownClaimed;
+        unsigned long lastSendMs;
+        u32 seqSeen; bool seeded;
+        BountyRow() : knownAmount(0), knownCrimes(0), knownClaimed(0),
+                      lastSendMs(0), seqSeen(0), seeded(false) {}
+    };
+    std::map<std::pair<Key, std::string>, BountyRow> bountyRows_;
+    u32           bountySeqOut_;
+    unsigned long bountySampleMs_;
+    bool          bountySync_;
+    // False until the first publishBounties sample has seeded every load-time
+    // bounty row as the shared-save baseline. After that, a newly-seen (char,
+    // faction) key is a genuine mid-session appearance (a fresh crime), streamed
+    // from an implicit zero instead of silently re-seeded (a bounty ROW can go
+    // from not-existing to existing, unlike the always-present faction/door rows).
+    bool          bountyBaseline_;
     // Protocol 23 recruitment sync state.
     bool recruitSync_;
     // Ownership PINS (protocols 23 + 35): per-hand overrides layered on the

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -987,6 +987,137 @@ void Replicator::applyResearch(const SyncContext& ctx) {
     }
 }
 
+void Replicator::publishBounties(const SyncContext& ctx) {
+    GameWorld* gw = ctx.gw; NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
+    if (!bountySync_) return;
+    const unsigned long SAMPLE_MS = 1000;  // crimes resolve over seconds; 1 Hz is plenty
+    const unsigned long RESEND_MS = 15000; // safety resend for rows we ever sent
+    unsigned long now = nowMs();
+    if (bountySampleMs_ != 0 && (now - bountySampleMs_) < SAMPLE_MS) return;
+    bountySampleMs_ = now;
+
+    // Snapshot every durable bounty row this engine carries (host-side driven
+    // copies of remote PCs + host-owned PCs - the H2 subject set).
+    const unsigned int MAX_ROWS = 128;
+    static engine::BountyPubRow rows[MAX_ROWS]; // main-thread only
+    unsigned int n = engine::enumBountyRows(gw, rows, MAX_ROWS);
+
+    // Track which (char, faction) keys are live this sample so a row that
+    // VANISHED (host paid off / served the sentence -> clearBounty removed the
+    // map entry, so it no longer enumerates) can stream a one-shot clear.
+    std::set<std::pair<Key, std::string> > seen;
+
+    for (unsigned int i = 0; i < n; ++i) {
+        const engine::BountyPubRow& r = rows[i];
+        Key k; k.t = r.hand[0]; k.c = r.hand[1]; k.cs = r.hand[2];
+        k.i = r.hand[3]; k.s = r.hand[4];
+        std::pair<Key, std::string> key(k, std::string(r.sid));
+        seen.insert(key);
+        BountyRow& br = bountyRows_[key];
+        BountyVal known; known.amount = br.knownAmount;
+        known.crimes = br.knownCrimes; known.claimed = br.knownClaimed;
+        BountyVal cur; cur.amount = r.amount; cur.crimes = r.crimes; cur.claimed = r.claimed;
+        if (!br.seeded) {
+            // Both clients loaded the same save, so a bounty already present at
+            // load is the SHARED baseline: seed silently, stream only movement.
+            br.seeded = true;
+            br.knownAmount = r.amount; br.knownCrimes = r.crimes; br.knownClaimed = r.claimed;
+            continue;
+        }
+        int resendDue = (br.lastSendMs != 0 && (now - br.lastSendMs) >= RESEND_MS) ? 1 : 0;
+        // Host-authoritative publish gate (the exact rule prototest locks): the
+        // host streams a seeded row that moved or is due a resend; a join never
+        // reaches here (Plugin.cpp calls this on the host only).
+        if (!bountyShouldSend(/*isHost*/1, /*seeded*/1, &known, &cur, resendDue)) continue;
+        bool changed = (known.amount != cur.amount) || (known.crimes != cur.crimes) ||
+                       (known.claimed != cur.claimed);
+        br.knownAmount = r.amount; br.knownCrimes = r.crimes; br.knownClaimed = r.claimed;
+        br.lastSendMs = now;
+        BountyPacket pkt;
+        memset(&pkt, 0, sizeof(pkt));
+        pkt.type    = (u8)PKT_BOUNTY;
+        pkt.ownerId = ownerId;
+        pkt.seq     = bountySeqOut_++;
+        for (unsigned int h = 0; h < 5; ++h) pkt.hand[h] = r.hand[h];
+        strncpy(pkt.sid, r.sid, sizeof(pkt.sid) - 1);
+        pkt.sid[sizeof(pkt.sid) - 1] = '\0';
+        pkt.amount  = r.amount;
+        pkt.crimes  = r.crimes;
+        pkt.claimed = (u8)(r.claimed ? 1 : 0);
+        net.queueBounty(pkt);
+        if (changed) { // resends stay silent; the movement is the signal
+            char b[200];
+            _snprintf(b, sizeof(b) - 1,
+                      "[bounty] SEND hand=%u,%u fac='%s' amount=%d crimes=0x%X claimed=%d seq=%u",
+                      r.hand[3], r.hand[4], r.sid, r.amount, r.crimes, r.claimed, pkt.seq);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        }
+    }
+
+    // Disappearance -> clear: a previously-positive seeded row absent from this
+    // sample means the host CLEARED it (paid off / sentence served). Stream one
+    // amount=0 row so the client drops its copy, and reset the baseline to 0 (NOT
+    // erase - if the subject merely went out of interest range and re-appears
+    // still-wanted, the next sample re-detects 0->amount and re-streams it).
+    for (std::map<std::pair<Key, std::string>, BountyRow>::iterator it = bountyRows_.begin();
+         it != bountyRows_.end(); ++it) {
+        BountyRow& br = it->second;
+        if (!br.seeded || br.knownAmount == 0) continue;
+        if (seen.find(it->first) != seen.end()) continue; // still live this sample
+        br.knownAmount = 0; br.knownCrimes = 0; br.knownClaimed = 0;
+        br.lastSendMs = now;
+        const Key& k = it->first.first;
+        BountyPacket pkt;
+        memset(&pkt, 0, sizeof(pkt));
+        pkt.type    = (u8)PKT_BOUNTY;
+        pkt.ownerId = ownerId;
+        pkt.seq     = bountySeqOut_++;
+        pkt.hand[0] = k.t; pkt.hand[1] = k.c; pkt.hand[2] = k.cs;
+        pkt.hand[3] = k.i; pkt.hand[4] = k.s;
+        strncpy(pkt.sid, it->first.second.c_str(), sizeof(pkt.sid) - 1);
+        pkt.sid[sizeof(pkt.sid) - 1] = '\0';
+        pkt.amount = 0; pkt.crimes = 0; pkt.claimed = 0;
+        net.queueBounty(pkt);
+        char b[200];
+        _snprintf(b, sizeof(b) - 1,
+                  "[bounty] SEND-CLEAR hand=%u,%u fac='%s' seq=%u",
+                  k.i, k.s, it->first.second.c_str(), pkt.seq);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
+}
+
+void Replicator::applyBounties(const SyncContext& ctx) {
+    GameWorld* gw = ctx.gw; Inbound& in = *ctx.in;
+    std::deque<InboundBounty> got;
+    in.drainBounty(got);
+    if (got.empty()) return;
+    if (!bountySync_) return;
+    for (std::deque<InboundBounty>::iterator it = got.begin(); it != got.end(); ++it) {
+        const BountyPacket& p = it->pkt;
+        if (p.sid[0] == '\0') continue;
+        Key k; k.t = p.hand[0]; k.c = p.hand[1]; k.cs = p.hand[2];
+        k.i = p.hand[3]; k.s = p.hand[4];
+        std::pair<Key, std::string> key(k, std::string(p.sid));
+        BountyRow& br = bountyRows_[key];
+        if (br.seqSeen != 0 && p.seq <= br.seqSeen) continue; // stale row (bountyApplyDecision SKIP_STALE)
+        br.seqSeen = p.seq;
+        // Echo guard: update the baseline BEFORE the write so the mutation this
+        // apply causes is never re-detected as local movement (the client does
+        // not publish, but the guard keeps the row's known state coherent).
+        br.knownAmount = p.amount; br.knownCrimes = p.crimes;
+        br.knownClaimed = p.claimed ? 1 : 0; br.seeded = true;
+        int before = -1, after = -1;
+        bool ok = engine::applyBountyRow(gw, p.hand, p.sid, p.amount, p.crimes,
+                                         p.claimed ? 1 : 0, &before, &after);
+        char b[224];
+        _snprintf(b, sizeof(b) - 1,
+                  "[bounty] RECV hand=%u,%u fac='%s' amount=%d was=%d now=%d crimes=0x%X ok=%d seq=%u",
+                  p.hand[3], p.hand[4], p.sid, p.amount, before, after,
+                  p.crimes, ok ? 1 : 0, p.seq);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
+}
+
 void Replicator::publishBuilds(const SyncContext& ctx) {
     NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
     if (!buildSync_) return;
@@ -1227,7 +1358,11 @@ void Replicator::driveSampledChannels(const SyncContext& ctx) {
         { &Replicator::buildSync_,    0,                     &Replicator::publishBuilds,     &Replicator::applyBuilds,     false },
         { &Replicator::buildSync_,    &Replicator::bdoorSync_, &Replicator::publishBuildDoors, &Replicator::applyBuildDoors, false },
         { &Replicator::prodSync_,     0,                     &Replicator::publishProd,       &Replicator::applyProd,       true  },
-        { &Replicator::researchSync_, 0,                     &Replicator::publishResearch,   &Replicator::applyResearch,   true  }
+        { &Replicator::researchSync_, 0,                     &Replicator::publishResearch,   &Replicator::applyResearch,   true  },
+        // Bounty/crime (protocol 45): host-authoritative, unidirectional
+        // host->clients (the join NEVER publishes its bounty state) - so hostAuth
+        // = true, exactly like prod/research. After research, as the old tick had.
+        { &Replicator::bountySync_,   0,                     &Replicator::publishBounties,   &Replicator::applyBounties,   true  }
     };
     const int n = (int)(sizeof(kCh) / sizeof(kCh[0]));
     for (int i = 0; i < n; ++i) {

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -1018,11 +1018,23 @@ void Replicator::publishBounties(const SyncContext& ctx) {
         known.crimes = br.knownCrimes; known.claimed = br.knownClaimed;
         BountyVal cur; cur.amount = r.amount; cur.crimes = r.crimes; cur.claimed = r.claimed;
         if (!br.seeded) {
-            // Both clients loaded the same save, so a bounty already present at
-            // load is the SHARED baseline: seed silently, stream only movement.
             br.seeded = true;
-            br.knownAmount = r.amount; br.knownCrimes = r.crimes; br.knownClaimed = r.claimed;
-            continue;
+            if (!bountyBaseline_) {
+                // FIRST channel sample: a bounty already present at (or near) load
+                // is the SHARED baseline (both clients loaded the same save), so
+                // seed it silently and stream only later movement.
+                br.knownAmount = r.amount; br.knownCrimes = r.crimes; br.knownClaimed = r.claimed;
+                continue;
+            }
+            // The baseline pass already ran, so this key APPEARED mid-session -
+            // a crime just created a bounty row where there was none (0 rows -> 1).
+            // That is exactly the movement H2 must carry, NOT a load-time seed:
+            // treat the implicit baseline as zero and fall through to the send
+            // path. (A row that instead existed at load but only now entered
+            // interest range still converges harmlessly - the receiver's apply is
+            // convergence-first against getActualBounty.)
+            br.knownAmount = 0; br.knownCrimes = 0; br.knownClaimed = 0;
+            known.amount = 0; known.crimes = 0; known.claimed = 0;
         }
         int resendDue = (br.lastSendMs != 0 && (now - br.lastSendMs) >= RESEND_MS) ? 1 : 0;
         // Host-authoritative publish gate (the exact rule prototest locks): the
@@ -1084,6 +1096,11 @@ void Replicator::publishBounties(const SyncContext& ctx) {
                   k.i, k.s, it->first.second.c_str(), pkt.seq);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
+
+    // The first sample has now captured every load-time bounty row as the shared
+    // baseline. From here on, a newly-seen (char, faction) key is a genuine
+    // mid-session appearance (a fresh crime), streamed from an implicit zero.
+    bountyBaseline_ = true;
 }
 
 void Replicator::applyBounties(const SyncContext& ctx) {

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -64,6 +64,7 @@ Replicator::Replicator()
       hungerSync_(true),
       prodSeqOut_(1), prodSampleMs_(0), prodSync_(true),
       researchSeqOut_(1), researchSampleMs_(0), researchSync_(true),
+      bountySeqOut_(1), bountySampleMs_(0), bountySync_(true), bountyBaseline_(false),
       storeSync_(false), contCensusMs_(0),
       timeSync_(true), timeSlew_(1.0f), timeSeqOut_(1), timeSeqSeen_(0),
       timeLastSendMs_(0), timeLastLogMs_(0), timeSlewApplied_(-1.0f),

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -102,6 +102,7 @@ static void testSizes() {
     CHECK_EQ("sizeof(NpcCensusHeader)",         sizeof(NpcCensusHeader),         7); // v35: census
     CHECK_EQ("sizeof(ResearchPacket)",          sizeof(ResearchPacket),          57); // v37: research
     CHECK_EQ("sizeof(CamHintPacket)",           sizeof(CamHintPacket),           17); // v43: camera hint
+    CHECK_EQ("sizeof(BountyPacket)",            sizeof(BountyPacket),            86); // v45: bounty/crime row
     // A full entity batch must fit one ~1400 B datagram (NetLink chunking cap).
     CHECK("entity batch fits datagram",
           sizeof(EntityBatchHeader) + ENTITY_BATCH_MAX * sizeof(EntityState) <= 1428);
@@ -207,7 +208,7 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v44: bulk channel + session epoch)", (int)PROTOCOL_VERSION, 44);
+    CHECK_EQ("PROTOCOL_VERSION (v45: bounty/crime / PKT_BOUNTY; v44 was bulk channel + session epoch)", (int)PROTOCOL_VERSION, 45);
 }
 
 // ---- 2. readPacket / packetType round-trips -----------------------------------
@@ -1355,6 +1356,79 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- 13. Bounty/crime authority + convergence (Wire.h pure decision logic) ------
+// Locks the protocol-45 H2 witness-local rules WITHOUT a live engine (the engine
+// read/write shims stay behind SEH in EngineCharState.cpp): the HOST is the sole
+// publisher (a join must NEVER push its own bounty state upstream), and the
+// receiver drops stale rows, skips converged rows, and picks the raise/clear
+// lever by the signed amount delta. These are the exact rules publishBounties /
+// applyBounties + applyBountyRow implement.
+static void testBounty() {
+    std::printf("== bounty/crime authority + convergence (Wire.h) ==\n");
+
+    // Value triples: a clean baseline vs a mid-session bounty.
+    BountyVal clean; clean.amount = 0;   clean.crimes = 0;      clean.claimed = 0;
+    BountyVal wanted; wanted.amount = 500; wanted.crimes = 0x20; wanted.claimed = 0;
+
+    // --- Publish gate: HOST authoritative (H2) ---
+    // Host, seeded, the row MOVED (0 -> 500): publish.
+    CHECK("host publishes a bounty that appeared",
+          bountyShouldSend(/*isHost*/1, /*seeded*/1, &clean, &wanted, /*resendDue*/0) == 1);
+    // Host, seeded, unchanged, no resend due: stay silent.
+    CHECK("host silent on an unchanged row",
+          bountyShouldSend(1, 1, &wanted, &wanted, 0) == 0);
+    // Host, seeded, unchanged, but a safety resend is due: publish.
+    CHECK("host resends an unchanged row when due",
+          bountyShouldSend(1, 1, &wanted, &wanted, 1) == 1);
+    // Host, NOT yet seeded (first sight of a shared-save bounty): silent seed.
+    CHECK("host seeds the shared-save baseline silently",
+          bountyShouldSend(1, 0, &clean, &wanted, 0) == 0);
+
+    // --- The discriminator: a JOIN never publishes (unidirectional host->clients) ---
+    // Even with a genuine local movement, a resend due, and a seeded row, a
+    // non-host caller must produce ZERO upstream traffic. This is the test that
+    // fails if the host-only authority is ever broken.
+    CHECK("join never publishes an appeared bounty",
+          bountyShouldSend(/*isHost*/0, 1, &clean, &wanted, 0) == 0);
+    CHECK("join never publishes even with a resend due",
+          bountyShouldSend(0, 1, &wanted, &wanted, 1) == 0);
+    // Join "revert" attempt: it received the host's 500, then its own engine
+    // reads its (forked, still-clean) copy as 0 and would try to stream that
+    // back. It must NOT - the host stays authoritative.
+    CHECK("join revert to local 0 is never sent upstream",
+          bountyShouldSend(0, 1, &wanted, &clean, 1) == 0);
+
+    // --- Receiver apply decision ---
+    int delta = -12345;
+    // Stale row: incoming seq <= the newest already applied -> drop, no write.
+    CHECK("apply drops a stale seq",
+          bountyApplyDecision(/*seqSeen*/7, /*incoming*/5, 500, 0, &delta) == BOUNTY_APPLY_SKIP_STALE);
+    // Fresh seq, local already at the target -> converged, no write (resend/echo).
+    CHECK("apply skips an already-converged row",
+          bountyApplyDecision(3, 9, 500, 500, &delta) == BOUNTY_APPLY_SKIP_CONVERGED);
+    // Fresh seq, raise 0 -> 500: additive lever, delta = +500.
+    delta = 0;
+    CHECK("apply raises with a positive delta",
+          bountyApplyDecision(3, 9, 500, 0, &delta) == BOUNTY_APPLY_ADD);
+    CHECK("apply raise delta is target-current", delta == 500);
+    // Fresh seq, raise 200 -> 500: delta = +300 (additive keeps engine derived state).
+    delta = 0;
+    CHECK("apply partial raise delta",
+          bountyApplyDecision(3, 9, 500, 200, &delta) == BOUNTY_APPLY_ADD);
+    CHECK("apply partial raise delta value", delta == 300);
+    // Fresh seq, target 0 with a live local bounty: clearBounty, not a delta.
+    delta = 999;
+    CHECK("apply clears when target is zero",
+          bountyApplyDecision(3, 9, 0, 500, &delta) == BOUNTY_APPLY_CLEAR);
+    // seqSeen == 0 (first ever row) must NOT be treated as stale.
+    CHECK("apply accepts the first row (seqSeen 0)",
+          bountyApplyDecision(0, 1, 500, 0, &delta) == BOUNTY_APPLY_ADD);
+
+    // --- Tag / identity ---
+    CHECK("PKT_BOUNTY tag is 42",             PKT_BOUNTY == 42);
+    CHECK("PKT_BOUNTY distinct from CAM_HINT", PKT_BOUNTY != PKT_CAM_HINT);
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1377,6 +1451,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testBounty();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
### What this adds

Bounties/crimes (`Character::crimes`, an inline `BountyManager` member) weren't synced at all — a crime committed by one player was invisible to the other. Determined empirically which side should own this: ran two live 2-client sessions where I had a real crime committed and traced who authored the resulting bounty row. A crime by a host-owned character was inconclusive (owner and witness were the same side). A second session with the crime committed by a JOIN-owned character discriminated cleanly: the host's log showed a persistent bounty row for that character across 186 samples; the join's log showed zero rows for the same hand the whole time. Conclusion: bounty authority is **witness-local** (the host, which simulates the witnessing guards) — the opposite of the faction channel, which is owner-authoritative.

### How

Protocol 45 (`PKT_BOUNTY=42` — note: originally built as protocol 44, but that number was independently claimed by your own `98e48ba` refactor for the bulk-channel/session-epoch work, so I renumbered to the next free slot during rebase). Host publishes bounty rows keyed per-character (matches `BountyManager` being an inline per-`Character` member — confirmed separately that squadmates of a bounty-holder stay clean). Join applies via the same engine levers the game itself uses (`unfairAddToBounty` / `clearBounty`), and never publishes its own side back (strictly one-way, no echo). Registered in the new table-driven channel registry (`kCh[]`) as a `hostAuth` channel, alongside the pattern your refactor already established for prod/research.

### Testing

- Unit: 18 checks, including that the join never publishes an appeared/resent/reverted-to-zero bounty upstream, and that a stale seq gets dropped. Prototest: 439/439.
- Live, 2-client, real crime injected on a join-owned character: `HOST SEND hand=... amount=500 seq=1` -> `JOIN RECV ... was=0 now=500 ok=1`, propagation ~46ms. All RECV lines landed on the correct hand only (0 leaked to squadmates). Join SEND=0, host RECV=0 (confirms one-way). Resends converge without effect. Re-ran this exact repro after rebasing onto your refactor — identical result (same hand, faction, amount, seq progression).
- The original live test caught a real bug the unit tests couldn't: a bounty appearing mid-session (a fresh crime after the world had already loaded) was being silently absorbed into first-sight baseline seeding and never sent. Fixed and reverified live (still holds after rebase).

### What was NOT tested

Bounty expiry/payoff/prison-sentence-served crossing back down to a value of 0 wasn't specifically forced live in this pass — the channel supports it (clears on disappearance) but I didn't stage a full pay-off-the-bounty scenario to watch it end-to-end.