### PR TITLE
Auto-hide the persistent "Connected" status banner after a stable window

### DIFF
--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -30,6 +30,7 @@
 #include "core/Config.h"
 #include "core/OwnRanks.h"
 #include "core/Inbound.h"
+#include "core/StatusAutohide.h" // persistent status-banner auto-hide policy
 #include "net/NetLink.h"
 #include "net/SteamP2P.h"
 #include "net/SteamInvite.h"
@@ -745,7 +746,31 @@ void coopPanelDrive(GameWorld* gw) {
     coop::steaminvite::tick();
 
     coop::engine::coopPanelTick(&ps, &coopUiConnect, &coopUiDisconnect);
-    coop::engine::coopOverlayTick(gw, detail.c_str(), ostate, g_net.isRunning());
+
+    // Auto-hide the persistent status banner once it has sat in the connected
+    // ("green", ostate == 2) state for a sustained window, so a stable session stops
+    // showing "Connected - peer joined" forever. Leaving green (peer disconnects,
+    // session drops, or a reconnect cycles back through the waiting state) reappears
+    // the banner instantly and re-arms the timer when green settles again. The
+    // decision lives in the pure, unit-tested StatusAutohide.h; here we just own the
+    // clock + the green-streak start tick. KENSHICOOP_STATUS_AUTOHIDE_MS overrides the
+    // 10 s default; 0 disables it (banner stays up = the pre-autohide behavior).
+    static int          s_autohideMs = -1;    // ms; -1 = unread, 0 = disabled
+    static unsigned long s_greenSince = 0;    // tick the green state began (0 = not green)
+    if (s_autohideMs < 0) {                   // read the env override once (matches autoRecruit)
+        const char* e = std::getenv("KENSHICOOP_STATUS_AUTOHIDE_MS");
+        s_autohideMs = e ? std::atoi(e) : (int)coop::STATUS_AUTOHIDE_MS;
+        if (s_autohideMs < 0) s_autohideMs = 0; // clamp junk negatives to "disabled"
+    }
+    unsigned long nowMs = GetTickCount();
+    if (ostate == 2) {                        // connected/green
+        if (s_greenSince == 0) s_greenSince = nowMs; // arm on the rising edge into green
+    } else {
+        s_greenSince = 0;                     // left green: disarm so the banner reappears
+    }
+    bool showBanner = coop::statusOverlayShown(g_net.isRunning(), s_greenSince,
+                                               nowMs, (unsigned long)s_autohideMs);
+    coop::engine::coopOverlayTick(gw, detail.c_str(), ostate, showBanner);
 }
 
 // Main-thread tick hook: the one safe point where we touch game state.

--- a/src/plugin/core/StatusAutohide.h
+++ b/src/plugin/core/StatusAutohide.h
@@ -1,0 +1,57 @@
+// StatusAutohide.h - auto-hide policy for the persistent co-op status banner
+// (pure, zero game/Win32 deps; unit-tested in prototest).
+//
+// The green "Connected - peer joined" banner (coopOverlayTick) floats over the
+// local leader for the WHOLE session. Once the session has held that settled,
+// fully-connected ("green") state continuously for a while, the banner has served
+// its purpose and should fade out so it stops cluttering the screen. If the state
+// later leaves green (the peer disconnects, the session drops, or it cycles back
+// through the "waiting/connecting" state on a reconnect) the banner reappears
+// immediately, and the timer re-arms once the green state settles again.
+//
+// This header holds ONLY the time/state decision so it can be unit-tested without a
+// game or GUI. The caller (Plugin.cpp coopPanelDrive) owns the millisecond clock
+// (GetTickCount) and the show/hide plumbing (coopOverlayTick's show flag). Same
+// unsigned-tick, wrap-safe shape as WorkPose.h's poseClearElapsed.
+//
+// Used by:
+//   * Plugin.cpp coopPanelDrive - gates the overlay 'show' flag
+//   * prototest                 - the no-game unit layer
+
+#ifndef COOP_STATUS_AUTOHIDE_H
+#define COOP_STATUS_AUTOHIDE_H
+
+namespace coop {
+
+// Default auto-hide delay (ms) for the connected/green status banner. Mirrors the
+// KENSHICOOP_STATUS_AUTOHIDE_MS default; 0 disables auto-hide entirely (banner stays
+// up for the whole session = the pre-autohide behavior).
+static const unsigned long STATUS_AUTOHIDE_MS = 10000;
+
+// True once the banner has sat in the settled "green" (fully connected) state long
+// enough to auto-hide. 'stableSinceMs' is the tick the green state began (0 = NOT
+// green right now, so never auto-hidden). 'autohideMs' == 0 disables the feature
+// (always returns false = keep showing). Unsigned tick math matches the engine's
+// millisecond clock, so a GetTickCount wrap across the window still yields the true
+// elapsed delta (see WorkPose.h poseClearElapsed for the same idiom).
+inline bool statusAutohideElapsed(unsigned long stableSinceMs, unsigned long now,
+                                  unsigned long autohideMs) {
+    if (autohideMs == 0) return false;    // feature off: banner never auto-hides
+    if (stableSinceMs == 0) return false; // not in the green state: keep showing
+    return (now - stableSinceMs) >= autohideMs;
+}
+
+// Whether the persistent status banner should be VISIBLE this tick, given the live
+// session flags and the auto-hide timer. 'running' == false hides it (no session).
+// While running, the banner shows UNLESS it has auto-hidden after a sustained green
+// streak. Only the green state arms 'stableSinceMs', so a running-but-not-green
+// state (waiting/connecting, stableSinceMs == 0) always shows.
+inline bool statusOverlayShown(bool running, unsigned long stableSinceMs,
+                               unsigned long now, unsigned long autohideMs) {
+    if (!running) return false;
+    return !statusAutohideElapsed(stableSinceMs, now, autohideMs);
+}
+
+} // namespace coop
+
+#endif // COOP_STATUS_AUTOHIDE_H

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -34,6 +34,7 @@
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
+#include "../plugin/core/StatusAutohide.h" // status-banner auto-hide policy (pure inline)
 
 #include <set>
 
