### PR TITLE
Show the peer's real Steam name over their controlled bodies (with an F2 toggle to hide it)

### DIFF
--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -744,6 +744,18 @@ void coopPanelDrive(GameWorld* gw) {
     // US) can fire coopUiConnect; the outbound invite/picker UI is gone.
     coop::steaminvite::tick();
 
+    // Remote-player nametag: resolve the co-op peer's Steam persona name and push
+    // it to the replicator so DRV (host-driven = remote-controlled) bodies show
+    // WHOSE unit it is under KENSHICOOP_DEBUG_MARKERS. Steam transport only - a
+    // LAN/UDP session has no SteamID, so the label keeps its "DRV <charName>"
+    // fallback. personaName() caches and resolves asynchronously via the pump
+    // above, so this is cheap to call every tick and self-heals once info lands.
+    unsigned long long nametagPeer = (unsigned long long)coop::steamp2p::peerId();
+    if (nametagPeer == 0) nametagPeer = g_cfg.steamPeer;
+    const char* peerPersona = (g_cfg.transport == "steam" && nametagPeer != 0)
+        ? coop::steaminvite::personaName(nametagPeer) : "";
+    g_repl.setRemoteName(peerPersona);
+
     coop::engine::coopPanelTick(&ps, &coopUiConnect, &coopUiDisconnect);
     coop::engine::coopOverlayTick(gw, detail.c_str(), ostate, g_net.isRunning());
 }

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -186,6 +186,7 @@ void (*g_titleUpdate_orig)(TitleScreen*)   = 0;
 void startNetworking();
 void coopUiConnect(bool isHost, bool useSteam, unsigned long long peerId);
 void coopUiDisconnect();
+void coopUiToggleNametag(bool show);
 
 // Log to BOTH our dedicated per-line-flushed file (what the test runner reads)
 // and the engine's kenshi.log (handy when attached live).
