### PR TITLE
Fix join's crafting/production and research choices being silently reverted (per-object production authority, symmetric research union)

### DIFF
--- a/scripts/CoopOracles.psm1
+++ b/scripts/CoopOracles.psm1
@@ -132,6 +132,7 @@ function Invoke-OneOracle {
         "load_sync"      { return (Test-LoadSync       -HostFile $HostLog -JoinFile $JoinLog) }
         "prod_probe"     { return (Test-ProdProbe      -HostFile $HostLog -JoinFile $JoinLog) }
         "prod_sync"      { return (Test-ProdSync       -HostFile $HostLog -JoinFile $JoinLog) }
+        "prod_sync_join" { return (Test-ProdSyncJoin   -HostFile $HostLog -JoinFile $JoinLog) }
         "research_probe" { return (Test-ResearchProbe  -HostFile $HostLog -JoinFile $JoinLog) }
         "research_sync"  { return (Test-ResearchSync   -HostFile $HostLog -JoinFile $JoinLog) }
         "store_probe"    { return (Test-StoreProbe     -HostFile $HostLog -JoinFile $JoinLog) }

--- a/scripts/oracles/World.ps1
+++ b/scripts/oracles/World.ps1
@@ -1862,6 +1862,92 @@ function Test-ProdSync {
                 -Metrics @{ outGap = $outGap; sent = $sent.Count; applied = $recv.Count } -Detail $detail)
 }
 
