### PR TITLE
Surface connection errors on screen + add a connect/disconnect toast

### DIFF
--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -35,6 +35,7 @@
 #include "net/SteamInvite.h"
 #include "game/Engine.h"
 #include "game/EngineUi.h"       // Phase 5a: F2 co-op panel + status overlay
+#include "game/ToastTimer.h"     // ephemeral peer connect/disconnect toast clock
 #include "game/EngineScenario.h" // Phase 5a: auto-bake scene builders
 #include "sync/Replicator.h"
 #include "sync/SaveXfer.h"
@@ -176,6 +177,26 @@ const DWORD     CRAFT_REARM_MS  = 3000; // re-issue the work goal at most this o
 const DWORD  SWAP_MIN_MS        = 400;   // shorter world-swap dips are flicker, not a reload
 const DWORD  LOAD_PUMP_GRACE_MS = 2000;  // deferred-LOADGAME backstop grace window
 
+// Ephemeral peer connect/disconnect toast (EngineUi coopToastTick). Purely a UI
+// blip - NOT session lifecycle state, so it lives as loose statics here rather
+// than in SessionController: it self-expires after TOAST_SHOW_MS and needs no
+// reset on a session boundary. processNetEvents arms it on a real connect/leave
+// edge; coopPanelDrive polls toastVisible() each frame and drives the label.
+bool         g_toastArmed = false; // a transition toast is currently timed
+DWORD        g_toastArmMs = 0;     // GetTickCount at the arming edge
+std::string  g_toastText;          // "Peer connected" / "Peer disconnected"
+int          g_toastState = 0;     // overlay colour state (2 = green, 0 = red)
+
+// Arm the ephemeral toast for a peer transition. connected=true -> green
+// "Peer connected"; false -> red "Peer disconnected". Records the wall clock so
+// coopPanelDrive can time out the banner via coop::engine::toastVisible().
+void armPeerToast(bool connected) {
+    g_toastText  = connected ? "Peer connected" : "Peer disconnected";
+    g_toastState = connected ? 2 : 0;
+    g_toastArmMs = GetTickCount();
+    g_toastArmed = true;
+}
+
 // Original function pointers, filled by KenshiLib::AddHook.
 void (*g_mainLoop_orig)(GameWorld*, float) = 0;
 void (*g_titleUpdate_orig)(TitleScreen*)   = 0;