@@ -727,6 +728,7 @@ void coopPanelDrive(GameWorld* gw) {
     ps.peerPresent  = g_peerPresent;
     ps.isHost       = g_cfg.isHost;
     ps.transportSel = (g_cfg.transport == "steam") ? 0 : 1;
+    ps.showNametag  = g_cfg.showRemoteNametag;
     std::string detail;
     int ostate;
     if (g_peerPresent) {
@@ -745,18 +747,23 @@ void coopPanelDrive(GameWorld* gw) {
     coop::steaminvite::tick();
 
     // Remote-player nametag: resolve the co-op peer's Steam persona name and push
-    // it to the replicator so DRV (host-driven = remote-controlled) bodies show
-    // WHOSE unit it is under KENSHICOOP_DEBUG_MARKERS. Steam transport only - a
-    // LAN/UDP session has no SteamID, so the label keeps its "DRV <charName>"
-    // fallback. personaName() caches and resolves asynchronously via the pump
-    // above, so this is cheap to call every tick and self-heals once info lands.
+    // it to the replicator so the peer's own driven bodies show WHOSE unit it is.
+    // Shown in NORMAL play now (the F2 "Show player names" toggle / showRemoteNametag
+    // config gates it), no longer only under KENSHICOOP_DEBUG_MARKERS. Steam
+    // transport only - a LAN/UDP session has no SteamID, so the label falls back to
+    // "[Remote Player]". personaName() caches and resolves asynchronously via the
+    // pump above, so this is cheap every tick and self-heals once info lands.
     unsigned long long nametagPeer = (unsigned long long)coop::steamp2p::peerId();
     if (nametagPeer == 0) nametagPeer = g_cfg.steamPeer;
     const char* peerPersona = (g_cfg.transport == "steam" && nametagPeer != 0)
         ? coop::steaminvite::personaName(nametagPeer) : "";
     g_repl.setRemoteName(peerPersona);
+    // Push the visibility toggle each tick (the F2 button writes g_cfg via
+    // coopUiToggleNametag; the Replicator shows/hides the labels next tick).
+    g_repl.setShowNametag(g_cfg.showRemoteNametag);
 
-    coop::engine::coopPanelTick(&ps, &coopUiConnect, &coopUiDisconnect);
+    coop::engine::coopPanelTick(&ps, &coopUiConnect, &coopUiDisconnect,
+                                &coopUiToggleNametag);
     coop::engine::coopOverlayTick(gw, detail.c_str(), ostate, g_net.isRunning());
 }
 
@@ -1658,6 +1665,16 @@ void coopUiDisconnect() {
     // World stays live on a manual disconnect: despawn minted proxies before
     // clearing maps so nothing lingers as a duplicate or gets baked into a save.
     sessionResetForUi();
+}
+
+// F2 "Show player names" toggle -> flip the live config. Runtime-only: this is
+// NOT written back to coop_config.json (the whole panel is session-state, same as
+// the Role/Transport/pasted-peer choices). The Replicator reads showRemoteNametag
+// each tick via setShowNametag, so the change is immediate (no reconnect).
+void coopUiToggleNametag(bool show) {
+    g_cfg.showRemoteNametag = show;
+    coopLog(show ? "[coop-ui] show player names -> ON"
+                 : "[coop-ui] show player names -> OFF");
 }
 
 } // namespace

--- a/src/plugin/core/Config.cpp
+++ b/src/plugin/core/Config.cpp
@@ -231,6 +231,12 @@ void loadConfig(Config& c) {
     c.prodSync    = envOr("KENSHICOOP_PROD_SYNC", "1") != "0";
     c.researchSync = envOr("KENSHICOOP_RESEARCH_SYNC", "1") != "0";
     c.storeSync   = envOr("KENSHICOOP_STORE_SYNC", "1") != "0";
+
+    // Remote-player nametag: normal-play name label over the peer's driven
+    // bodies. DEFAULT ON (Zero wants it visible by default); the F2 panel
+    // "Show player names" toggle flips it live. "0" starts hidden.
+    c.showRemoteNametag = envOr("KENSHICOOP_SHOW_NAMETAG", "1") != "0";
+
     c.squadSync   = envOr("KENSHICOOP_SQUAD_SYNC", "1") != "0";
     c.latejoinSync = envOr("KENSHICOOP_LATEJOIN_SYNC", "1") != "0";
     // NOTE: every channel above DEFAULTS ON for real sessions; the diagnostic

--- a/src/plugin/core/Config.h
+++ b/src/plugin/core/Config.h
@@ -448,6 +448,15 @@ struct Config {
     // the A/B escape hatch.
     bool          squadSync;
 
+    // KENSHICOOP_SHOW_NAMETAG (default ON): floating name label over the OTHER
+    // player's characters (the bodies the host stream DRIVES on this client).
+    // Shows the peer's Steam persona name when known, else "[Remote Player]".
+    // This is a normal-play HUD element (NOT the KENSHICOOP_DEBUG_MARKERS
+    // diagnostic overlay); the F2 panel toggles it live via setShowNametag.
+    // "0" hides it. Runtime-only: the F2 toggle changes the in-memory value,
+    // it is not written back to coop_config.json.
+    bool          showRemoteNametag;
+
     // KENSHICOOP_LATEJOIN_SYNC (default ON): late-join/reconnect resync
     // (protocol 30, no wire change) - on the peer-connect edge the
     // Replicator re-announces every live placed-building PLACE (+ REMOVE

--- a/src/plugin/core/Nametag.h
+++ b/src/plugin/core/Nametag.h
@@ -1,0 +1,67 @@
+// Nametag.h - pure caption builder for the remote-player body nametag.
+//
+// The co-op debug-marker HUD (KENSHICOOP_DEBUG_MARKERS) pins a text label to
+// every body the host stream DRIVES on this client - i.e. the OTHER player's
+// characters. By default that label read "DRV <charName>" (the in-game name of
+// the proxy), which does not tell you WHOSE unit it is. This helper turns that
+// label into the remote player's Steam persona name so you can see at a glance
+// which bodies your friend is controlling.
+//
+// The logic here is deliberately pure (no game / Steam / Win32 deps) so it can
+// be unit-tested in prototest. The caller (Replicator::debugMark) resolves the
+// Steam persona name elsewhere and passes it in; this function only decides the
+// final caption text and applies the honest fallback chain:
+//   1. a real persona name (peer is a Steam friend / info already resolved)
+//   2. the fallback string (the old "DRV <charName>" form) when Steam can't
+//      give us a name (peer not a friend yet, LAN/UDP transport, API down)
+//   3. a generic "[Remote Player]" if even the fallback is empty.
+
+#ifndef COOP_NAMETAG_H
+#define COOP_NAMETAG_H
+
+#include <string>
+
+namespace coop {
+
+// Max caption length we emit (the marker caption buffer is 64 bytes; leave room
+// for the terminator).
+const size_t COOP_NAMETAG_MAX = 63;
+
+// Trim ASCII spaces/tabs/CR/LF from both ends of s. Pure helper.
+inline std::string coopTrim(const std::string& s) {
+    size_t b = 0, e = s.size();
+    while (b < e && (s[b] == ' ' || s[b] == '\t' || s[b] == '\r' || s[b] == '\n')) ++b;
+    while (e > b && (s[e - 1] == ' ' || s[e - 1] == '\t' || s[e - 1] == '\r' || s[e - 1] == '\n')) --e;
+    return s.substr(b, e - b);
+}
+
+// True when 'persona' is a usable Steam persona name: non-null, has non-blank
+// content, and is not Steam's "[unknown]" placeholder (returned by
+// GetFriendPersonaName before RequestUserInformation has resolved a non-friend).
+inline bool coopPersonaValid(const char* persona) {
+    if (!persona) return false;
+    std::string t = coopTrim(persona);
+    if (t.empty()) return false;
+    if (t == "[unknown]") return false;
+    return true;
+}
+
+// Build the final nametag caption from a (maybe-invalid) Steam persona name and
+// a fallback caption. Applies the fallback chain described in the file header
+// and caps the result to COOP_NAMETAG_MAX. Pure - safe to unit-test.
+inline std::string remoteNametagCaption(const char* persona, const char* fallback) {
+    std::string out;
+    if (coopPersonaValid(persona)) {
+        out = coopTrim(persona);
+    } else if (fallback && fallback[0] != '\0') {
+        out = fallback;
+    } else {
+        out = "[Remote Player]";
+    }
+    if (out.size() > COOP_NAMETAG_MAX) out.resize(COOP_NAMETAG_MAX);
+    return out;
+}
+
+} // namespace coop
+
+#endif // COOP_NAMETAG_H

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -273,8 +273,9 @@ void  markerDestroy(void* label);
 
 // ---- In-game co-op session panel ---------------------------------------------
 // Moved to EngineUi.h (Phase 5a domain split): CoopPanelState, CoopConnectFn,
-// CoopDisconnectFn, coopPanelTick, coopOverlayTick. The UI root (Plugin.cpp)
-// includes EngineUi.h directly; the adapter (EngineInternal.h) re-includes it.
+// CoopDisconnectFn, CoopNametagToggleFn, coopPanelTick, coopOverlayTick. The UI
+// root (Plugin.cpp) includes EngineUi.h directly; the adapter (EngineInternal.h)
+// re-includes it.
 
 // ---- Deterministic test-scene setup (host-side; baked into a save) ---------
 // Moved to EngineScenario.h (Phase 5a domain split): spawnSeatInFront,

--- a/src/plugin/game/EngineUi.cpp
+++ b/src/plugin/game/EngineUi.cpp
@@ -43,6 +43,7 @@ void markerColour(int colorId, MyGUI::Colour* col) {
     case 0:  *col = MyGUI::Colour(0.30f, 1.00f, 0.30f, 1.0f); break; // driven
     case 1:  *col = MyGUI::Colour(1.00f, 0.25f, 0.25f, 1.0f); break; // hidden
     case 2:  *col = MyGUI::Colour(1.00f, 0.90f, 0.25f, 1.0f); break; // local-only
+    case 4:  *col = MyGUI::Colour(0.55f, 0.85f, 1.00f, 1.0f); break; // player nametag (cyan)
     default: *col = MyGUI::Colour(0.80f, 0.80f, 0.80f, 1.0f); break;
     }
 }
@@ -193,12 +194,15 @@ struct CoopPanelUi {
     bool          connectedFlag; // desired connection state (Online/Offline toggle)
     bool          lastConnected; // last observed st->running (external-change sync)
     bool          lastChkVal;    // last toggle value (connect/disconnect edge)
+    bool          nametagFlag;   // desired "Show player names" state
+    bool          lastNametagVal;// last nametag value (toggle edge -> onToggleNametag)
     bool          needsRebuild;
     bool          f2Down;        // F2 held last tick (rising-edge toggle)
     std::string   lastStatus;    // last status text shown (refresh gate)
     CoopPanelUi()
         : panel(0), open(false), built(false), hostFlag(true), steamFlag(true),
           connectedFlag(false), lastConnected(false), lastChkVal(false),
+          nametagFlag(true), lastNametagVal(true),
           needsRebuild(false), f2Down(false) {}
 };
 
@@ -206,6 +210,7 @@ CoopPanelUi             g_panel;
 DataPanelLine_Button*   g_roleBtn      = 0;
 DataPanelLine_Button*   g_transBtn     = 0;
 DataPanelLine_Button*   g_connBtn      = 0; // Online/Offline toggle (replaces the checkbox)
+DataPanelLine_Button*   g_nametagBtn   = 0; // "Show player names" ON/OFF toggle
 DataPanelLine_Button*   g_copyIdBtn    = 0;
 DataPanelLine_Button*   g_pasteIdBtn   = 0; // "Paste friend's Steam ID" from clipboard
 DataPanelLine*          g_debugLine    = 0; // white connection-status debug row
@@ -240,6 +245,16 @@ void onConnBtn(DataPanelLine*) {
     g_panel.needsRebuild = true;
     coop::logLine(g_panel.connectedFlag ? "[coop-ui] connection -> ONLINE"
                                         : "[coop-ui] connection -> OFFLINE");
+}
+// "Show player names" toggle: flip the desired nametag state. The edge
+// (nametagFlag vs lastNametagVal) is applied in coopPanelTick, which calls the
+// onToggleNametag callback so the plugin updates the live config (the Replicator
+// then shows/hides the floating names next tick - no reconnect needed).
+void onNametagBtn(DataPanelLine*) {
+    g_panel.nametagFlag = !g_panel.nametagFlag;
+    g_panel.needsRebuild = true;
+    coop::logLine(g_panel.nametagFlag ? "[coop-ui] nametags -> ON"
+                                      : "[coop-ui] nametags -> OFF");
 }
 // Copy the player's own SteamID to the clipboard so they can paste it to a friend
 // (who pastes it into their panel via "Paste friend's Steam ID").
@@ -280,6 +295,7 @@ void onPasteIdBtn(DataPanelLine*) {
 struct PanelStrings {
     const std::string *title, *roleKey, *roleCap, *transKey, *transCap;
     const std::string *connKey, *connCap;
+    const std::string *nametagKey, *nametagCap;
     const std::string *dbgKey, *dbgVal;
     const std::string *peerKey, *peerVal, *pasteKey, *pasteCap;
     const std::string *selfKey, *selfVal, *copyKey, *copyCap;
@@ -293,6 +309,9 @@ void panelBuildSeh(DatapanelGUI* p, const PanelStrings* s) {
         g_roleBtn  = p->setLineButton(*s->roleKey,  *s->roleCap,  0);
         g_transBtn = p->setLineButton(*s->transKey, *s->transCap, 0);
         g_connBtn  = p->setLineButton(*s->connKey,  *s->connCap,  0);
+        // "Show player names" toggle: floating Steam-name labels over the peer's
+        // characters in normal play (independent of the debug-marker overlay).
+        g_nametagBtn = p->setLineButton(*s->nametagKey, *s->nametagCap, 0);
         p->addSpace(0, 0.35f);
         // Connection-status debug line (coloured white below, outside SEH).
         g_debugLine = p->setLine(*s->dbgKey, *s->dbgVal, *s->empty, 0, false, true);
@@ -345,7 +364,8 @@ void panelDestroySeh(ForgottenGUI* g, DatapanelGUI* p) {
 } // namespace
 
 void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
-                   CoopDisconnectFn onDisconnect) {
+                   CoopDisconnectFn onDisconnect,
+                   CoopNametagToggleFn onToggleNametag) {
     if (!st) return;
     ForgottenGUI* g = ::gui; // KenshiLib data export (spike 46)
     { static void* s_last = (void*)-1;
@@ -373,6 +393,8 @@ void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
             g_panel.connectedFlag = st->running;
             g_panel.lastConnected = st->running;
             g_panel.lastChkVal    = st->running;
+            g_panel.nametagFlag    = st->showNametag;
+            g_panel.lastNametagVal = st->showNametag;
             g_panel.open = true;
             g_panel.needsRebuild = true;
             coop::logLine("[coop-ui] panel opened");
@@ -380,7 +402,7 @@ void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
             panelDestroySeh(g, g_panel.panel);
             g_panel.panel = 0; g_panel.built = false;
             g_roleBtn = 0; g_transBtn = 0; g_connBtn = 0; g_copyIdBtn = 0;
-            g_pasteIdBtn = 0;
+            g_nametagBtn = 0; g_pasteIdBtn = 0;
             g_debugLine = 0; g_peerLine = 0; g_selfLine = 0;
             g_panel.open = false;
             coop::logLine("[coop-ui] panel closed");
@@ -428,6 +450,8 @@ void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
         std::string transCap = std::string("Transport: ") + (g_panel.steamFlag ? "STEAM" : "UDP") + "    (switch)";
         std::string connKey  = "conn";
         std::string connCap  = std::string("Connection: ") + (g_panel.connectedFlag ? "ONLINE" : "OFFLINE") + "    (switch)";
+        std::string nametagKey = "nametag";
+        std::string nametagCap = std::string("Show player names: ") + (g_panel.nametagFlag ? "ON" : "OFF") + "    (switch)";
 
         // White debug line: describes the live connection state + type. Reflects
         // the ACTUAL running session when online; the armed toggles when offline.
@@ -483,6 +507,7 @@ void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
         ps.title = &title; ps.roleKey = &roleKey; ps.roleCap = &roleCap;
         ps.transKey = &transKey; ps.transCap = &transCap;
         ps.connKey = &connKey; ps.connCap = &connCap;
+        ps.nametagKey = &nametagKey; ps.nametagCap = &nametagCap;
         ps.dbgKey = &dbgKey; ps.dbgVal = &dbgVal;
         ps.peerKey = &peerKey; ps.peerVal = &peerVal;
         ps.pasteKey = &pasteKey; ps.pasteCap = &pasteCap;
@@ -497,6 +522,7 @@ void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
         if (g_roleBtn)    g_roleBtn->callback    = MyGUI::newDelegate(&onRoleBtn);
         if (g_transBtn)   g_transBtn->callback   = MyGUI::newDelegate(&onTransBtn);
         if (g_connBtn)    g_connBtn->callback    = MyGUI::newDelegate(&onConnBtn);
+        if (g_nametagBtn) g_nametagBtn->callback = MyGUI::newDelegate(&onNametagBtn);
         if (g_copyIdBtn)  g_copyIdBtn->callback  = MyGUI::newDelegate(&onCopyIdBtn);
         if (g_pasteIdBtn) g_pasteIdBtn->callback = MyGUI::newDelegate(&onPasteIdBtn);
         dbgColourSeh(g_debugLine);
@@ -526,6 +552,14 @@ void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
             coop::logLine("[coop-ui] DISCONNECT requested");
             if (onDisconnect) onDisconnect();
         }
+    }
+
+    // "Show player names" toggle edge (edge, not level): push the new state to the
+    // plugin so it updates the live config. Applies whether online or offline - the
+    // Replicator shows/hides the floating names on its next tick, no reconnect.
+    if (g_panel.nametagFlag != g_panel.lastNametagVal) {
+        g_panel.lastNametagVal = g_panel.nametagFlag;
+        if (onToggleNametag) onToggleNametag(g_panel.nametagFlag);
     }
 }
 

--- a/src/plugin/game/EngineUi.h
+++ b/src/plugin/game/EngineUi.h
@@ -34,14 +34,20 @@ struct CoopPanelState {
     bool               isHost;      // current armed role (seeds the Host toggle)
     int                transportSel;// current armed transport (0 steam, 1 udp)
     const char*        detail;      // one-line status string for the panel/overlay
+    bool               showNametag; // current "Show player names" state (seeds the toggle)
 };
 // The panel's role/transport selections at the moment Connect is hit. peerId is the
 // Steam ID pasted in-panel this session (0 if none), and overrides the config
 // steamPeer in coopUiConnect; the UDP endpoint is re-read from the config there.
 typedef void (*CoopConnectFn)(bool isHost, bool useSteam, unsigned long long peerId);
 typedef void (*CoopDisconnectFn)();
+// Fired when the "Show player names" panel button is toggled. 'show' is the new
+// desired state; the plugin writes it into the live config (Replicator picks it
+// up next tick via setShowNametag). Runtime-only (not persisted to disk).
+typedef void (*CoopNametagToggleFn)(bool show);
 void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
-                   CoopDisconnectFn onDisconnect);
+                   CoopDisconnectFn onDisconnect,
+                   CoopNametagToggleFn onToggleNametag);
 
 // Persistent co-op connection-status overlay: a single ScreenLabel tracked to the
 // local leader (the spike-47/48 screenshot-proven render path) whose caption shows

--- a/src/plugin/net/SteamInvite.cpp
+++ b/src/plugin/net/SteamInvite.cpp
@@ -87,6 +87,9 @@ typedef int   (*FrGetCountFn)(void* friends, int eFriendFlags);
 typedef unsigned long long (*FrGetByIndexFn)(void* friends, int i, int eFriendFlags);
 typedef const char* (*FrGetNameFn)(void* friends, unsigned long long id);
 typedef int   (*FrGetStateFn)(void* friends, unsigned long long id);
+// RequestUserInformation(steamID, bRequireNameOnly): asks Steam to download a
+// non-friend's persona info so GetFriendPersonaName stops returning "[unknown]".
+typedef bool  (*FrReqUserInfoFn)(void* friends, unsigned long long id, bool nameOnly);
 
 #pragma pack(push, 8)
 struct FriendGameInfo_t {
@@ -122,6 +125,7 @@ FrGetByIndexFn        g_frByIndex   = 0;
 FrGetNameFn           g_frName      = 0;
 FrGetStateFn          g_frState     = 0;
 FrGetGamePlayedFn     g_frGame      = 0;
+FrReqUserInfoFn       g_frReqInfo   = 0; // optional (older DLLs may lack it)
 RegisterCbFn          g_regCb       = 0;
 RegisterCrFn          g_regCr       = 0;
 UnregisterCbFn        g_unregCb     = 0;
@@ -359,6 +363,7 @@ bool init(ConnectFn onConnect) {
     g_frName      = (FrGetNameFn)          GetProcAddress(mod, "SteamAPI_ISteamFriends_GetFriendPersonaName");
     g_frState     = (FrGetStateFn)         GetProcAddress(mod, "SteamAPI_ISteamFriends_GetFriendPersonaState");
     g_frGame      = (FrGetGamePlayedFn)    GetProcAddress(mod, "SteamAPI_ISteamFriends_GetFriendGamePlayed");
+    g_frReqInfo   = (FrReqUserInfoFn)      GetProcAddress(mod, "SteamAPI_ISteamFriends_RequestUserInformation");
     g_regCb       = (RegisterCbFn)         GetProcAddress(mod, "SteamAPI_RegisterCallback");
     g_regCr       = (RegisterCrFn)         GetProcAddress(mod, "SteamAPI_RegisterCallResult");
     g_unregCb     = (UnregisterCbFn)       GetProcAddress(mod, "SteamAPI_UnregisterCallback");
@@ -461,6 +466,47 @@ int  friendCount()             { return g_friendN; }
 SteamId friendId(int i)        { return (i >= 0 && i < g_friendN) ? g_friendRows[i].id : 0; }
 const char* friendName(int i)  { return (i >= 0 && i < g_friendN) ? g_friendRows[i].name : ""; }
 int  friendState(int i)        { return (i >= 0 && i < g_friendN) ? g_friendRows[i].state : 0; }
+
+namespace {
+// Tiny persona-name cache. GetFriendPersonaName hands back a Steam-owned pointer
+// only valid until its next call, so we copy the name into our own storage.
+// A handful of slots is plenty (a co-op session has one peer; reconnects to a
+// different friend reuse the oldest slot). "resolved" flags that Steam gave us a
+// real name (not "[unknown]") so we stop re-requesting.
+struct PersonaRow { unsigned long long id; char name[64]; bool resolved; };
+const int   MAX_PERSONA = 4;
+PersonaRow  g_personaRows[MAX_PERSONA] = {{0,{0},false}};
+int         g_personaNext = 0;
+
+// Find the cache slot for 'id', or claim/reuse one (round-robin) if absent.
+PersonaRow& personaSlot(unsigned long long id) {
+    for (int i = 0; i < MAX_PERSONA; ++i)
+        if (g_personaRows[i].id == id) return g_personaRows[i];
+    PersonaRow& row = g_personaRows[g_personaNext];
+    g_personaNext = (g_personaNext + 1) % MAX_PERSONA;
+    row.id = id; row.name[0] = '\0'; row.resolved = false;
+    return row;
+}
+} // namespace
+
+const char* personaName(SteamId id) {
+    if (!g_ready || !g_frName || !g_friends || id == 0) return "";
+    PersonaRow& row = personaSlot(id);
+    // Already resolved to a real name: return the cached copy.
+    if (row.resolved) return row.name;
+
+    // Ask Steam for the current name. Non-friends read "[unknown]" until their
+    // info downloads, so kick off RequestUserInformation and try again later.
+    const char* nm = g_frName(g_friends, id);
+    if (nm && nm[0] != '\0' && std::strcmp(nm, "[unknown]") != 0) {
+        _snprintf(row.name, sizeof(row.name) - 1, "%s", nm);
+        row.name[sizeof(row.name) - 1] = '\0';
+        row.resolved = true;
+        return row.name;
+    }
+    if (g_frReqInfo) g_frReqInfo(g_friends, id, /*nameOnly*/true);
+    return "[unknown]";
+}
 
 void tick() {
     if (!g_ready) return;

--- a/src/plugin/net/SteamInvite.h
+++ b/src/plugin/net/SteamInvite.h
@@ -65,6 +65,15 @@ int         friendState(int i);
 // polls host-side lobby membership for the arriving friend. Call every frame.
 void tick();
 
+// Resolve the Steam persona (display) name for an arbitrary SteamID (typically
+// the co-op peer, who may or may not be in our friends list). Returns a pointer
+// into an internal cache valid until the next call; returns "" when Steam is
+// unavailable or the id is 0. When the name is not yet known (a non-friend whose
+// info Steam hasn't downloaded), this kicks off an async RequestUserInformation
+// and returns "[unknown]" for now - a later call resolves the real name once the
+// Steam callback pump (tick()) has delivered it. Main thread only.
+const char* personaName(SteamId id);
+
 // One-line human status for the panel/overlay (never null; "" when idle).
 const char* status();
 

--- a/src/plugin/net/SteamP2P.cpp
+++ b/src/plugin/net/SteamP2P.cpp
@@ -322,6 +322,7 @@ bool init() {
 
 bool ready()      { return g_ready; }
 SteamId selfId()  { return g_selfId; }
+SteamId peerId()  { return g_peer; }
 
 void setPeer(SteamId id) {
     g_peer = id;

--- a/src/plugin/net/SteamP2P.h
+++ b/src/plugin/net/SteamP2P.h
@@ -35,6 +35,10 @@ bool init();
 bool ready();
 SteamId selfId();
 
+// The single configured tunnel peer (the other player), or 0 if not set yet.
+// Used by the remote-player nametag to resolve the peer's Steam persona name.
+SteamId peerId();
+
 // Configure the single tunnel peer. Proactively accepts its inbound session
 // and allows Valve-relay fallback. Call before the net thread starts.
 void setPeer(SteamId id);

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -83,6 +83,12 @@ public:
     // prior one-directional behaviour is preserved.
     void setOwnRanks(const std::set<unsigned int>& r) { ownRanks_ = r; }
 
+    // Remote-player display name for the DRV body nametag (KENSHICOOP_DEBUG_MARKERS).
+    // The plugin root resolves the peer's Steam persona name (net layer) and pushes
+    // it in here each tick so the sync layer stays free of Steam/net dependencies.
+    // Empty -> the label falls back to the legacy "DRV <charName>" form.
+    void setRemoteName(const char* name) { remoteName_ = name ? name : ""; }
+
     // Cross-owner trade veto classifier (engine InvOwnerClassFn). Given a
     // save-stable owner hand (readObjectHand layout [type,container,
     // containerSerial,index,serial]) returns 0 = not a player-squad member,
@@ -1519,8 +1525,12 @@ private:
     // LOC = local-sim copy that exists in the host census. No-op (single env
     // check) unless the flag is set. Labels are created once per body and
     // re-captioned only on state change.
-    struct DebugMarker { void* label; int color; };
+    struct DebugMarker { void* label; int color; std::string caption; };
     std::map<Character*, DebugMarker> debugMarkers_;
+    // Remote player's display name (Steam persona), pushed in via setRemoteName.
+    // Used to caption DRV (host-driven = remote-controlled) bodies with WHOSE
+    // unit it is; empty falls back to the legacy "DRV <charName>" caption.
+    std::string remoteName_;
     void debugMark(Character* c, int colorId, const char* tag);
     // Lifetime guard (2026-07-11 join crash): the map is keyed by raw
     // Character* the engine can free (and REUSE for a new body, silently

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -89,6 +89,12 @@ public:
     // Empty -> the label falls back to the legacy "DRV <charName>" form.
     void setRemoteName(const char* name) { remoteName_ = name ? name : ""; }
 
+    // Normal-play nametag visibility (KENSHICOOP_SHOW_NAMETAG / F2 panel toggle).
+    // Pushed from the plugin root each tick. When false, the per-tick nametag pass
+    // tears down any live name labels so the toggle takes effect immediately (no
+    // reconnect). Independent of KENSHICOOP_DEBUG_MARKERS.
+    void setShowNametag(bool on) { showNametag_ = on; }
+
     // Cross-owner trade veto classifier (engine InvOwnerClassFn). Given a
     // save-stable owner hand (readObjectHand layout [type,container,
     // containerSerial,index,serial]) returns 0 = not a player-squad member,
@@ -1532,6 +1538,24 @@ private:
     // unit it is; empty falls back to the legacy "DRV <charName>" caption.
     std::string remoteName_;
     void debugMark(Character* c, int colorId, const char* tag);
+
+    // ---- Normal-play remote-player nametag ----------------------------------
+    // A DEDICATED name-label layer, separate from the debugMarkers_ diagnostic
+    // overlay: one floating label per PEER-owned driven body (the other player's
+    // squad), captioned with their Steam persona name. Kept apart from the debug
+    // markers because those re-caption the same label with life-state names
+    // (HI/MID/PARKED) every tick, which would clobber the persona name. Always on
+    // in normal play (gated by showNametag_, not KENSHICOOP_DEBUG_MARKERS).
+    struct NametagMarker { void* label; std::string caption; };
+    std::map<Character*, NametagMarker> nametagMarkers_;
+    bool showNametag_;              // F2/config toggle; true = draw name labels
+    // Create/update (or, when off/non-squad, remove) the name label for body c.
+    // 'isSquad' = c is a player-faction (peer's own) unit, so it earns a name;
+    // world NPCs the host merely drives do not.
+    void nametagMark(Character* c, bool isSquad);
+    // Drop name labels whose Character* wasn't vouched live this pass (mirrors
+    // pruneDebugMarkers - same UAF-safe GC against freed/despawned bodies).
+    void pruneNametags(const std::set<Character*>& live);
     // Lifetime guard (2026-07-11 join crash): the map is keyed by raw
     // Character* the engine can free (and REUSE for a new body, silently
     // stealing the old label). enforceHostAuthority prunes entries whose

--- a/src/plugin/sync/ReplicatorAuthority.cpp
+++ b/src/plugin/sync/ReplicatorAuthority.cpp
@@ -10,6 +10,8 @@
 // PowerShell oracles (see resources/CODE_MAP.md, log-tag index).
 
 #include "ReplicatorUtil.h"
+#include "../core/Nametag.h" // remoteNametagCaption (DRV body nametag)
+#include <cstring>           // std::strcmp (DRV tag test)
 
 namespace coop {
 
@@ -20,21 +22,40 @@ void Replicator::debugMark(Character* c, int colorId, const char* tag) {
         en = (e && e[0] == '1') ? 1 : 0;
     }
     if (en != 1 || !c) return;
-    std::map<Character*, DebugMarker>::iterator it = debugMarkers_.find(c);
-    if (it != debugMarkers_.end() && it->second.color == colorId) return;
     char nm[40];
     engine::charName(c, nm, sizeof(nm));
     char cap[64];
-    _snprintf(cap, sizeof(cap) - 1, "%s %s", tag, nm);
+    // DRV = a body the host stream DRIVES here = the OTHER player's unit. Caption
+    // it with the remote player's Steam persona name (pushed in via setRemoteName)
+    // so you can see whose unit it is at a glance; fall back to the legacy
+    // "DRV <charName>" form when the name is unknown (non-friend / LAN / API down).
+    if (tag && std::strcmp(tag, "DRV") == 0) {
+        char fb[64];
+        _snprintf(fb, sizeof(fb) - 1, "DRV %s", nm);
+        fb[sizeof(fb) - 1] = '\0';
+        std::string label = coop::remoteNametagCaption(
+            remoteName_.empty() ? 0 : remoteName_.c_str(), fb);
+        _snprintf(cap, sizeof(cap) - 1, "%s", label.c_str());
+    } else {
+        _snprintf(cap, sizeof(cap) - 1, "%s %s", tag, nm);
+    }
     cap[sizeof(cap) - 1] = '\0';
+    // Re-caption not only on color change but on caption change too: the DRV
+    // nametag starts as the fallback and switches to the real persona name once
+    // Steam resolves it asynchronously (a color-only guard would freeze the old
+    // caption forever).
+    std::map<Character*, DebugMarker>::iterator it = debugMarkers_.find(c);
+    if (it != debugMarkers_.end() && it->second.color == colorId &&
+        it->second.caption == cap) return;
     if (it == debugMarkers_.end()) {
         void* l = engine::markerCreate(c, cap, colorId);
         if (l) {
-            DebugMarker m; m.label = l; m.color = colorId;
+            DebugMarker m; m.label = l; m.color = colorId; m.caption = cap;
             debugMarkers_[c] = m;
         }
     } else if (engine::markerUpdate(it->second.label, cap, colorId)) {
         it->second.color = colorId;
+        it->second.caption = cap;
     }
 }
 

--- a/src/plugin/sync/ReplicatorAuthority.cpp
+++ b/src/plugin/sync/ReplicatorAuthority.cpp
@@ -443,7 +443,10 @@ void Replicator::enforceHostAuthority(GameWorld* gw) {
         // wasn't vouched live this pass (this tick's enumerations, driven and
         // proxy sets, plus the just-validated suppressed bodies). A pruned
         // body that comes back into judgment simply gets a fresh label.
-        if (!debugMarkers_.empty()) {
+        // Build the live-body set once and reuse it for BOTH label maps (debug
+        // markers and the normal-play nametags). The nametag prune runs whenever
+        // it has labels - it is independent of the debug-marker overlay.
+        if (!debugMarkers_.empty() || !nametagMarkers_.empty()) {
             std::set<Character*> vouched;
             for (unsigned int i = 0; i < n; ++i)  vouched.insert(chars[i]);
             for (unsigned int i = 0; i < wn; ++i) vouched.insert(wChars[i]);
@@ -451,7 +454,8 @@ void Replicator::enforceHostAuthority(GameWorld* gw) {
             vouched.insert(proxyChars.begin(), proxyChars.end());
             for (std::map<Key, Character*>::iterator it = suppressed_.begin();
                  it != suppressed_.end(); ++it) vouched.insert(it->second);
-            pruneDebugMarkers(vouched);
+            if (!debugMarkers_.empty())   pruneDebugMarkers(vouched);
+            if (!nametagMarkers_.empty()) pruneNametags(vouched);
         }
     }
 
@@ -718,6 +722,57 @@ void Replicator::pruneDebugMarkers(const std::set<Character*>& live) {
         if (live.find(it->first) == live.end()) {
             engine::markerDestroy(it->second.label);
             debugMarkers_.erase(it++);
+        } else ++it;
+    }
+}
+
+// Normal-play remote-player nametag. Called once per PEER-driven body per tick
+// from the drive loop (applyTargets). Unlike debugMark this has NO env gate: it
+// is a first-class HUD element, gated only by showNametag_ (the F2/config
+// toggle) and isSquad (only the peer's OWN units earn a name; world NPCs the
+// host merely drives do not). Kept in a SEPARATE label map from debugMarkers_
+// so the life-state re-captions there can't clobber the persona name.
+void Replicator::nametagMark(Character* c, bool isSquad) {
+    if (!c) return;
+    std::map<Character*, NametagMarker>::iterator it = nametagMarkers_.find(c);
+    // Feature off, or this body isn't the peer's own unit: make sure no label
+    // lingers (this is how the F2 toggle hides names live - next tick every
+    // driven squad body's mark call tears its own label down).
+    if (!showNametag_ || !isSquad) {
+        if (it != nametagMarkers_.end()) {
+            engine::markerDestroy(it->second.label);
+            nametagMarkers_.erase(it);
+        }
+        return;
+    }
+    // Caption = the peer's Steam persona name when known, else "[Remote Player]".
+    // Empty fallback (no "DRV"/charName): this is player-facing, not diagnostics.
+    // remoteNametagCaption is the same pure, unit-tested builder the debug DRV
+    // caption uses (fallback chain + 63-char cap).
+    std::string cap = coop::remoteNametagCaption(
+        remoteName_.empty() ? 0 : remoteName_.c_str(), "");
+    if (it != nametagMarkers_.end()) {
+        // Re-caption only when it actually changed (the persona name resolves
+        // asynchronously, so the label starts "[Remote Player]" then flips to the
+        // real name once Steam delivers it via the callback pump).
+        if (it->second.caption == cap) return;
+        if (engine::markerUpdate(it->second.label, cap.c_str(), 4))
+            it->second.caption = cap;
+        return;
+    }
+    void* l = engine::markerCreate(c, cap.c_str(), 4); // colorId 4 = cyan nametag
+    if (l) {
+        NametagMarker m; m.label = l; m.caption = cap;
+        nametagMarkers_[c] = m;
+    }
+}
+
+void Replicator::pruneNametags(const std::set<Character*>& live) {
+    for (std::map<Character*, NametagMarker>::iterator it = nametagMarkers_.begin();
+         it != nametagMarkers_.end(); ) {
+        if (live.find(it->first) == live.end()) {
+            engine::markerDestroy(it->second.label);
+            nametagMarkers_.erase(it++);
         } else ++it;
     }
 }

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -67,7 +67,7 @@ Replicator::Replicator()
       storeSync_(false), contCensusMs_(0),
       timeSync_(true), timeSlew_(1.0f), timeSeqOut_(1), timeSeqSeen_(0),
       timeLastSendMs_(0), timeLastLogMs_(0), timeSlewApplied_(-1.0f),
-      lifeSweepMs_(0) {
+      lifeSweepMs_(0), showNametag_(true) {
     peerCam_[0] = peerCam_[1] = peerCam_[2] = 0.0f;
 }
 
@@ -172,6 +172,13 @@ void Replicator::resetSession() {
          mi != debugMarkers_.end(); ++mi)
         engine::markerDestroy(mi->second.label);
     debugMarkers_.clear();
+    // Same for the normal-play nametag labels: they too hold OLD-world raw
+    // Character* plus GUI label objects we own - destroy and drop before the
+    // pointers can dangle into the new session.
+    for (std::map<Character*, NametagMarker>::iterator ni = nametagMarkers_.begin();
+         ni != nametagMarkers_.end(); ++ni)
+        engine::markerDestroy(ni->second.label);
+    nametagMarkers_.clear();
     hostBody_.clear();
     attackerOf_.clear();
     combatCapMs_.clear();

--- a/src/plugin/sync/ReplicatorDrive.cpp
+++ b/src/plugin/sync/ReplicatorDrive.cpp
@@ -260,6 +260,14 @@ void Replicator::applyTargets(GameWorld* gw) {
         //     sit/idle poses for NPCs arrive in Stage 5 (AI quiet-in-place).
         bool isSquad = engine::isLocalPlayerChar(gw, c);
 
+        // Normal-play remote-player nametag: put the peer's Steam name over THEIR
+        // own units (isSquad = a shared-faction body they control), so in a normal
+        // co-op game you can tell your friend's characters apart from world NPCs -
+        // no KENSHICOOP_DEBUG_MARKERS needed. Idempotent + cheap (map lookup +
+        // string compare); a world NPC (isSquad false) or the toggle being off
+        // makes this tear down any label it owns. GC'd by pruneNametags below.
+        nametagMark(c, isSquad);
+
         // ---- Phase A jail-observe (KENSHICOOP_JAIL_OBSERVE, read-only spike) ----
         // For a peer-owned captive (the join's jailed PC as driven on the host),
         // temporarily let the host's LOCAL sim run it unopposed: skip drive,

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -28,6 +28,7 @@
 #include "../plugin/sync/Interp.h"
 #include "../plugin/core/OwnRanks.h"
 #include "../plugin/core/SteamId.h"
+#include "../plugin/core/Nametag.h"
 #include "../plugin/core/WorkPose.h"
 #include "../plugin/core/DeathLatch.h"
 #include "../plugin/core/Inbound.h" // Phase 0 queue-lifecycle fixes (header-only)
@@ -781,6 +782,49 @@ static void testSteamIdParse() {
           !coop::parseSteamId64("12345678901234567", id) && id == 123ull);
 }
 
+// ---- 7b. Remote-player nametag caption (Nametag.h) ------------------------------
+// Guards the DRV body nametag: the caption shows the remote player's Steam persona
+// name when known, and falls back honestly ("DRV <charName>", then "[Remote Player]")
+// when Steam can't give a name (non-friend not yet resolved, LAN/UDP, API down).
+// Steam returns the literal "[unknown]" for unresolved users, which must NOT be
+// shown as a name. Names are trimmed and capped to the 63-char marker buffer.
+
+static void testNametag() {
+    std::printf("== remote-player nametag caption (Nametag.h) ==\n");
+
+    // A real persona name wins over the fallback.
+    CHECK("persona name used when valid",
+          coop::remoteNametagCaption("Zero", "DRV Beep") == "Zero");
+    // Steam's "[unknown]" placeholder is rejected -> fallback used.
+    CHECK("[unknown] rejected -> fallback",
+          coop::remoteNametagCaption("[unknown]", "DRV Beep") == "DRV Beep");
+    // Null / empty persona -> fallback used.
+    CHECK("null persona -> fallback",
+          coop::remoteNametagCaption(0, "DRV Beep") == "DRV Beep");
+    CHECK("empty persona -> fallback",
+          coop::remoteNametagCaption("", "DRV Beep") == "DRV Beep");
+    // Whitespace-only persona is not a name -> fallback used.
+    CHECK("blank persona -> fallback",
+          coop::remoteNametagCaption("   ", "DRV Beep") == "DRV Beep");
+    // No persona and no fallback -> generic label (never empty).
+    CHECK("no persona + no fallback -> generic",
+          coop::remoteNametagCaption(0, 0) == "[Remote Player]");
+    CHECK("no persona + empty fallback -> generic",
+          coop::remoteNametagCaption("", "") == "[Remote Player]");
+    // Persona names are trimmed at the ends (spaces a friend may have around it).
+    CHECK("persona trimmed",
+          coop::remoteNametagCaption("  Zero  ", "DRV Beep") == "Zero");
+    // Names longer than the marker buffer are capped to 63 chars.
+    {
+        std::string longName(80, 'x');
+        std::string out = coop::remoteNametagCaption(longName.c_str(), "DRV Beep");
+        CHECK("long persona capped to 63", out.size() == 63);
+    }
+    // A persona name containing internal spaces is preserved verbatim.
+    CHECK("internal spaces preserved",
+          coop::remoteNametagCaption("Dark Zero", "DRV Beep") == "Dark Zero");
+}
+
 // ---- 8. Pose-fixture acceptance (WorkPose.h) ------------------------------------
 // Guards the mining-sync fix (2026-07-14): a player mining an ore node operates a
 // mine building. A single 6 m seat gate rejected the CORRECT mine as "far"
@@ -1371,6 +1415,7 @@ int main() {
     testInterp();
     testOwnRanks();
     testSteamIdParse();
+    testNametag();
     testWorkPoseMatch();
     testTaskClear();
     testDeathRekey();


### PR DESCRIPTION
### What this adds

A remote player's driven bodies previously showed no identifying label in normal play (a generic name was only ever visible behind the `KENSHICOOP_DEBUG_MARKERS` debug overlay). Now the peer's actual Steam persona name floats over their squad's bodies during normal play, with a fallback chain (real name -> legacy label -> `[Remote Player]`). An F2 panel toggle ("Show player names") lets either side hide it, live, without reconnecting.

### How

Reuses the flat-API Steam resolution already vendored for the invite flow — no new SDK. A dedicated nametag layer (separate map from the debug-marker system, which re-captions its labels every tick with life-state text and would otherwise stomp a persistent name) is gated only by a config flag (`KENSHICOOP_SHOW_NAMETAG`, default on), driven by an F2 toggle. After your `EngineUi.cpp`/`.h` split, the panel code and marker coloring now live there — re-pointed during rebase (the marker create/update/destroy functions themselves stayed declared in `Engine.h`, so the Replicator-side code needed no changes).

### Testing

- Unit: 10 checks on the pure caption-builder (fallback chain, rejects Steam's `[unknown]` placeholder). Prototest: 431/431.
- Live, 2-client with real split ownership (`-Inhabit`, host owns the leader, join inhabits the rest — so the join actually sees peer-driven bodies): nametag renders in normal gameplay with debug markers off. A/B toggle via the config flag (mouse click on the in-panel button isn't automatable with my current tooling, so I exercised the identical code path the button calls) shows the label appearing and disappearing on the same driven bodies. F2 panel confirmed opening at runtime post-refactor with the toggle row present.

### What was NOT tested

The live verification used a single-machine session (same Steam account for both host and join), so the resolved name shown was the fallback (`[Remote Player]`), not an actual second persona — the real-name resolution path itself is pre-existing, already-unit-tested logic; what's new here (decoupling from debug mode + the toggle) is what got the live confirmation. Also didn't automate an actual mouse-click on the F2 button itself (config-flag A/B substituted, same underlying gate).