+# prod_sync_join (protocolo 33, AUTORIDAD POR-OBJETO): ESPEJO de Test-ProdSync
+# con los roles host/join intercambiados. Aqui conduce el JOIN (coloca+opera el
+# banco de crafteo que EL coloco) y el HOST observa. Prueba que:
+#   * el JOIN coloco las maquinas y corrio las patas locales (place/ramp/power/
+#     setitem/operate) - todo en el log del JOIN;
+#   * el WIRE cruzo en sentido JOIN->HOST: el join emitio [prod] SEND y el host
+#     los aplico ([prod] RECV) - IMPOSIBLE antes de este fix (el join no
+#     publicaba);
+#   * el banco que el host MINTEO del join convergio al outAmt operado por el
+#     join (gap <= 1.0) => el host ve el crafteo del join y NO lo revierte.
+# Un PASS aqui es la evidencia directa de que el join deja de ser espectador.
+function Test-ProdSyncJoin {
+    param([string]$HostFile, [string]$JoinFile)
+    $why = @()
+    # El CONDUCTOR es el JOIN: su log lleva PRODPLACE y las patas locales.
+    $joinP = Select-String -Path $JoinFile -Pattern $script:ProdPlaceRegex -ErrorAction SilentlyContinue | Select-Object -Last 1
+    if ($null -eq $joinP) { $why += "join never logged its PRODPLACE (no condujo)" }
+    elseif ($joinP.Matches[0].Groups[3].Value -ne '1' -or $joinP.Matches[0].Groups[7].Value -ne '1') {
+        $why += "join machine placement failed (genOk=$($joinP.Matches[0].Groups[3].Value) benchOk=$($joinP.Matches[0].Groups[7].Value))"
+    }
+    $hSeries = Get-ProdSeries -File $HostFile
+    $jSeries = Get-ProdSeries -File $JoinFile
+    if ($hSeries.Keys.Count -eq 0) { $why += "host machine census empty" }
+    if ($jSeries.Keys.Count -eq 0) { $why += "join machine census empty" }
+
+    # Patas locales del CONDUCTOR (join): power write, setProductionItem, operate.
+    $pw = @(Select-String -Path $JoinFile -Pattern $script:ProdPowerRegex -ErrorAction SilentlyContinue)
+    $pwOk = @($pw | Where-Object { $_.Matches[0].Groups[3].Value -eq '1' -and $_.Matches[0].Groups[2].Value -eq $_.Matches[0].Groups[5].Value })
+    if ($pwOk.Count -eq 0) { $why += "join power writes missing/never applied" }
+    $ow = @(Select-String -Path $JoinFile -Pattern $script:ProdOutWriteRegex -ErrorAction SilentlyContinue)
+    $setItem = @($ow | Where-Object { $_.Matches[0].Groups[2].Value -eq 'setitem' }) | Select-Object -Last 1
+    if ($null -eq $setItem -or $setItem.Matches[0].Groups[4].Value -ne '1') { $why += "join native setProductionItem write missing/failed" }
+    $ops = @(Select-String -Path $JoinFile -Pattern $script:ProdOpRegex -ErrorAction SilentlyContinue)
+    if ($ops.Count -eq 0) { $why += "join operate loop never ran" }
+
+    # El WIRE cruzo JOIN->HOST (el nucleo del fix): el join emitio, el host aplico.
+    $sent = @(Select-String -Path $JoinFile -Pattern '\[prod\] SEND key=' -ErrorAction SilentlyContinue)
+    $recv = @(Select-String -Path $HostFile -Pattern '\[prod\] RECV key=' -ErrorAction SilentlyContinue)
+    if ($sent.Count -eq 0) { $why += "join never sent a [prod] row (sigue siendo espectador)" }
+    if ($recv.Count -eq 0) { $why += "host never received/applied a [prod] row del join" }
+    Write-Host "    FINDING: [prod] rows join sent=$($sent.Count) host applied=$($recv.Count)"
+
+    $outGap = -1.0
+    if ($null -ne $joinP) {
+        # Convergencia del banco: el HOST minteo el banco que el join coloco.
+        $benchKey = $joinP.Matches[0].Groups[9].Value
+        $benchLocal = Get-MintLocalHand -PeerFile $HostFile -PlacerKey $benchKey
+        if ($null -eq $benchLocal) { $why += "host never minted the join bench (key=$benchKey)" }
+        elseif (-not $hSeries.ContainsKey($benchLocal)) { $why += "host bench copy (local=$benchLocal) absent from its census" }
+        elseif (-not $jSeries.ContainsKey($benchKey)) { $why += "join bench absent from its own census" }
+        else {
+            $js = $jSeries[$benchKey]; $hs = $hSeries[$benchLocal]
+            $jLast = $js[$js.Count-1].outAmt; $hLast = $hs[$hs.Count-1].outAmt
+            $outGap = [math]::Abs($jLast - $hLast)
+            Write-Host ("    FINDING: bench outAmt join first={0:N3} last={1:N3} host copy first={2:N3} last={3:N3} gap={4:N3}" -f `
+                $js[0].outAmt, $jLast, $hs[0].outAmt, $hLast, $outGap)
+            if ($outGap -gt 1.0) { $why += "bench output diverged (gap $([math]::Round($outGap,3)) > 1.0)" }
+        }
+        # Cruce de energia del generador sobre la copia minteada en el host.
+        $genKey = $joinP.Matches[0].Groups[5].Value
+        $genLocal = Get-MintLocalHand -PeerFile $HostFile -PlacerKey $genKey
+        if ($null -eq $genLocal) { $why += "host never minted the join generator (key=$genKey)" }
+        elseif (-not $hSeries.ContainsKey($genLocal)) { $why += "host generator copy (local=$genLocal) absent from its census" }
+        else {
+            $gs = $hSeries[$genLocal]
+            $offW = @($pw | Where-Object { $_.Matches[0].Groups[2].Value -eq '0' }) | Select-Object -Last 1
+            if ($null -ne $offW) {
+                $wt = [long]$offW.Matches[0].Groups[7].Value
+                $hit = @($gs | Where-Object { $_.t -ge $wt -and $_.t -le ($wt + 6000) -and $_.power -eq 0 })
+                if ($hit.Count -eq 0) { $why += "join power OFF never crossed onto the host generator copy" }
+                else { Write-Host "    FINDING: join power OFF CROSSED ($($hit.Count) host samples within 6 s)" }
+            }
+            $hFinalPwr = $gs[$gs.Count-1].power
+            $jFinalPwr = if ($jSeries.ContainsKey($genKey)) { $jSeries[$genKey][$jSeries[$genKey].Count-1].power } else { -1 }
+            Write-Host "    FINDING: final generator power join=$jFinalPwr host=$hFinalPwr"
+            if ($jFinalPwr -ge 0 -and $hFinalPwr -ne $jFinalPwr) { $why += "final generator power disagrees (join=$jFinalPwr host=$hFinalPwr)" }
+        }
+    }
+
+    $v = if ($why.Count -eq 0) { "PASS" } else { "FAIL" }
+    $detail = $why -join "; "
+    Write-Host "  PROD-SYNC-JOIN $v - outGap=$([math]::Round($outGap,3)) sent=$($sent.Count) applied=$($recv.Count) $detail"
+    return (Add-GateResult -Name "prod_sync_join" -Status $v `
+                -Metrics @{ outGap = $outGap; sent = $sent.Count; applied = $recv.Count } -Detail $detail)
+}
+
 # Parse the 1 Hz SCENARIO RESEARCH subject poll into ordered samples
 # @{known; can; t} (protocol 38).
 function Get-ResearchSeries {

--- a/scripts/scenarios.psd1
+++ b/scripts/scenarios.psd1
@@ -961,6 +961,22 @@
             Tier = 'full'; WanVariant = $false
         }
 
+        # prod_sync_join: MISMO script que prod_sync pero conduce el JOIN (coloca
+        # + opera el banco de crafteo); el host observa. Prueba la AUTORIDAD
+        # POR-OBJETO del protocolo 33: una maquina placed la conduce quien la
+        # coloco, asi que el JOIN debe poder craftear y el HOST verlo sin
+        # revertirlo. El oraculo (Test-ProdSyncJoin) es el espejo de prod_sync
+        # con los roles host/join intercambiados: gate que el JOIN coloco+envio
+        # [prod] rows, el HOST los recibio+aplico, y el banco minteado en el host
+        # convergio al outAmt operado por el join (gap <= 1.0).
+        prod_sync_join = @{
+            Save = 'sync'; Setup = ''; Tolerance = 6.0
+            PrimaryGate = 'prod_sync_join'
+            Gating   = @('prod_sync_join', 'clock_sync')
+            Advisory = @('smoothness', 'anim_truth', 'march')
+            Tier = 'full'; WanVariant = $false
+        }
+
         # research_probe: tech-tree phase-0 diagnostic (protocol 38 -
         # researchSync forced OFF). Both sides pick the deterministic
         # not-known-researchable RESEARCH subject at t=8s and poll

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -265,6 +265,30 @@ void processNetEvents(GameWorld* gw) {
     std::deque<coop::u32> conns, leaves;
     g_inbound.drainConnects(conns);
     g_inbound.drainLeaves(leaves);
+    // Ordering note (connect vs leave in the same drain batch): conn_ and leave_
+    // are two SEPARATE net-thread queues, so draining them independently LOSES
+    // the true cross-queue interleave - from here we cannot tell "connect then
+    // leave" (a blip, ends absent) from "leave then connect" (a reconnect, ends
+    // present). We process connects first, then leaves, then the unconditional
+    // crash-cleanup at the bottom. Crucially, that trailing
+    // clearPeerReplicationState()/resetSession() runs whenever ANY leave is in
+    // the batch, AFTER both loops, and wipes the very row/build maps a connect's
+    // onPeerConnected() resync re-arms - so it is ORDER-INDEPENDENT: swapping
+    // these two loops would NOT change the same-batch outcome (the connect's
+    // resync is reset either way; only its already-queued outbound re-announce
+    // survives). We deliberately keep this order and let the batch resolve to
+    // the clean/absent state, because:
+    //  - The safety-critical proxy despawn (clearPeerReplicationState) is
+    //    unconditional and thus never at risk from ordering.
+    //  - A real reconnect's connect and leave edges are many ticks apart, so
+    //    they land in SEPARATE batches: the leave batch cleans, a LATER connect
+    //    batch resyncs correctly. The same-batch collision is a rare timing
+    //    edge that self-heals via the peers' periodic safety resends (RESEND_MS)
+    //    plus that subsequent connect edge.
+    // A same-batch reconnect that keeps its resync would require running the
+    // connect handling AFTER the trailing clear - a larger restructure that
+    // would leave a genuine blip pointing g_peerPresent at a gone peer; not
+    // worth it for a rare, self-healing case. (Re-audit if multi-peer lands.)
     for (std::deque<coop::u32>::iterator it = conns.begin(); it != conns.end(); ++it) {
         char b[96];
         _snprintf(b, sizeof(b) - 1, "handshake: peer present id=%u (local id=%u)",

--- a/src/plugin/core/ProdAuthority.h
+++ b/src/plugin/core/ProdAuthority.h
@@ -1,0 +1,57 @@
+// ProdAuthority.h - modelo de autoridad POR-OBJETO para la produccion/crafteo
+// (protocolo 33). Funcion pura, sin dependencias de juego/Win32, testeable en
+// src/prototest/main.cpp (testProdAuthority).
+//
+// EL PROBLEMA (antes de este fix): el protocolo 33 era HOST-autoritativo en un
+// solo sentido (Plugin.cpp: "if isHost publishProd else applyProd"). Una
+// maquina de crafteo colocada por el JOIN quedaba conducida por el HOST: si el
+// join seleccionaba una receta, applyProd sobrescribia su estado ~1s despues
+// para igualarlo al del host y la seleccion se revertia visiblemente. El join
+// era un mero espectador de la economia de la base compartida.
+//
+// LA SOLUCION - particion natural por objeto (a diferencia del dinero, que es
+// un pool compartido SIN particion): cada maquina tiene UN unico duenno, y solo
+// su duenno publica su estado; el otro lado lo aplica. Como cada maquina tiene
+// exactamente una autoridad, NUNCA hay dos escritores sobre la MISMA maquina,
+// asi que no hay conflicto de reconciliacion (a diferencia del delta de dinero).
+//
+// La regla de propiedad reutiliza el precedente del protocolo 27 (buildSync ya
+// es "placer-autoritativo"): produccion = quien COLOCO la maquina.
+//   - Maquina "baked" (del guardado base, sin colocador): manda el HOST. Esto
+//     preserva EXACTAMENTE el comportamiento host-autoritativo previo para todo
+//     lo que existia en el save (incluido el caso host-solo).
+//   - Maquina "placed" (colocada en sesion, protocolo 27): manda el cliente que
+//     la coloco (la tiene en su ownBuilds_). Asi el JOIN conduce las maquinas
+//     que EL construyo, y el host las suyas, sin solaparse.
+//
+// LIMITACION CONOCIDA (documentada, no un bug): una maquina "baked" preexistente
+// sigue siendo host-autoritativa; el join no puede conducirla. En co-op las
+// bases se construyen entre los jugadores (maquinas "placed"), que es el caso
+// real cubierto; conducir una maquina baked desde el join queda como caso borde
+// fuera de alcance (requeriria arbitraje de "primer-tocador", que reintroduce el
+// problema de 2 escritores que este modelo evita a proposito).
+
+#ifndef COOP_PROD_AUTHORITY_H
+#define COOP_PROD_AUTHORITY_H
+
+namespace coop {
+
+// Decide si ESTE cliente es la AUTORIDAD de produccion de una maquina concreta.
+// Parametros (todos calculables localmente, sin red):
+//   isHost        - true si este cliente es el host de la sesion.
+//   isPlaced      - true si la maquina se coloco en sesion (protocolo 27); false
+//                   si es una maquina "baked" del guardado base.
+//   placedByLocal - true si la maquina "placed" la coloco ESTE cliente (esta en
+//                   su ownBuilds_); false si la coloco el peer (proxy minted).
+//                   Solo tiene sentido cuando isPlaced es true.
+//
+// Devuelve true -> este cliente PUBLICA el estado de la maquina (y el peer lo
+// aplica). Devuelve false -> este cliente APLICA lo que reciba del peer.
+inline bool prodIsLocalAuthority(bool isHost, bool isPlaced, bool placedByLocal) {
+    if (!isPlaced) return isHost;   // baked -> manda el host (comportamiento previo)
+    return placedByLocal;           // placed -> manda quien la coloco
+}
+
+} // namespace coop
+
+#endif // COOP_PROD_AUTHORITY_H

--- a/src/plugin/game/EngineWorld.cpp
+++ b/src/plugin/game/EngineWorld.cpp
@@ -966,26 +966,60 @@ static GameData* findProdTemplate(GameWorld* gw, int kind, int skip) {
     g_dataScratch.clear();
     g_getDataOfTypeFn(&gw->gamedata, &g_dataScratch, BUILDING);
     unsigned int n = g_dataScratch.size();
+    // Diagnostico de una sola vez: vuelca los primeros edificios (name+sid) para
+    // caracterizar el juego real. Kenshi de Zero corre en es_ES, asi que el
+    // name de DISPLAY esta traducido; por eso ademas del name emparejamos por
+    // stringID (el ID interno de FCS, estable e independiente del idioma).
+    static bool s_dumped = false;
+    if (!s_dumped) {
+        s_dumped = true;
+        char h[96];
+        _snprintf(h, sizeof(h) - 1, "[prod] tmpl-dump BUILDING count=%u", n);
+        h[sizeof(h) - 1] = '\0'; coop::logLine(h);
+        unsigned int cap = n < 60 ? n : 60;
+        for (unsigned int i = 0; i < cap; ++i) {
+            GameData* gd = g_dataScratch[i];
+            if (!gd) continue;
+            char b[224];
+            _snprintf(b, sizeof(b) - 1, "[prod] tmpl[%u] name='%s' sid='%s'",
+                      i, gd->name.c_str(), gd->stringID.c_str());
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        }
+    }
+    // Prefijos en INGLES (casan por stringID) + ESPANOL (casan por name de
+    // display). ciContains es case-insensitive y de subcadena, asi que cada
+    // termino cubre variantes ("Pequeno generador eolico" contiene "generador").
     const char* genPrefs[]   = { "small wind generator", "wind generator",
-                                 "small generator", "generator" };
+                                 "small generator", "generator",
+                                 "generador" };
     const char* craftPrefs[] = { "armour crafting bench", "weapon smithing bench",
-                                 "weapon smith", "engineering bench" };
+                                 "weapon smith", "engineering bench",
+                                 "herreria", "herrer", "armadura",
+                                 "ingenieria", "ingenier", "fabricaci",
+                                 "banco de" };
     const char* storePrefs[] = { "general storage", "storage box", "storage chest",
-                                 "chest", "storage" };
+                                 "chest", "storage",
+                                 "almacen", "caja", "cofre" };
     const char* resPrefs[]   = { "small research bench", "research bench",
-                                 "research" };
+                                 "research",
+                                 "investigaci" };
     const char** prefs;
     unsigned int nPrefs;
-    if (kind == 0)      { prefs = genPrefs;   nPrefs = 4; }
-    else if (kind == 2) { prefs = storePrefs; nPrefs = 5; }
-    else if (kind == 3) { prefs = resPrefs;   nPrefs = 3; }
-    else                { prefs = craftPrefs; nPrefs = 4; }
+    if (kind == 0)      { prefs = genPrefs;   nPrefs = sizeof(genPrefs)/sizeof(genPrefs[0]); }
+    else if (kind == 2) { prefs = storePrefs; nPrefs = sizeof(storePrefs)/sizeof(storePrefs[0]); }
+    else if (kind == 3) { prefs = resPrefs;   nPrefs = sizeof(resPrefs)/sizeof(resPrefs[0]); }
+    else                { prefs = craftPrefs; nPrefs = sizeof(craftPrefs)/sizeof(craftPrefs[0]); }
     GameData* seen[16];
     unsigned int nSeen = 0;
     for (unsigned int k = 0; k < nPrefs; ++k) {
         for (unsigned int i = 0; i < n; ++i) {
             GameData* gd = g_dataScratch[i];
-            if (!gd || !ciContains(gd->name.c_str(), prefs[k])) continue;
+            // Empareja por name (display, puede estar traducido) O por stringID
+            // (interno, estable). Esto arregla el fallo "no template" en es_ES.
+            if (!gd) continue;
+            if (!ciContains(gd->name.c_str(), prefs[k]) &&
+                !ciContains(gd->stringID.c_str(), prefs[k]))
+                continue;
             bool dup = false; // a name can match several prefs
             for (unsigned int s = 0; s < nSeen; ++s)
                 if (seen[s] == gd) { dup = true; break; }

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -1414,10 +1414,23 @@ private:
     unsigned long prodSampleMs_;
     bool          prodSync_;
     // Protocol 38 known-research rows, keyed by the RESEARCH stringID (the
-    // cross-client-stable wire identity, spike 401). HOST: sent/lastSendMs =
-    // first-sight send + safety resend. JOIN: seqSeen = stale-row guard,
-    // applied = the local startResearch landed (isKnown flipped) so resends
-    // stop re-applying.
+    // cross-client-stable wire identity, spike 401). Research now runs as a
+    // grow-only CRDT union (kCh[] hostAuth=false): BOTH sides publish their
+    // known set AND apply what they receive, so a JOIN-side unlock reaches the
+    // host too (this is the fix/crafting-research-join-authority change; the
+    // old model was one-directional host->join). Per row: sent/lastSendMs =
+    // first-sight send + safety resend (our PUBLISH half); seqSeen =
+    // stale/dup-row guard, applied = the local startResearch landed (isKnown
+    // flipped) so resends stop re-applying (our APPLY half). Convergence is by
+    // idempotence - knowing a sid can never be "un-known", so there is no
+    // arbitration and message order does not matter.
+    // FUTURE (4-player): the SCALAR seqSeen guard is safe TODAY because a row's
+    // content is independent of the emitter (any sender asserting sid X means
+    // the exact same thing). With 3+ distinct emitters interleaving their own
+    // seq counters on one sid, this single per-row counter must be re-audited:
+    // a high seq from one peer can shadow a still-unapplied resend from
+    // another - harmless here ONLY because 'applied' latches on the first
+    // successful start, but a per-sender seqSeen would be the clean fix.
     struct ResearchRow {
         unsigned long lastSendMs;
         u32  seqSeen;

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -414,38 +414,55 @@ public:
     // BEFORE engine (protocol 33, HOST only - the world-simulation
     // authority): sample machine-class buildings near the interest centers
     // (~1 Hz) and stream a PKT_PROD row per machine - the first sight of a
-    // machine SENDS (the host's state IS the baseline, unlike the symmetric
-    // door channel), then change-gated on the quantized fields with a 10 s
-    // safety resend (which is also what keeps a join whose own engine
+    // machine SENDS, then change-gated on the quantized fields with a 10 s
+    // safety resend (which is also what keeps a peer whose own engine
     // drifted converging). Identity: baked hand (keyKind=0) or protocol-27
     // placer key through the build maps (keyKind=1).
+    //
+    // AUTORIDAD POR-OBJETO (ProdAuthority.h): ambos lados llaman a publishProd,
+    // pero cada uno publica SOLO las maquinas de las que es autoridad -> maquina
+    // baked la publica el host; maquina placed la publica quien la coloco. Asi
+    // el JOIN conduce sus propias maquinas de crafteo. ctx.isHost decide la
+    // propiedad de las maquinas baked.
     void publishProd(const SyncContext& ctx);
 
-    // BEFORE engine (protocol 33, join side): drain received machine rows;
-    // resolve the key (baked hand directly; placer key through ownBuilds_/
-    // peerBuilds_), read the local machine, and apply only what actually
-    // diverged through the engine's own levers (switchPowerOn / direct
-    // amount + farm-float writes; a still-null output buffer is first
-    // MATERIALIZED via the native setProductionItem). Per-key seq guard
-    // drops stale rows; unresolvable keys skip silently (out-of-interest).
+    // BEFORE engine (protocol 33): drain received machine rows; resolve the
+    // key (baked hand directly; placer key through ownBuilds_/peerBuilds_),
+    // read the local machine, and apply only what actually diverged through
+    // the engine's own levers (switchPowerOn / direct amount + farm-float
+    // writes; a still-null output buffer is first MATERIALIZED via the native
+    // setProductionItem). Per-key seq guard drops stale rows; unresolvable
+    // keys skip silently (out-of-interest).
+    //
+    // AUTORIDAD POR-OBJETO: aplica SOLO las maquinas de las que este cliente NO
+    // es autoridad -> una fila para una maquina propia (baked siendo host, o
+    // placed que colocamos nosotros) se ignora, evitando que el peer pise
+    // nuestro estado (ese era el bug del join-espectador). ctx.isHost decide.
     void applyProd(const SyncContext& ctx);
 
     // Production machine sync master enable (KENSHICOOP_PROD_SYNC).
     void setProdSync(bool v) { prodSync_ = v; }
 
-    // BEFORE engine (protocol 38, HOST only - the tech-tree authority):
-    // sample the Research store's known set ~1 Hz (Research::isKnown over
-    // the shared RESEARCH GameData enumeration) and stream one PKT_RESEARCH
-    // row per known sid - first sight sends (the host's known set IS the
-    // session baseline), then a safety resend covers a lost row / a join
-    // whose apply lever needed prerequisites that arrived later.
+    // BEFORE engine (protocol 38): sample the Research store's known set ~1 Hz
+    // (Research::isKnown over the shared RESEARCH GameData enumeration) and
+    // stream one PKT_RESEARCH row per known sid - first sight sends, then a
+    // safety resend covers a lost row / a peer whose apply lever needed
+    // prerequisites that arrived later.
+    //
+    // UNION SIMETRICA (CRDT grow-only set): AMBOS lados publican Y aplican. El
+    // conjunto de investigaciones conocidas solo CRECE (startResearch nunca
+    // des-conoce, applyResearch salta lo ya conocido), asi que la union de los
+    // dos conjuntos es libre de conflicto por construccion - no hace falta
+    // arbitraje ni autoridad. Antes era host->join en un solo sentido, por lo
+    // que una investigacion completada por el JOIN nunca llegaba al host; ahora
+    // se propaga en ambos sentidos.
     void publishResearch(const SyncContext& ctx);
 
-    // BEFORE engine (protocol 38, join side): drain received known-research
-    // rows; sids already known locally are skipped (idempotent), the rest
-    // apply through Research::startResearch - the exact lever a research-UI
-    // click commits (flips isKnown in the same tick, spike 401). Per-sid
-    // seq guard drops stale rows.
+    // BEFORE engine (protocol 38): drain received known-research rows; sids
+    // already known locally are skipped (idempotent), the rest apply through
+    // Research::startResearch - the exact lever a research-UI click commits
+    // (flips isKnown in the same tick, spike 401). Per-sid seq guard drops
+    // stale rows. Corre en ambos lados (ver publishResearch: union simetrica).
     void applyResearch(const SyncContext& ctx);
 
     // Research tech-tree sync master enable (KENSHICOOP_RESEARCH_SYNC).

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -11,6 +11,7 @@
 // PowerShell oracles (see resources/CODE_MAP.md, log-tag index).
 
 #include "ReplicatorUtil.h"
+#include "../core/ProdAuthority.h" // modelo de autoridad por-objeto (protocolo 33)
 
 namespace coop {
 
@@ -743,6 +744,7 @@ inline int qProd(float v) {
 
 void Replicator::publishProd(const SyncContext& ctx) {
     GameWorld* gw = ctx.gw; NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
+    const bool isHost = ctx.isHost; // autoridad por-objeto: baked -> host publica
     if (!prodSync_) return;
     const unsigned long SAMPLE_MS = tuning_.prodSampleMs;  // machines tick slowly; 1 Hz is plenty
     const unsigned long RESEND_MS = tuning_.prodResendMs;  // safety resend = the join drift corrector
@@ -762,12 +764,19 @@ void Replicator::publishProd(const SyncContext& ctx) {
         // join's placement translates through the reverse map). Everything
         // else is a BAKED machine with a save-stable hand.
         int keyKind = 0; Key wk = lk;
+        bool placedByLocal = false; // colocada por ESTE cliente (esta en ownBuilds_)
         if (ownBuilds_.find(lk) != ownBuilds_.end()) {
-            keyKind = 1;
+            keyKind = 1; placedByLocal = true;
         } else {
             std::map<Key, Key>::iterator mit = mintByLocal_.find(lk);
             if (mit != mintByLocal_.end()) { keyKind = 1; wk = mit->second; }
         }
+        // Autoridad por-objeto: publicamos SOLO las maquinas de las que somos
+        // duenno (baked -> host; placed -> quien la coloco). Una maquina placed
+        // del peer (proxy minted, placedByLocal=false) la conduce el peer: no la
+        // publicamos para no crear dos escritores sobre la misma maquina.
+        if (!prodIsLocalAuthority(isHost, keyKind == 1, placedByLocal))
+            continue;
         ProdRow& pr = prodRows_[std::make_pair(keyKind, wk)];
         int qOut = qProd(r.outAmount);
         int qIn0 = qProd(r.nInputs > 0 ? r.inAmount[0] : -1.0f);
@@ -826,6 +835,7 @@ void Replicator::publishProd(const SyncContext& ctx) {
 
 void Replicator::applyProd(const SyncContext& ctx) {
     Inbound& in = *ctx.in;
+    const bool isHost = ctx.isHost; // autoridad por-objeto: ignora ecos de maquinas propias
     std::deque<InboundProd> got;
     in.drainProd(got);
     if (got.empty()) return;
@@ -837,17 +847,22 @@ void Replicator::applyProd(const SyncContext& ctx) {
         ProdRow& pr = prodRows_[std::make_pair((int)p.keyKind, wk)];
         if (!sync::gateSeqAccept(pr.seqSeen, p.seq)) continue; // stale/dup row
         pr.seqSeen = p.seq;
-        // Resolve the wire key to OUR machine's hand: baked hands resolve
-        // directly; a placer key is either a building WE placed (our own
-        // hand) or one we MINTED for the host's placement (translation map).
+        // Resolve the wire key to OUR machine's hand, aplicando SOLO las
+        // maquinas de las que NO somos autoridad (ProdAuthority.h). Una fila
+        // para una maquina propia se ignora: seria el peer pisando nuestro
+        // estado (ese era el bug del join-espectador).
         unsigned int hand[5];
         if (p.keyKind == 0) {
+            // Baked: la conduce el host. Si somos host, somos la autoridad ->
+            // ignoramos ecos; el join aplica lo que recibe.
+            if (isHost) continue;
             for (unsigned int h = 0; h < 5; ++h) hand[h] = p.key[h];
         } else {
             std::map<Key, OwnBuild>::iterator ob = ownBuilds_.find(wk);
             if (ob != ownBuilds_.end()) {
-                if (ob->second.removed) continue;
-                memcpy(hand, ob->second.hand, sizeof(hand));
+                // La colocamos NOSOTROS -> somos la autoridad; no aplicamos las
+                // filas del peer sobre nuestra propia maquina.
+                continue;
             } else {
                 std::map<Key, PeerBuild>::iterator pb = peerBuilds_.find(wk);
                 if (pb == peerBuilds_.end() || pb->second.minted != 1 ||
@@ -1226,8 +1241,17 @@ void Replicator::driveSampledChannels(const SyncContext& ctx) {
         { &Replicator::doorSync_,     0,                     &Replicator::publishDoors,      &Replicator::applyDoors,      false },
         { &Replicator::buildSync_,    0,                     &Replicator::publishBuilds,     &Replicator::applyBuilds,     false },
         { &Replicator::buildSync_,    &Replicator::bdoorSync_, &Replicator::publishBuildDoors, &Replicator::applyBuildDoors, false },
-        { &Replicator::prodSync_,     0,                     &Replicator::publishProd,       &Replicator::applyProd,       true  },
-        { &Replicator::researchSync_, 0,                     &Replicator::publishResearch,   &Replicator::applyResearch,   true  }
+        // Prod y research pasan a DIRECCION SIMETRICA (hostAuth=false): ambos
+        // clientes publican Y aplican. Prod usa autoridad POR-OBJETO interna
+        // (publishProd/applyProd leen ctx.isHost + ProdAuthority.h -> baked lo
+        // conduce el host, placed quien la coloco), asi que nunca hay dos
+        // escritores sobre la misma maquina pese al camino simetrico; ese era
+        // el bug del join-espectador que revertia el crafteo del join. Research
+        // es una UNION grow-only (CRDT): ambos publican su set conocido y saltan
+        // lo ya conocido, converge sin arbitraje y una investigacion del JOIN
+        // llega al host. Antes ambos eran hostAuth=true (host->join un sentido).
+        { &Replicator::prodSync_,     0,                     &Replicator::publishProd,       &Replicator::applyProd,       false },
+        { &Replicator::researchSync_, 0,                     &Replicator::publishResearch,   &Replicator::applyResearch,   false }
     };
     const int n = (int)(sizeof(kCh) / sizeof(kCh[0]));
     for (int i = 0; i < n; ++i) {

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -654,6 +654,19 @@ void Replicator::publishDoors(const SyncContext& ctx) {
         // Protocol 28 partition: doors on SESSION-PLACED buildings (ours or
         // minted proxies) ride PKT_BUILD_DOOR on the translated identity -
         // their runtime hands would never resolve on the peer anyway.
+        // Channel-order caveat: this filter reads mintByLocal_, which
+        // applyBuilds populates (idx 2 in kCh[]) AFTER publishDoors runs
+        // (idx 1). The window is benign in practice: applyBuilds sets
+        // mintByLocal_ in the SAME statement that mints the proxy, so the
+        // building's doors can only be enumerated here on a LATER tick, by
+        // which point the key is already present; and a door's first sighting
+        // seeds its row silently (no packet) below. Worst case a proxy door
+        // whose state changed in the exact seed tick emits ONE PKT_DOOR with a
+        // runtime hand the peer drops clean, self-correcting next sample - no
+        // data loss. NOT worth reordering kCh[] to close: that table's order is
+        // the fixed wire cadence (see driveSampledChannels), and moving builds
+        // ahead of doors would perturb every channel's publish sequence for a
+        // cosmetic, self-healing transient.
         if (r.doorIndex >= 0) {
             Key pk; pk.t = r.parentHand[0]; pk.c = r.parentHand[1];
             pk.cs = r.parentHand[2]; pk.i = r.parentHand[3]; pk.s = r.parentHand[4];

--- a/src/plugin/test/ScenarioBuildings.cpp
+++ b/src/plugin/test/ScenarioBuildings.cpp
@@ -506,9 +506,18 @@ private:
 // + setItem write applied); crossing/convergence is the sync oracle's job.
 class ProdProbeScenario : public TimedScenario {
 public:
-    explicit ProdProbeScenario(bool probe)
-        : TimedScenario(probe ? "prod_probe" : "prod_sync", /*evidenceMs=*/1000),
-          probe_(probe), censusLogged_(0),
+    // joinDrives: si true, es el JOIN quien coloca+opera las maquinas (el host
+    // observa). Sirve para verificar en vivo la AUTORIDAD POR-OBJETO del
+    // protocolo 33: una maquina placed la conduce quien la coloco, asi que el
+    // JOIN debe poder crafteear y el HOST verlo sin revertirlo. Con false (por
+    // defecto) el comportamiento es IDENTICO al prod_sync/prod_probe previos.
+    // El nombre resuelto se pasa a TimedScenario (que ya gestiona name()/passed_/
+    // el timing de evidencia), por eso joinDrives elige "prod_sync_join" aqui.
+    explicit ProdProbeScenario(bool probe, bool joinDrives = false)
+        : TimedScenario(joinDrives ? "prod_sync_join"
+                                   : (probe ? "prod_probe" : "prod_sync"),
+                        /*evidenceMs=*/1000),
+          probe_(probe), joinDrives_(joinDrives), censusLogged_(0),
           placed_(false), placeGenOk_(false), placeBenchOk_(false),
           rampStep_(0), rampGenDone_(false), rampBenchDone_(false),
           nextRampMs_(0), nextOpMs_(0), opCount_(0), nextResearchMs_(0),
@@ -531,7 +540,10 @@ public:
     virtual bool onTick(const ScenarioContext& ctx) {
         if (evidenceDue(ctx.elapsedMs))
             logCensus(ctx);
-        if (ctx.isHost) {
+        // El CONDUCTOR (host por defecto; join si joinDrives_) coloca+opera las
+        // maquinas; el otro lado solo observa/aplica lo que reciba por la red.
+        const bool isDriver = (ctx.isHost != joinDrives_);
+        if (isDriver) {
             if (!placed_ && ctx.elapsedMs >= PLACE_AT_MS) {
                 placed_ = true;
                 doPlace(ctx);
@@ -567,7 +579,7 @@ public:
         }
         if (ctx.elapsedMs >= DURATION_MS) {
             passed_ = (censusLogged_ > 0);
-            if (ctx.isHost) {
+            if (isDriver) {
                 // Local legs on the driving side: both machines placed and
                 // completed, the power toggle applied, the native output
                 // write landed, and the operate loop ran. What CROSSED (or
@@ -752,6 +764,7 @@ private:
     static const unsigned int  MAX_RAMP_STEPS    = 8;
 
     bool          probe_;
+    bool          joinDrives_; // true: conduce el JOIN (prueba autoridad por-objeto)
     unsigned int  censusLogged_;
     bool          placed_;
     bool          placeGenOk_;
@@ -1265,6 +1278,10 @@ Scenario* makeBuildingScenario(const std::string& name) {
     if (name == "bdoor_sync")    return new BdoorProbeScenario(false);
     if (name == "prod_probe")     return new ProdProbeScenario(true);
     if (name == "prod_sync")      return new ProdProbeScenario(false);
+    // prod_sync_join: mismo script pero conduce el JOIN. Prueba en vivo que el
+    // join puede craftear en una maquina que EL coloco y el host lo ve sin
+    // revertirlo (autoridad por-objeto del protocolo 33).
+    if (name == "prod_sync_join") return new ProdProbeScenario(false, true);
     if (name == "research_probe") return new ResearchProbeScenario(true);
     if (name == "research_sync")  return new ResearchProbeScenario(false);
     if (name == "store_probe")    return new StoreProbeScenario(true);

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -34,6 +34,7 @@
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
+#include "../plugin/core/ProdAuthority.h" // autoridad por-objeto de crafteo (protocolo 33)
 
 #include <set>
 
@@ -1355,6 +1356,42 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+static void testProdAuthority() {
+    std::printf("== production per-object authority (ProdAuthority.h) ==\n");
+
+    // Maquina baked (sin colocador): manda el HOST. Preserva EXACTAMENTE el
+    // comportamiento host-autoritativo previo. placedByLocal es irrelevante.
+    CHECK("baked: host es autoridad",
+          prodIsLocalAuthority(/*isHost*/true,  /*isPlaced*/false, /*placedByLocal*/false));
+    CHECK("baked: join NO es autoridad",
+          !prodIsLocalAuthority(/*isHost*/false, /*isPlaced*/false, /*placedByLocal*/false));
+
+    // Maquina placed: manda quien la COLOCO, sea host o join. Este es el fix:
+    // el join conduce las maquinas que el construyo.
+    CHECK("placed por join: join es autoridad",
+          prodIsLocalAuthority(/*isHost*/false, /*isPlaced*/true, /*placedByLocal*/true));
+    CHECK("placed por peer (proxy en join): join NO es autoridad",
+          !prodIsLocalAuthority(/*isHost*/false, /*isPlaced*/true, /*placedByLocal*/false));
+    CHECK("placed por host: host es autoridad",
+          prodIsLocalAuthority(/*isHost*/true,  /*isPlaced*/true, /*placedByLocal*/true));
+    CHECK("placed por peer (proxy en host): host NO es autoridad",
+          !prodIsLocalAuthority(/*isHost*/true,  /*isPlaced*/true, /*placedByLocal*/false));
+
+    // Invariante de particion: para CUALQUIER maquina, exactamente UN lado es la
+    // autoridad -> nunca hay dos escritores sobre la misma maquina. Barremos las
+    // 4 combinaciones (baked/placed x colocada-por-host/join) y comprobamos que
+    // host y join no son ambos autoridad ni ambos no-autoridad de la misma.
+    // baked: host lo posee en los dos clientes (placedByLocal solo aplica a placed).
+    CHECK("baked: exactamente una autoridad",
+          prodIsLocalAuthority(true, false, false) != prodIsLocalAuthority(false, false, false));
+    // placed colocada por el HOST: en el host placedByLocal=true, en el join =false.
+    CHECK("placed-by-host: exactamente una autoridad",
+          prodIsLocalAuthority(true, true, true) != prodIsLocalAuthority(false, true, false));
+    // placed colocada por el JOIN: en el join placedByLocal=true, en el host =false.
+    CHECK("placed-by-join: exactamente una autoridad",
+          prodIsLocalAuthority(false, true, true) != prodIsLocalAuthority(true, true, false));
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1377,6 +1414,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testProdAuthority();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
### What this fixes

Production/crafting (protocol 33) and research (protocol 38) were strictly host-authoritative one-way. That means the joining player's queue selections at a crafting bench or research pick got silently reverted the moment the host's next publish landed — the join could never actually drive crafting or research, only watch the host's.

### How

Two different authority models, chosen per the actual shape of the state:

- **Production = per-object ownership** (`ProdAuthority.h`, `prodIsLocalAuthority(isHost, isPlaced, placedByLocal)`): whoever placed a given machine owns it and is authoritative for it; pre-existing/baked machines stay host-owned (preserves old behavior for the world's starting benches). Registered as a symmetric (`hostAuth=false`) channel in your new `kCh[]` registry — both sides publish AND apply, filtered by per-object authority.
- **Research = symmetric union** (grow-only CRDT set): the known-research set only ever grows, so both sides publish and apply without arbitration — converges regardless of who researched what first. Also registered `hostAuth=false`.

### Testing

- Unit: `testProdAuthority`, 9 checks including a partition invariant ("exactly one authority per machine"). Prototest: 430/430.
- Live, 2-client, real session (rebased onto your `98e48ba` modularization): `prod_sync_join` — join-placed bench crafting converges on the host without reverting (`sent=7, applied=4, outGap=0`). `research_sync` — both sides now publish (host SEND=3, join SEND=3, where only host used to), join's `known` flips 0->1 and stays `known=1` on both sides after crossing the wire. Both gates PASS.

### What was NOT tested

Concurrent placement of the exact same machine by both players in the same tick (a genuine ownership race) wasn't specifically reproduced — the partition invariant unit test covers the intended logic, but a real simultaneous-placement race in live play wasn't forced.