@@ -1355,6 +1356,46 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- 13. Persistent status-banner auto-hide (StatusAutohide.h) ------------------
+// Guards the QoL auto-hide (2026-07-20): the green "Connected - peer joined" banner
+// floats over the leader for the whole session. Once the session has held the
+// connected/green state for a sustained window it auto-hides so it stops cluttering
+// the screen; leaving green (disconnect / peer leave / reconnect) reappears it
+// immediately and re-arms the timer. Same unsigned-wrap-safe shape as poseClearElapsed.
+static void testStatusAutohide() {
+    std::printf("== status banner auto-hide (StatusAutohide.h) ==\n");
+    const unsigned long ms = STATUS_AUTOHIDE_MS; // 10000 (default)
+
+    // Not green (stableSince == 0): never auto-hidden, banner keeps showing.
+    CHECK("not green never auto-hides",  !statusAutohideElapsed(0, 999999, ms));
+
+    // Green but still inside the window: banner holds (no premature hide).
+    CHECK("green 0 ms holds",            !statusAutohideElapsed(5000, 5000,  ms));
+    CHECK("green 9999 ms holds",         !statusAutohideElapsed(5000, 14999, ms));
+
+    // Green at/after the window: banner auto-hides.
+    CHECK("green 10000 ms hides",         statusAutohideElapsed(5000, 15000, ms));
+    CHECK("green 30 s hides",             statusAutohideElapsed(5000, 35000, ms));
+
+    // autohideMs == 0 disables the feature (banner never auto-hides).
+    CHECK("disabled never hides",        !statusAutohideElapsed(5000, 999999, 0));
+
+    // Unsigned GetTickCount wrap across the window still elapses correctly: the green
+    // streak started 100 ms before the 2^32 rollover; 'now' is written post-wrapped.
+    const unsigned long nearMax  = 0xFFFFFFFFul - 100; // green began 100 ms before wrap
+    const unsigned long preWrap  = nearMax + 50;       // 50 ms later, pre-wrap (holds)
+    const unsigned long postWrap = 9899UL;             // (nearMax + 10000) mod 2^32 = 10000 ms later
+    CHECK("wrap: 50 ms holds",           !statusAutohideElapsed(nearMax, preWrap,  ms));
+    CHECK("wrap: 10 s hides",             statusAutohideElapsed(nearMax, postWrap, ms));
+
+    // statusOverlayShown combiner: running gate + auto-hide decision together.
+    CHECK("offline never shows",         !statusOverlayShown(false, 0,    100,   ms));
+    CHECK("green fresh shows",            statusOverlayShown(true,  5000, 5000,  ms));
+    CHECK("green stale hides",           !statusOverlayShown(true,  5000, 20000, ms));
+    CHECK("running non-green shows",      statusOverlayShown(true,  0,    99999, ms)); // waiting
+    CHECK("disabled stays shown",         statusOverlayShown(true,  5000, 99999, 0));
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1377,6 +1418,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testStatusAutohide();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
### What this fixes

The connection-status overlay ("Connected - peer joined", green) stays on screen forever once connected — useful at first, clutter after. It now auto-hides after a stable window in the green state, and reappears instantly the moment the state leaves green (drop, reconnect), re-hiding again after the same window if it settles back to green.

### How

`StatusAutohide.h` (pure, wrap-safe timer): arms on entering green, disarms/reshows instantly on leaving green. Configurable via `KENSHICOOP_STATUS_AUTOHIDE_MS` (default 10000; 0 disables it, restoring the old always-on behavior). The overlay itself now lives in your new `EngineUi.cpp` after the modularization — this fix's call site follows it there.

### Testing

- Unit: prototest 434/434.
- Live, host side, 2 full cycles (re-run after rebasing onto your refactor): banner appears green on connect, auto-hides at the configured ~10s window, reappears instantly (yellow "Hosting - waiting for peer...") when the join process was killed, and re-hides on reconnect. Screenshots + timestamps both times.

### What was NOT tested

Only the host side got full live visual confirmation — the join side runs the identical logic, but the join in my test sessions didn't get past the main menu into gameplay for an unrelated harness reason (a save-loading quirk, not a bug in this feature), so its own "Connected to host" overlay wasn't visually confirmed separately.