@@ -278,6 +299,9 @@ void processNetEvents(GameWorld* gw) {
         if (g_cfg.latejoinSync) g_repl.onPeerConnected(g_net, g_net.localId());
         else coopLog("[latejoin] connect edge seen, resync OFF (gate)");
         g_peerPresent = true;
+        // Pop the ephemeral "Peer connected" toast at the exact connect edge
+        // (distinct from the persistent status banner, which only reflects state).
+        armPeerToast(true);
         // Coordinated save (protocol 31): while connected under save-sync,
         // the JOIN never writes a save locally - the host's save is
         // authoritative and a local save press forwards as PKT_SAVE_REQ.
@@ -302,6 +326,9 @@ void processNetEvents(GameWorld* gw) {
         // release any carry or occupancy its driven copies still hold.
         if (gw && (g_cfg.carrySync || g_cfg.furnSync)) g_repl.sweepCarries(gw);
         g_peerPresent = false;
+        // Pop the ephemeral "Peer disconnected" toast at the exact leave edge -
+        // the momentary notice the persistent banner (now back to "waiting") lacks.
+        armPeerToast(false);
         // Coordinated save: disconnected = solo again; local saves must work.
         if (!g_cfg.isHost && g_cfg.saveSync) {
             coop::engine::setSaveSuppress(false);
@@ -767,6 +794,14 @@ void coopPanelDrive(GameWorld* gw) {
 
     coop::engine::coopPanelTick(&ps, &coopUiConnect, &coopUiDisconnect);
     coop::engine::coopOverlayTick(gw, detail.c_str(), ostate, g_net.isRunning());
+
+    // Ephemeral transition toast: a peer connect/leave edge armed it (armPeerToast);
+    // show it until TOAST_SHOW_MS elapses, then disarm so coopToastTick removes the
+    // label. Independent of the persistent overlay above (its own label + timer).
+    bool toastShow = coop::engine::toastVisible(g_toastArmed, g_toastArmMs,
+                                                GetTickCount(), coop::engine::TOAST_SHOW_MS);
+    if (g_toastArmed && !toastShow) g_toastArmed = false; // window elapsed: retire it
+    coop::engine::coopToastTick(gw, g_toastText.c_str(), g_toastState, toastShow);
 }
 
 // Main-thread tick hook: the one safe point where we touch game state.

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -739,10 +739,31 @@ void coopPanelDrive(GameWorld* gw) {
         detail = "Offline - press F2, then set Connection to ONLINE";
         ostate = 0;
     }
-    ps.detail = detail.c_str();
     // Still pump Steam callbacks so an inbound "Join Game" (a friend inviting
-    // US) can fire coopUiConnect; the outbound invite/picker UI is gone.
+    // US) can fire coopUiConnect; the outbound invite/picker UI is gone. Pumped
+    // BEFORE reading steaminvite::status() so the status we surface is fresh.
     coop::steaminvite::tick();
+
+    // Surface the REAL connection error/status the lower layers already produce
+    // instead of only the generic Offline/Connecting/Connected text. Priority:
+    //   1. netUiError()  - a hard NET-thread reject (protocol/version mismatch);
+    //                      this is the failure that used to vanish into the log
+    //                      and leave the JOIN stuck on "Connecting..." -> "Offline".
+    //   2. steaminvite::status() - the Steam invite/lobby flow's own messages
+    //                      ("Version mismatch with host...", "Lobby creation
+    //                      failed...", "Connecting to host...") - already written,
+    //                      previously never consumed (orphaned getter).
+    //   3. the generic detail computed above.
+    // ostate (overlay colour) is left as-is: a hard reject drops the connection,
+    // so isRunning() goes false and the text shows in the Offline colour naturally.
+    const char* netErrMsg = coop::netUiError();          // "" unless a reject fired
+    const char* steamMsg  = coop::steaminvite::status(); // "" when idle
+    if (netErrMsg && netErrMsg[0]) {
+        detail = netErrMsg;
+    } else if (steamMsg && steamMsg[0]) {
+        detail = steamMsg;
+    }
+    ps.detail = detail.c_str();
 
     coop::engine::coopPanelTick(&ps, &coopUiConnect, &coopUiDisconnect);
     coop::engine::coopOverlayTick(gw, detail.c_str(), ostate, g_net.isRunning());

--- a/src/plugin/game/EngineUi.cpp
+++ b/src/plugin/game/EngineUi.cpp
@@ -541,6 +541,14 @@ Character*   g_overlayLeader = 0;
 int          g_overlayState  = -1;
 std::string  g_overlayText;
 
+// Ephemeral toast label state (peer connect/disconnect transitions). A SEPARATE
+// ScreenLabel from the persistent overlay above, driven the same way but at a
+// higher head offset so both can show at once without overlapping.
+ScreenLabel* g_toast         = 0;
+Character*   g_toastLeader   = 0;
+int          g_toastState    = -1;
+std::string  g_toastText;
+
 int overlayColorId(int state) { return state == 2 ? 0 : (state == 1 ? 2 : 1); }
 
 Character* panelLeaderSeh(GameWorld* gw) {
@@ -550,35 +558,56 @@ Character* panelLeaderSeh(GameWorld* gw) {
         return gw->player->playerCharacters[0];
     } __except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
 }
-} // namespace
 
-void coopOverlayTick(GameWorld* gw, const char* text, int state, bool show) {
-    ForgottenGUI* g = ::gui;
-    if (!g) return;
-
+// Shared driver for one leader-tracked ScreenLabel (the persistent overlay OR the
+// ephemeral toast). The label/leader/state/text statics are passed IN by pointer
+// so the two banners stay fully independent labels sharing this create-once /
+// update-in-place / destroy-on-hide lifecycle (the spike-47/48 render path via the
+// marker* SEH shims). offY is the head-height offset that separates the two.
+void trackedLabelTick(ForgottenGUI* g, GameWorld* gw, const char* text, int state,
+                      bool show, float offY, ScreenLabel** label,
+                      Character** leaderSlot, int* stateSlot, std::string* textSlot) {
     Character* leader = show ? panelLeaderSeh(gw) : 0;
     if (!show || !leader) {
-        if (g_overlay) {
-            markerDestroySeh(g, g_overlay);
-            g_overlay = 0; g_overlayLeader = 0; g_overlayState = -1; g_overlayText.clear();
+        if (*label) {
+            markerDestroySeh(g, *label);
+            *label = 0; *leaderSlot = 0; *stateSlot = -1; textSlot->clear();
         }
         return;
     }
 
     std::string t = text ? std::string(text) : std::string();
-    if (!g_overlay || leader != g_overlayLeader) {
-        if (g_overlay) markerDestroySeh(g, g_overlay);
+    if (!*label || leader != *leaderSlot) {
+        if (*label) markerDestroySeh(g, *label);
         MyGUI::Colour col; markerColour(overlayColorId(state), &col);
-        Ogre::Vector3 off(0.0f, 2.8f, 0.0f);
-        g_overlay = markerCreateSeh(g, leader, &t, &col, &off);
-        g_overlayLeader = leader; g_overlayState = state; g_overlayText = t;
+        Ogre::Vector3 off(0.0f, offY, 0.0f);
+        *label = markerCreateSeh(g, leader, &t, &col, &off);
+        *leaderSlot = leader; *stateSlot = state; *textSlot = t;
         return;
     }
-    if (t != g_overlayText || state != g_overlayState) {
+    if (t != *textSlot || state != *stateSlot) {
         MyGUI::Colour col; markerColour(overlayColorId(state), &col);
-        markerUpdateSeh(g_overlay, &t, &col);
-        g_overlayText = t; g_overlayState = state;
+        markerUpdateSeh(*label, &t, &col);
+        *textSlot = t; *stateSlot = state;
     }
+}
+} // namespace
+
+void coopOverlayTick(GameWorld* gw, const char* text, int state, bool show) {
+    ForgottenGUI* g = ::gui;
+    if (!g) return;
+    // Persistent status banner: pinned at head height 2.8 (spike-47 render offset).
+    trackedLabelTick(g, gw, text, state, show, 2.8f,
+                     &g_overlay, &g_overlayLeader, &g_overlayState, &g_overlayText);
+}
+
+void coopToastTick(GameWorld* gw, const char* text, int state, bool show) {
+    ForgottenGUI* g = ::gui;
+    if (!g) return;
+    // Ephemeral transition toast: sits at 3.4, just ABOVE the persistent overlay,
+    // so a "Peer connected/disconnected" pop never overlaps the status banner.
+    trackedLabelTick(g, gw, text, state, show, 3.4f,
+                     &g_toast, &g_toastLeader, &g_toastState, &g_toastText);
 }
 
 } // namespace engine

--- a/src/plugin/game/EngineUi.h
+++ b/src/plugin/game/EngineUi.h
@@ -51,6 +51,14 @@ void coopPanelTick(const CoopPanelState* st, CoopConnectFn onConnect,
 // to remove it. Main-thread only; SEH-guarded.
 void coopOverlayTick(GameWorld* gw, const char* text, int state, bool show);
 
+// Ephemeral co-op TOAST: a second leader-tracked ScreenLabel, sitting just above
+// the persistent overlay, that announces a peer CONNECT/DISCONNECT transition for
+// a few seconds and then self-hides. Same render path (marker* shims) and state
+// colouring as the overlay, but an independent label with its own lifetime - the
+// caller drives show via ToastTimer's toastVisible(), passing show=false once the
+// window elapses so this removes it. Main-thread only; SEH-guarded.
+void coopToastTick(GameWorld* gw, const char* text, int state, bool show);
+
 } // namespace engine
 } // namespace coop
 

--- a/src/plugin/game/ToastTimer.h
+++ b/src/plugin/game/ToastTimer.h
@@ -1,0 +1,40 @@
+// ToastTimer - pure visibility clock for the ephemeral on-screen co-op toast.
+//
+// The persistent status overlay (coopOverlayTick) shows the CURRENT session
+// state (offline/waiting/connected) and stays up as long as the session runs.
+// It cannot, on its own, announce a TRANSITION: the exact moment a peer connects
+// or drops. This module is the timer behind a second, EPHEMERAL banner
+// (coopToastTick) that pops "Peer connected" / "Peer disconnected" for a few
+// seconds and then removes itself - distinct from the persistent overlay.
+//
+// Only the timing decision lives here, as pure inline logic with no I/O and no
+// game/GUI dependency, so the unit layer (prototest) can lock it without linking
+// the engine. The Plugin arms the toast (records nowMs) on a connect/leave edge
+// and each frame asks toastVisible() whether to still draw it; the drawing is
+// EngineUi's job.
+
+#ifndef KENSHICOOP_TOAST_TIMER_H
+#define KENSHICOOP_TOAST_TIMER_H
+
+namespace coop {
+namespace engine {
+
+// How long an armed toast stays on screen before it self-hides (ms). A few
+// seconds: long enough to read the transition, short enough to feel momentary
+// and never be mistaken for the persistent status banner.
+const unsigned long TOAST_SHOW_MS = 4000;
+
+// Pure visibility decision (unit-testable): a toast armed at armMs is visible at
+// nowMs while fewer than durationMs have elapsed. An un-armed toast is never
+// visible. The subtraction is unsigned so a GetTickCount() wrap within one
+// window still yields the true elapsed delta (mirrors poseClearElapsed).
+inline bool toastVisible(bool armed, unsigned long armMs, unsigned long nowMs,
+                         unsigned long durationMs) {
+    if (!armed) return false;
+    return (unsigned long)(nowMs - armMs) < durationMs;
+}
+
+} // namespace engine
+} // namespace coop
+
+#endif // KENSHICOOP_TOAST_TIMER_H

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -27,6 +27,14 @@ const enet_uint8 CH_UNRELIABLE = 1;  // entity batches / stealth / cam (newest s
 const enet_uint8 CH_BULK       = 2;  // coordinated save/load transfer (bulk reliable)
 const int        CH_COUNT      = 3;  // channels negotiated at host-create / connect
 
+// Disconnect reason codes carried in enet_peer_disconnect(peer, data) - ENet
+// delivers 'data' to the peer as event.data on its DISCONNECT event. This is how
+// the HOST tells a REJECTED joiner WHY (the host detects a version mismatch at
+// HELLO, before any WELCOME, so the join otherwise just sees a bare disconnect
+// and no on-screen reason). 0 = normal/graceful (ENet's default); nonzero = a
+// specific reason the peer can map to a user-facing message.
+const enet_uint32 DISCONNECT_VERSION_MISMATCH = 1;
+
 // Net-thread diagnostics. OutputDebugStringA is thread-safe, and CoopLog guards
 // its FILE* with a lock, so both are safe to call off the main thread.
 void netLog(const char* msg) {
@@ -47,6 +55,20 @@ void netErr(const char* msg) {
     buf[sizeof(buf) - 1] = '\0';
     coop::logErrLine(buf);
 }
+
+// Cross-thread UI-error channel backing store (see NetLink.h). The buffer holds
+// the latest player-facing connection-reject reason; the NET thread writes it and
+// the MAIN thread reads it. Wrapped in a global object whose constructor runs at
+// DLL load under the loader lock (single-threaded, before any net thread exists),
+// so the CRITICAL_SECTION is always initialized before first use - no lazy-init
+// race (VC10 has no thread-safe function-local statics).
+struct NetUiErrChannel {
+    CRITICAL_SECTION cs;
+    char             buf[256];
+    NetUiErrChannel() { InitializeCriticalSection(&cs); buf[0] = '\0'; }
+    ~NetUiErrChannel() { DeleteCriticalSection(&cs); }
+};
+NetUiErrChannel g_netUiErr; // constructed at DLL load, destroyed at unload
 
 // Monotonic ms clock for the batch send stamp (v35). QPC, not GetTickCount:
 // the receiver reconstructs snapshot SPACING from consecutive stamps, and
@@ -77,6 +99,31 @@ void pushLocked(CRITICAL_SECTION& cs, std::vector<T>& q, const T& v) {
 }
 } // namespace
 
+// Cross-thread UI-error channel (declared in NetLink.h). setNetUiError() is
+// called on the NET thread; netUiError()/clearNetUiError() on the MAIN thread.
+// All three take the same lock, so the buffer is never read mid-write.
+void setNetUiError(const char* msg) {
+    EnterCriticalSection(&g_netUiErr.cs);
+    _snprintf(g_netUiErr.buf, sizeof(g_netUiErr.buf) - 1, "%s", msg ? msg : "");
+    g_netUiErr.buf[sizeof(g_netUiErr.buf) - 1] = '\0';
+    LeaveCriticalSection(&g_netUiErr.cs);
+}
+const char* netUiError() {
+    // The caller (F2 panel) is MAIN-thread only, so copy the shared buffer into a
+    // MAIN-thread-private static under the lock and hand back a stable pointer -
+    // the returned string can't be torn by a concurrent NET-thread write.
+    static char mainCopy[256];
+    EnterCriticalSection(&g_netUiErr.cs);
+    memcpy(mainCopy, g_netUiErr.buf, sizeof(mainCopy));
+    LeaveCriticalSection(&g_netUiErr.cs);
+    return mainCopy;
+}
+void clearNetUiError() {
+    EnterCriticalSection(&g_netUiErr.cs);
+    g_netUiErr.buf[0] = '\0';
+    LeaveCriticalSection(&g_netUiErr.cs);
+}
+
 NetLink::NetLink()
     : isHost_(false), port_(0),
       enetHost_(0), serverPeer_(0), inbound_(0),
@@ -94,11 +141,13 @@ NetLink::~NetLink() {
 }
 
 bool NetLink::startHost(int port, Inbound* inbound) {
+    clearNetUiError(); // wipe any reject reason from a previous attempt
     isHost_ = true; port_ = port; inbound_ = inbound; myId_ = 0;
     return launchThread();
 }
 
 bool NetLink::startClient(const std::string& ip, int port, Inbound* inbound) {
+    clearNetUiError(); // wipe any reject reason from a previous attempt
     isHost_ = false; ip_ = ip; port_ = port; inbound_ = inbound; myId_ = 0;
     return launchThread();
 }
@@ -452,7 +501,15 @@ void NetLink::threadLoop() {
                                           (unsigned)h.version, (unsigned)PROTOCOL_VERSION);
                                 b[sizeof(b) - 1] = '\0';
                                 netErr(b);
-                                enet_peer_disconnect(ev.peer, 0);
+                                // Surface the reject on the host's F2 panel too, not
+                                // just the log: the joiner was turned away for a
+                                // version mismatch and the host should see why.
+                                setNetUiError("Rejected a joiner: version mismatch - "
+                                              "update both to the same KenshiCoop build");
+                                // Carry the reason to the join in the disconnect data,
+                                // so the rejected player sees WHY on their own screen
+                                // (they never get a WELCOME to check the version).
+                                enet_peer_disconnect(ev.peer, DISCONNECT_VERSION_MISMATCH);
                             } else {
                                 u32 id = nextId++;
                                 // TWO-PLAYER ASSUMPTION (step-6 guard): the sync model
@@ -464,6 +521,10 @@ void NetLink::threadLoop() {
                                 if (id >= 2) {
                                     netErr("3+ players unsupported: join-authored state is "
                                            "not relayed peer-to-peer; expect desync");
+                                    // A clear, user-visible warning on the host's panel
+                                    // (this is a soft guard - the peer is still admitted).
+                                    setNetUiError("3+ players not supported - "
+                                                  "expect desync");
                                 }
                                 ev.peer->data = (void*)(size_t)id;
                                 WelcomePacket w;
@@ -490,6 +551,11 @@ void NetLink::threadLoop() {
                                           (unsigned)w.version, (unsigned)PROTOCOL_VERSION);
                                 b[sizeof(b) - 1] = '\0';
                                 netErr(b);
+                                // THE key UX fix: the JOIN used to sit on "Connecting..."
+                                // and silently drop to "Offline" here. Publish the real
+                                // reason so the F2 panel/overlay shows it on screen.
+                                setNetUiError("Version mismatch with host - "
+                                              "update both to the same KenshiCoop build");
                             } else {
                                 InterlockedExchange(&myId_, (LONG)w.playerId);
                                 char b[96];
@@ -893,6 +959,14 @@ void NetLink::threadLoop() {
                     } else {
                         serverPeer_ = 0;
                         if (inbound_) inbound_->pushLeave(OWNER_ID_ALL);
+                        // The host may have carried a reject reason in the disconnect
+                        // data (version mismatch): surface it so the JOIN shows WHY on
+                        // screen instead of silently dropping to "Offline".
+                        if (ev.data == DISCONNECT_VERSION_MISMATCH) {
+                            netErr("host rejected us: protocol/version mismatch");
+                            setNetUiError("Version mismatch with host - "
+                                          "update both to the same KenshiCoop build");
+                        }
                         netLog("disconnected from host");
                     }
                     break;

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -25,6 +25,21 @@
 
 namespace coop {
 
+// --- Cross-thread connection-error channel (NET thread -> UI) ----------------
+// The NET thread rejects/aborts a connection for reasons a player must see
+// (protocol/version mismatch above all): before this channel those reasons only
+// reached the file log via netErr(), so a failed JOIN just sat on "Connecting..."
+// and then fell back to "Offline" with no explanation on screen. setNetUiError()
+// publishes a one-line human reason under an internal lock; the MAIN-thread F2
+// panel/overlay reads it each tick via netUiError() and shows it over the generic
+// status. clearNetUiError() is called when a fresh connect attempt starts so a
+// stale reason from a previous try never lingers. The buffer is guarded by a
+// CRITICAL_SECTION constructed at DLL load (before any net thread exists), so
+// every access is race-free.
+void        setNetUiError(const char* msg); // NET thread: publish a reject reason
+const char* netUiError();                   // MAIN thread: "" when none pending
+void        clearNetUiError();              // MAIN thread: wipe on a new attempt
+
 class NetLink {
 public:
     NetLink();

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -33,6 +33,7 @@
 #include "../plugin/core/Inbound.h" // Phase 0 queue-lifecycle fixes (header-only)
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
+#include "../plugin/game/ToastTimer.h"   // ephemeral connect/disconnect toast clock
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
 
 #include <set>
@@ -1355,6 +1356,46 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- 12. Ephemeral toast visibility clock (ToastTimer.h toastVisible) -----------
+// Guards the peer connect/disconnect on-screen TOAST (2026-07-21): armPeerToast
+// records GetTickCount at the connect/leave edge and coopPanelDrive keeps the
+// EngineUi toast label shown only while toastVisible() is true, then disarms so
+// the label self-hides - the "momentary transition notice" distinct from the
+// persistent status banner. This locks the pure timing: un-armed is never shown,
+// an armed toast shows through the window and hides exactly at TOAST_SHOW_MS, and
+// the unsigned subtraction tolerates a GetTickCount wrap mid-window.
+static void testToastTimer() {
+    std::printf("== ephemeral toast visibility clock (ToastTimer.h) ==\n");
+    using coop::engine::toastVisible;
+    const unsigned long dur = coop::engine::TOAST_SHOW_MS; // 4000
+
+    // Un-armed: never visible, whatever the clock says.
+    CHECK("unarmed never visible",        !toastVisible(false, 0,     999999, dur));
+    CHECK("unarmed never visible (armMs)",!toastVisible(false, 10000, 10000,  dur));
+
+    // Armed: visible from the arming instant, through the window, hidden AT the
+    // boundary (elapsed >= duration) and after.
+    CHECK("armed visible at t0",           toastVisible(true, 10000, 10000, dur));
+    CHECK("armed visible mid-window",      toastVisible(true, 10000, 12000, dur));
+    CHECK("armed visible at 3999 ms",      toastVisible(true, 10000, 13999, dur));
+    CHECK("armed hidden AT window (4000)", !toastVisible(true, 10000, 14000, dur));
+    CHECK("armed hidden past window",      !toastVisible(true, 10000, 20000, dur));
+
+    // GetTickCount wrap: armed 100 ms before the 2^32 rollover, the unsigned delta
+    // still measures true elapsed time across the boundary.
+    const unsigned long nearMax  = 0xFFFFFFFFul - 100; // armed 100 ms before wrap
+    const unsigned long preWrap  = nearMax + 50;       // 50 ms later, no overflow
+    const unsigned long postWrap = 1899UL;             // (nearMax + 2000) mod 2^32
+    const unsigned long postHide = 3999UL;             // (nearMax + 4100) mod 2^32
+    CHECK("wrap: 50 ms still visible",     toastVisible(true, nearMax, preWrap,  dur));
+    CHECK("wrap: 2000 ms still visible",   toastVisible(true, nearMax, postWrap, dur));
+    CHECK("wrap: 4100 ms hidden",         !toastVisible(true, nearMax, postHide, dur));
+
+    // Duration sanity: a few seconds - long enough to read, short enough to feel
+    // momentary and not be mistaken for the persistent banner.
+    CHECK("toast window sane (2-8 s)", dur >= 2000 && dur <= 8000);
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1377,6 +1418,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testToastTimer();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
### What this fixes

When something fails on connect (protocol/version mismatch, lobby issues), the player never sees why — it only goes to the log file, which a normal player never opens. Two concrete gaps:

1. `NetLink.cpp` rejects a peer on protocol mismatch with only a log line (`netErr(...)`) — the join is left on "Connecting…" and eventually falls back to "Offline" with zero explanation.
2. `SteamInvite.cpp` already builds good user-facing messages via `setStatus()`/`status()` (e.g. "Version mismatch with host - update both sides") — but nothing consumes `status()`. It's a dead getter.

### How

- `NetLink.h/.cpp`: new cross-thread NET→UI error channel (critical-section guarded buffer, constructed at DLL load so there's no init race with the net thread). On a protocol-mismatch rejection, the host both logs it and calls `enet_peer_disconnect` with a reason code; the client reads that reason code off the `ENET_EVENT_TYPE_DISCONNECT` event and surfaces it too (this is the only reliable path for the join, since it never gets a WELCOME on a real mismatch).
- `Plugin.cpp` (`coopPanelDrive`): now consumes the net-error channel and the previously-orphaned `steaminvite::status()`, with priority over the generic Offline/Connecting/Connected text.
- Reused the native ENet disconnect-reason mechanism rather than inventing a new packet type.

Second half of this PR: a connect/disconnect **toast** — a separate ephemeral message ("Peer connected"/"Peer disconnected") distinct from the persistent status banner, for the actual moment of the network transition. New `ToastTimer.h` (pure, testable visibility clock) and a shared `trackedLabelTick` helper so the toast and the persistent banner reuse the same render path without ever overlapping (different screen offsets).

### Testing

- Unit: prototest 432/432 (11 new `testToastTimer` checks: unarmed/armed/exact 4000ms boundary/`GetTickCount` wrap).
- Live, 2-client real session: forced a real protocol mismatch (host v44, join v43) — host log shows the rejection, join log shows `host rejected us: protocol/version mismatch` via the new disconnect-reason handler, and a screenshot confirms the host's overlay shows **"Rejected a joiner: version mismatch - update both to the same KenshiCoop build"** in-game, not just in the log.
- Live, toast: screenshots confirm the green "Peer connected" toast appears above the persistent green banner on connect and auto-hides after ~4s (banner survives); same for the red "Peer disconnected" toast over the yellow "waiting for peer" banner on disconnect.

### What was NOT tested

Didn't get a screenshot of the *join*-side error overlay specifically (an unrelated RE_Kenshi startup popup blocked that client's auto-load mid-test) — the join's net layer connected and received the rejection correctly per the logs, and it renders through the identical `coopPanelDrive` path already shown working on the host, but I don't have a second screenshot for that specific side.
