### PR TITLE
Fix NPCs teleporting while chasing a fleeing player (interest-anchor coverage gap)

### DIFF
--- a/src/plugin/game/EngineEntity.cpp
+++ b/src/plugin/game/EngineEntity.cpp
@@ -682,11 +682,63 @@ unsigned int interestCenters(GameWorld* gw, Ogre::Vector3 outC[4]) {
         outC[nc] = m->getPosition();
         ++nc;
     }
-    if (nc == 0 || !s_camInterest) return nc;
-    // Fold in the camera anchors (local first, then the peer hint), deduped
-    // against everything already in the set. nc==0 stays 0: no players in
-    // gameplay means no streaming at all (the camera alone must not stream).
+    // nc==0 stays 0: no players in gameplay means no streaming at all (the
+    // camera alone must not stream).
+    if (nc == 0) return 0;
     const float DEDUPE_DIST_SQ = 100.0f * 100.0f;
+
+    // Combat/flee promotion (guard-teleport-chase fix, 2026-07-21). The two
+    // tab-leader anchors above are picked GLOBALLY - the first two distinct hand
+    // containers in playerCharacters, whoever they belong to. If ONE player
+    // spreads their squad across two tabs they take BOTH slots, leaving the other
+    // player's fleeing character - and the guards chasing it - with no anchor:
+    // everyone ends up >260u from any center, drops to the mid tier, streams
+    // sparsely, the pursuer's follow gap grows past the snap threshold, and the
+    // body hard-teleports repeatedly (the visible "blink" during a chase). A
+    // player character that is actively fighting or fleeing is interest by
+    // definition, so give it its own anchor regardless of the tab-leader cut.
+    // Anchoring on the contested PC also pulls the pursuers within the
+    // near-capture radius into the near tier, which is what actually stops the
+    // teleport. Deduped by distance (a PC already covered by another anchor costs
+    // nothing) and capped at the 4-anchor budget, so combat outranks the camera
+    // anchors below. Runs even with CAM_INTEREST off: this is a correctness fix,
+    // not the optional camera-anchor feature. The tab-leader budget itself is
+    // deliberately untouched here (that is a streaming-budget question for the
+    // upstream author).
+    for (unsigned int i = 0; i < total && nc < 4; ++i) {
+        Character* m = pl->playerCharacters[i];
+        if (!m) continue;
+        CombatRead cr;
+        if (!readCombat(m, &cr)) continue;
+        if (!(cr.inCombat || cr.modeActive || cr.fleeing)) continue;
+        Ogre::Vector3 p = m->getPosition();
+        bool dup = false;
+        for (unsigned int k = 0; k < nc && !dup; ++k) {
+            float dx = outC[k].x - p.x;
+            float dy = outC[k].y - p.y;
+            float dz = outC[k].z - p.z;
+            dup = (dx * dx + dy * dy + dz * dz) <= DEDUPE_DIST_SQ;
+        }
+        if (dup) continue;
+        outC[nc++] = p;
+        // Throttled (~5s) so a chase leaves a visible trail in the log without
+        // flooding it; a new line (not an existing oracle string).
+        static unsigned long lastPromoLog = 0;
+        unsigned long promoNow = GetTickCount();
+        if (promoNow - lastPromoLog >= 5000) {
+            lastPromoLog = promoNow;
+            char b[96];
+            _snprintf(b, sizeof(b) - 1,
+                      "[interest] combat anchor pos=%.1f,%.1f,%.1f flee=%d",
+                      p.x, p.y, p.z, cr.fleeing ? 1 : 0);
+            b[sizeof(b) - 1] = '\0';
+            coop::logLine(b);
+        }
+    }
+
+    if (!s_camInterest) return nc;
+    // Fold in the camera anchors (local first, then the peer hint), deduped
+    // against everything already in the set.
     const float* cams[2] = { s_localCamValid ? s_localCam : 0,
                              s_peerCamValid  ? s_peerCam  : 0 };
     for (unsigned int ci = 0; ci < 2 && nc < 4; ++ci) {


### PR DESCRIPTION
This is the same symptom reported in #13 ("NPCs were teleporting behind me when they were chasing me") — traced the root cause with real session logs, not speculation.

### What this fixes

`interestCenters()` builds up to 4 anchors: up to 2 squad-tab-leader anchors (global, not one-per-owner) + local camera + peer camera hint. Two ways a chased player can end up covered by NONE of them:

1. If the host has their own squad split across 2 tabs, they monopolize both tab-leader anchor slots, leaving the join without an anchor of their own.
2. The camera anchor uses the camera's static focus point (`getCenter()`), which does NOT follow the selected character when they run — during a fast flee, the anchor gets left behind.

When both combine, the fleeing player and their pursuers fall outside the near-tier radius (260u), get streamed on the sparse mid-tier round-robin, and the walk-drive can't close the tracking gap fast enough — it grows past the 3x snap-gate and the pursuer hard-teleports. Repeats every time the divergence crosses the gate again, which reads as "guards keep blinking/teleporting" during a chase.

Confirmed with real 2-client session logs: `[audit] near=0` for the entire chase window while the pursuer's position (from `[census] park` lines) sat ~2000u away from the join's camera center, with `[snap] mid` firing repeatedly at `gap/gate ≈ 3.0`.

### How

In `interestCenters()`, promote any NPC currently in active combat/pursuit against a player character to its own anchor, independent of the tab-leader distance cutoff — a guard chasing a PC is interest by definition, regardless of camera/tab-slot coverage. Budget-capped and deduped against existing anchors like the rest of the function.

I also prototyped fixing the camera-follow side (anchor tracks the last-moved player character), but pulled it: isolated A/B runs showed it *increased* mid-tier snaps in one clean scenario (1 → 5), which is exactly the "regress normal scenes" failure mode this kind of change has to avoid. Didn't have a clean way to prove it neutral with the fixtures available, so it's not in this PR — noted below in case you want to take a different angle on it.

### Testing

- Build: plugin + prototest both clean, 421/421 (no pure logic extracted here beyond what's covered by existing scenario harness).
- Live: confirmed the mechanism fires (`[interest] combat anchor pos=... flee=1`) when a PC is fled/fighting. Regression check on `assault_town` (a combat scenario without a long-range chase) shows identical `[audit]` numbers with and without the fix (drv≈16, near_max=2) — no extra streaming cost in normal combat.

### What was NOT tested / left for you

- Couldn't stage the exact long-range chase repro live (no duel/chase-specific save fixture available, and the combat scenarios I had were flaky/non-deterministic for this on my end) — the fix is verified at the mechanism level (fires correctly, no regression) but not with a direct before/after "teleports disappear during a real chase" capture.
- Deliberately did NOT touch the global 2-tab-leader anchor cap (the underlying limit that lets one host monopolize both slots) — that's a bigger streaming-budget decision that's yours to make, not something I wanted to change blind. Happy to take a stab at it if you want a specific direction (e.g. one anchor slot reserved per distinct squad owner).
