### PR TITLE
Remember the last pasted friend's Steam ID between sessions

### DIFF
--- a/scripts/build_prototest.cmd
+++ b/scripts/build_prototest.cmd
@@ -5,7 +5,8 @@ REM (VC++ 2010) x64 compiler as the plugin so the packed-struct layout under
 REM test is EXACTLY the layout the shipped DLL compiles (that is the point:
 REM prototest locks the wire contract of this toolchain).
 REM
-REM No game/KenshiLib/ENet dependencies - just the CRT.
+REM No game/KenshiLib/ENet dependencies - just the CRT (+ Win32 for Config.cpp's
+REM last-peer file, which resolves next to the module = cwd in this test exe).
 setlocal
 
 set "REPO=%~dp0.."
@@ -29,7 +30,8 @@ cl.exe /nologo /O2 /EHsc /W3 ^
     /Fo"%REPO%\build\prototest\\" ^
     /Fe"%REPO%\dist\prototest.exe" ^
     "%REPO%\src\prototest\main.cpp" ^
-    "%REPO%\src\plugin\sync\Interp.cpp"
+    "%REPO%\src\plugin\sync\Interp.cpp" ^
+    "%REPO%\src\plugin\core\Config.cpp"
 if errorlevel 1 (
     echo prototest build FAILED
     exit /b 1

--- a/src/plugin/core/Config.cpp
+++ b/src/plugin/core/Config.cpp
@@ -2,6 +2,7 @@
 
 #include "Config.h"
 #include "OwnRanks.h"
+#include "SteamId.h" // parseSteamId64 (pure) - re-validates the persisted last-peer file
 #include <cstdlib>
 #include <cstdio>
 #include <map>
@@ -70,16 +71,30 @@ std::map<std::string, std::string> parseFlatJson(const std::string& text) {
     return m;
 }
 
-// Absolute path to coop_config.json next to KenshiCoop.dll (fallback: cwd).
-std::string configFilePath() {
+// Directory that holds KenshiCoop.dll, with a trailing slash (fallback: cwd = "").
+// Both the config file and its sibling last-peer file live here.
+std::string moduleDirPath() {
     char buf[MAX_PATH];
     HMODULE h = GetModuleHandleA("KenshiCoop.dll");
     DWORD n = GetModuleFileNameA(h, buf, MAX_PATH); // h == 0 would give the exe path
-    if (h == 0 || n == 0 || n >= MAX_PATH) return "coop_config.json";
+    if (h == 0 || n == 0 || n >= MAX_PATH) return std::string();
     std::string p(buf, n);
     size_t slash = p.find_last_of("\\/");
-    p = (slash != std::string::npos) ? p.substr(0, slash + 1) : std::string();
-    return p + "coop_config.json";
+    return (slash != std::string::npos) ? p.substr(0, slash + 1) : std::string();
+}
+
+// Absolute path to coop_config.json next to KenshiCoop.dll (fallback: cwd).
+std::string configFilePath() {
+    return moduleDirPath() + "coop_config.json";
+}
+
+// Absolute path to the sibling last-peer file (coop_last_peer.txt) next to
+// coop_config.json / the DLL. This is the tiny convenience store for the friend
+// SteamID last pasted in the F2 panel - kept OUT of coop_config.json so the
+// hand-authored config (with its // comments, which our flat parser would strip
+// on a rewrite) is never clobbered.
+std::string lastPeerFilePath() {
+    return moduleDirPath() + "coop_last_peer.txt";
 }
 
 std::map<std::string, std::string> readConfigFile() {
@@ -247,6 +262,13 @@ void loadConfig(Config& c) {
     c.transport = envOr("KENSHICOOP_TRANSPORT", fileOr(f, "transport", "udp").c_str());
     c.steamPeer = (unsigned long long)_strtoui64(
         envOr("KENSHICOOP_STEAM_PEER", fileOr(f, "steamPeer", "0").c_str()).c_str(), 0, 10);
+    // Lowest-precedence default: if neither the env var nor coop_config.json set a
+    // peer (the normal panel-driven install ships steamPeer unset), fall back to the
+    // friend SteamID last pasted in the F2 panel (persisted in coop_last_peer.txt).
+    // This flows through to CoopPanelState::peerSteamId, so the panel opens with the
+    // last friend's ID pre-filled; the player can still paste a different one to play
+    // with someone else that session. Precedence stays env > file > last-pasted.
+    if (c.steamPeer == 0) c.steamPeer = loadLastPeer();
     c.steamPing = (unsigned long long)_strtoui64(envOr("KENSHICOOP_STEAM_PING", "0").c_str(), 0, 10);
 
     // In-game panel session control: opt-in legacy auto-start. Default OFF so a
@@ -413,6 +435,31 @@ void reloadPeerFromFile(Config& c) {
     if (it != f.end() && !it->second.empty()) c.ip = it->second;
     it = f.find("port");
     if (it != f.end() && !it->second.empty()) c.port = std::atoi(it->second.c_str());
+}
+
+void saveLastPeer(unsigned long long id) {
+    // Persist the friend SteamID last pasted in the F2 panel so a regular co-op
+    // pair does not have to re-paste each other's IDs on every launch. Best-effort:
+    // a failed open is silently ignored (this is only a convenience default). id 0
+    // is a no-op - we never persist "no peer".
+    if (id == 0) return;
+    std::ofstream f(lastPeerFilePath().c_str(), std::ios::binary | std::ios::trunc);
+    if (!f) return;
+    char b[32];
+    _snprintf(b, sizeof(b) - 1, "%llu\n", id);
+    b[sizeof(b) - 1] = '\0';
+    f << b;
+}
+
+unsigned long long loadLastPeer() {
+    // Read the persisted last-peer SteamID (0 if the file is missing/unreadable or
+    // its contents are not a valid SteamID64). Re-validating through parseSteamId64
+    // means a corrupted/edited file can never inject a bogus peer.
+    std::ifstream f(lastPeerFilePath().c_str(), std::ios::binary);
+    if (!f) return 0;
+    std::string text((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    unsigned long long id = 0;
+    return parseSteamId64(text, id) ? id : 0;
 }
 
 } // namespace coop

--- a/src/plugin/core/Config.h
+++ b/src/plugin/core/Config.h
@@ -498,6 +498,14 @@ void loadConfig(Config& out);
 // applies without restarting the game. No-op for keys absent from the file.
 void reloadPeerFromFile(Config& c);
 
+// Persist / read the friend SteamID last pasted in the F2 panel. Stored in a small
+// sibling file (coop_last_peer.txt) next to coop_config.json so a co-op pair does
+// not have to re-paste each other's IDs every launch. saveLastPeer is best-effort
+// (silent on I/O failure) and ignores id 0; loadLastPeer returns 0 when the file is
+// missing or its contents are not a valid SteamID64 (re-validated on read).
+void saveLastPeer(unsigned long long id);
+unsigned long long loadLastPeer();
+
 // One-line summary of the RESOLVED (effective) config - every sync channel's
 // on/off state plus the key tuning knobs - for the startup log. Makes "which
 // config did this run actually use?" answerable from the log alone (real

--- a/src/plugin/game/EngineUi.cpp
+++ b/src/plugin/game/EngineUi.cpp
@@ -24,6 +24,7 @@
 #include <windows.h>
 
 #include "../core/SteamId.h" // parseSteamId64 (pure) for the paste-from-clipboard button
+#include "../core/Config.h"  // saveLastPeer - persist the pasted friend ID for next launch
 
 namespace coop {
 namespace engine {
@@ -213,10 +214,10 @@ DataPanelLine*          g_peerLine     = 0; // white "Friend's Steam ID" row
 DataPanelLine*          g_selfLine     = 0; // white "Your Steam ID" row
 std::string             g_selfIdStr;   // self SteamID as digits (set each tick; "" = none)
 
-// Friend's SteamID pasted in-panel this session (0 = none). Per-session by
-// design: it lives only in memory, so relaunching Kenshi clears it and the
-// friend's id is re-pasted (nothing is written to disk). Passed to onConnect,
-// where it overrides the (usually empty) config steamPeer.
+// Friend's SteamID pasted in-panel this session (0 = none). A valid paste is also
+// persisted to coop_last_peer.txt (see saveLastPeer) so the NEXT launch pre-fills
+// it as the default peer; within a session this in-memory value is still what wins
+// and is passed to onConnect, overriding the (usually empty) config steamPeer.
 unsigned long long      g_pastedPeer   = 0;
 bool                    g_pasteFailed  = false; // last paste wasn't a valid Steam ID
 
@@ -265,6 +266,10 @@ void onPasteIdBtn(DataPanelLine*) {
     if (clipboardGetText(clip) && coop::parseSteamId64(clip, id)) {
         g_pastedPeer  = id;
         g_pasteFailed = false;
+        // Persist for next launch so a regular co-op pair never re-pastes (best-
+        // effort; a write failure only loses the convenience default, not this
+        // session's peer, which lives in g_pastedPeer above).
+        coop::saveLastPeer(id);
         char b[64];
         _snprintf(b, sizeof(b) - 1, "[coop-ui] paste friend id=%llu ok=1", id);
         b[sizeof(b) - 1] = '\0';

--- a/src/plugin/game/EngineUi.h
+++ b/src/plugin/game/EngineUi.h
@@ -21,8 +21,10 @@ namespace engine {
 // MyGUI comboboxes/editboxes have no usable RVAs and don't receive keyboard focus
 // during gameplay) and Connect/Disconnect. The friend's Steam ID is entered by
 // clipboard: "Copy my Steam ID" puts the player's own id on the clipboard to
-// share, and "Paste friend's Steam ID" reads the friend's id back in (per-session,
-// never written to disk). The UDP endpoint (ip/port) still comes from
+// share, and "Paste friend's Steam ID" reads the friend's id back in. A valid
+// paste is remembered across launches (persisted to coop_last_peer.txt) so it
+// pre-fills next time; it stays overridable by pasting a different friend's id.
+// The UDP endpoint (ip/port) still comes from
 // coop_config.json. The GUI layer stays session-agnostic: live status is passed IN
 // via *st and the user's actions are handed BACK through the callbacks (the plugin
 // root owns the session/config wiring). Main-thread only; SEH-guarded.

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -28,6 +28,7 @@
 #include "../plugin/sync/Interp.h"
 #include "../plugin/core/OwnRanks.h"
 #include "../plugin/core/SteamId.h"
+#include "../plugin/core/Config.h" // saveLastPeer/loadLastPeer round-trip (compiled from Config.cpp)
 #include "../plugin/core/WorkPose.h"
 #include "../plugin/core/DeathLatch.h"
 #include "../plugin/core/Inbound.h" // Phase 0 queue-lifecycle fixes (header-only)
@@ -781,6 +782,41 @@ static void testSteamIdParse() {
           !coop::parseSteamId64("12345678901234567", id) && id == 123ull);
 }
 
+// ---- 7b. Last-peer persistence (Config.cpp saveLastPeer/loadLastPeer) ------------
+// Guards the F2-panel convenience persistence: a valid pasted friend SteamID is
+// written to coop_last_peer.txt so the next launch pre-fills it (loadConfig folds
+// it into steamPeer when neither env nor coop_config.json set one). The store must
+// round-trip, re-validate on read (a junk file yields 0, never a bogus peer), and
+// treat id 0 as "nothing to remember". No game deps - path resolves next to the
+// module, which for this test exe is the cwd (GetModuleHandleA("KenshiCoop.dll")
+// is null here), so the file lands in the working dir and is cleaned up after.
+static void testLastPeerPersist() {
+    std::printf("== last-peer persistence (Config.cpp) ==\n");
+    std::remove("coop_last_peer.txt"); // start from a known-empty state
+
+    CHECK("missing file -> 0", coop::loadLastPeer() == 0ull);
+
+    coop::saveLastPeer(76561198012345678ull);
+    CHECK("saved id round-trips", coop::loadLastPeer() == 76561198012345678ull);
+
+    // A later paste overwrites the remembered id (truncating write, not appending).
+    coop::saveLastPeer(76561198099999999ull);
+    CHECK("second save overwrites", coop::loadLastPeer() == 76561198099999999ull);
+
+    // id 0 is a no-op: it must NOT wipe the remembered peer.
+    coop::saveLastPeer(0ull);
+    CHECK("save(0) is a no-op", coop::loadLastPeer() == 76561198099999999ull);
+
+    // A corrupted/edited file re-validates to 0 (parseSteamId64 gate on read).
+    {
+        std::FILE* f = std::fopen("coop_last_peer.txt", "wb");
+        if (f) { std::fputs("not-a-steam-id", f); std::fclose(f); }
+        CHECK("corrupted file -> 0", coop::loadLastPeer() == 0ull);
+    }
+
+    std::remove("coop_last_peer.txt"); // clean up the test artifact
+}
+
 // ---- 8. Pose-fixture acceptance (WorkPose.h) ------------------------------------
 // Guards the mining-sync fix (2026-07-14): a player mining an ore node operates a
 // mine building. A single 6 m seat gate rejected the CORRECT mine as "far"
@@ -1371,6 +1407,7 @@ int main() {
     testInterp();
     testOwnRanks();
     testSteamIdParse();
+    testLastPeerPersist();
     testWorkPoseMatch();
     testTaskClear();
     testDeathRekey();


### PR DESCRIPTION
### What this fixes

The pasted friend's Steam ID lives only in memory — every relaunch, both players have to re-copy/paste each other's ID to reconnect. Small but real friction for two friends playing regularly, and a silent-failure risk if either side mistypes it.

### How

- `Config.h/.cpp`: `saveLastPeer(id)` / `loadLastPeer()`, persisted to a sibling file (`coop_last_peer.txt`) next to `coop_config.json` rather than rewriting that file directly (it has `//` comments a plain parser would strip). Precedence stays env > `coop_config.json` > last-pasted value, so nothing existing changes behavior. Re-validated through the existing `parseSteamId64` on load — a corrupted file resolves to 0, never garbage.
- `EngineUi.cpp`: saves on a valid paste; the panel already read from `steamPeer` for display, so no UI change needed for the preload itself.
- UX call: remember-the-last-one by default, no separate opt-in checkbox — it's just a prefill the player can always overwrite by pasting a different ID, so an extra toggle felt like unnecessary panel clutter.

### Testing

- Unit: 5 new checks (round-trip, overwrite-on-second-save, save(0) is a no-op, missing file → 0, corrupted file → 0). Prototest 426/426 total.
- Live: screenshots confirm the panel field is empty on first run, and shows the persisted ID prefilled after a relaunch with `coop_last_peer.txt` present.

### What was NOT tested

The literal in-game mouse click on "Paste friend's Steam ID" isn't automatable with the input tooling I had (Kenshi's OIS/DirectInput input doesn't see synthetic window-message clicks reliably) — the save path (paste → `saveLastPeer`) is unit-tested directly and the call site is a one-line hookup, and the load → prefill path is confirmed live end-to-end, so the full chain is covered, just not via an actual mouse click in the loop.
