### PR TITLE
Add a free camera mode (client-only, reimplemented for 1.0.65)

### DIFF
--- a/src/plugin/KenshiCoop.vcxproj
+++ b/src/plugin/KenshiCoop.vcxproj
@@ -124,6 +124,7 @@
     <ClCompile Include="game\EngineSpawnCombat.cpp" />
     <ClCompile Include="game\EngineCharState.cpp" />
     <ClCompile Include="game\EngineWorld.cpp" />
+    <ClCompile Include="game\FreeCamera.cpp" />
     <!-- Diagnostic probes (spike 401/451/402): HARNESS-ONLY, excluded from the
          shipped Release DLL like the Scenario*.cpp harness (Phase 5e). Its only
          callers are the probe scenarios, which are themselves Release-excluded. -->

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -1455,6 +1455,14 @@ void mainLoop_hook(GameWorld* gw, float dt) {
     // apply (its caches are now stale; the reset runs next tick's reload edge).
     tickReplicateApply(gw, worldLive);
 
+    // Cámara libre local (capturas / vídeo). POST-motor: el update() orbital ya
+    // corrió este frame, así que nuestra posición es la última que ve el renderer.
+    // Puramente local/visual (no red, no sync). Solo en sesiones interactivas
+    // (scenario vacío + sin test-seconds), igual que el panel F2, para no perturbar
+    // los oráculos del harness. El gate de config + la tecla van dentro.
+    if (g_cfg.scenario.empty() && g_cfg.testSeconds == 0)
+        coop::engine::freeCameraTick(gw, g_cfg.freeCamera);
+
     // Coordinated load deferred-signal backstop: if the LOADGAME signal stalls
     // past the grace window, pump SaveManager::execute() once from end-of-tick.
     tickLoadPumpBackstop(gw);

--- a/src/plugin/core/Config.cpp
+++ b/src/plugin/core/Config.cpp
@@ -249,6 +249,10 @@ void loadConfig(Config& c) {
         envOr("KENSHICOOP_STEAM_PEER", fileOr(f, "steamPeer", "0").c_str()).c_str(), 0, 10);
     c.steamPing = (unsigned long long)_strtoui64(envOr("KENSHICOOP_STEAM_PING", "0").c_str(), 0, 10);
 
+    // Cámara libre local (feature de capturas/vídeo). DEFAULT ON; "0" la
+    // deshabilita. Es puramente local/visual: no hay wire, no hay sync.
+    c.freeCamera = envOr("KENSHICOOP_FREE_CAMERA", "1") != "0";
+
     // In-game panel session control: opt-in legacy auto-start. Default OFF so a
     // panel-driven (env-free) install defers the session to the Connect button;
     // the test harness overrides this in Plugin.cpp (scenario / test-seconds).
@@ -370,7 +374,7 @@ std::string describeConfig(const Config& c) {
         { "store",   c.storeSync },    { "squad",   c.squadSync },
         { "latejoin",c.latejoinSync }, { "aiSuspend", c.aiSuspend },
         { "gateAuth",c.gateAuthority },{ "camInterest", c.camInterest },
-        { "censusFreezeAi", c.censusFreezeAi },
+        { "censusFreezeAi", c.censusFreezeAi }, { "freeCam", c.freeCamera },
     };
     s += " on=[";
     bool first = true;

--- a/src/plugin/core/Config.h
+++ b/src/plugin/core/Config.h
@@ -477,6 +477,15 @@ struct Config {
     // independent of the transport in use. 0 = off.
     unsigned long long steamPing;
 
+    // Cámara libre local (KENSHICOOP_FREE_CAMERA != "0"; DEFAULT ON). Feature de
+    // conveniencia 100% CLIENTE/VISUAL para capturas y vídeo: la tecla F3 desacopla
+    // la cámara Ogre del personaje y la deja volar con WASD + Q/E + flechas. No
+    // toca ningún canal de sync ni se replica al peer (cada jugador activa la suya
+    // de forma independiente). Solo actúa en sesiones interactivas (scenario vacío
+    // + sin test-seconds), igual que el panel F2, para no perturbar los oráculos.
+    // "0" es la escotilla de escape (deshabilita la tecla por completo).
+    bool          freeCamera;
+
     // In-game co-op panel session control (2026-07-13). When the mod is driven
     // by the F2 panel instead of the env launchers, networking is DEFERRED at
     // load: the session (host listen / client connect) only starts when the

--- a/src/plugin/core/FreeCamMath.h
+++ b/src/plugin/core/FreeCamMath.h
@@ -1,0 +1,100 @@
+// FreeCamMath.h - lógica PURA de la cámara libre (sin dependencias de Ogre ni
+// del juego). Aislada aquí para poder testearla en prototest.exe (igual que
+// WorkPose.h / DeathLatch.h): dado el estado (yaw, pitch, posición) y el input
+// del teclado, calcula la nueva posición y el vector de vista de la cámara.
+//
+// La implementación runtime (FreeCamera.cpp) usa ESTAS MISMAS funciones y luego
+// vuelca el resultado en el Ogre::Camera* real, de modo que lo que valida el
+// test es exactamente la matemática que corre en el juego.
+//
+// Convención (Ogre, right-handed, la cámara mira hacia -Z local):
+//   yaw   = rotación horizontal alrededor de +Y  (0 => mirando a -Z)
+//   pitch = rotación vertical                     (0 => horizontal; + => arriba)
+
+#ifndef KENSHICOOP_FREECAM_MATH_H
+#define KENSHICOOP_FREECAM_MATH_H
+
+#include <cmath>
+
+namespace coop {
+
+// Vector 3D mínimo (sin depender de Ogre::Vector3 para que el test no enlace Ogre).
+struct FcVec3 {
+    float x, y, z;
+};
+
+// Estado del input de un frame (una tecla por eje de movimiento/rotación).
+struct FcInput {
+    bool fwd, back, left, right; // WASD: avanzar/retroceder/strafe
+    bool up, down;               // Q/E o Space/Ctrl: subir/bajar en +Y mundo
+    bool turbo;                  // Shift: multiplicador de velocidad
+};
+
+// Vector de VISTA completo (incluye pitch): hacia dónde mira la cámara. Se pasa
+// tal cual a Ogre::Camera::setDirection en la implementación real.
+inline FcVec3 fcForward(float yaw, float pitch) {
+    float cy = std::cos(yaw),  sy = std::sin(yaw);
+    float cp = std::cos(pitch), sp = std::sin(pitch);
+    FcVec3 f;
+    f.x = sy * cp;
+    f.y = sp;
+    f.z = -cy * cp;
+    return f;
+}
+
+// Vector DERECHA horizontal (ignora el pitch): eje de strafe A/D. Ortogonal al
+// forward horizontal, mantiene el strafe siempre pegado al plano del suelo.
+inline FcVec3 fcRight(float yaw) {
+    FcVec3 r;
+    r.x = std::cos(yaw);
+    r.y = 0.0f;
+    r.z = std::sin(yaw);
+    return r;
+}
+
+// Desplazamiento de un frame (aún sin escalar por velocidad/tiempo): suma de los
+// ejes activos. Se normaliza a magnitud 1 cuando hay input, para que moverse en
+// diagonal no vaya más rápido que en recto (y para que el test sea determinista).
+inline FcVec3 fcMoveDir(float yaw, float pitch, const FcInput& in) {
+    FcVec3 f = fcForward(yaw, pitch);
+    FcVec3 r = fcRight(yaw);
+    FcVec3 d = { 0.0f, 0.0f, 0.0f };
+    if (in.fwd)   { d.x += f.x; d.y += f.y; d.z += f.z; }
+    if (in.back)  { d.x -= f.x; d.y -= f.y; d.z -= f.z; }
+    if (in.right) { d.x += r.x; d.y += r.y; d.z += r.z; }
+    if (in.left)  { d.x -= r.x; d.y -= r.y; d.z -= r.z; }
+    if (in.up)    { d.y += 1.0f; }
+    if (in.down)  { d.y -= 1.0f; }
+    float len = std::sqrt(d.x * d.x + d.y * d.y + d.z * d.z);
+    if (len > 1e-4f) { d.x /= len; d.y /= len; d.z /= len; }
+    return d;
+}
+
+// Nueva posición tras un frame: pos + dir_normalizada * velocidad * dt, con el
+// multiplicador de turbo aplicado. dtSeconds es tiempo REAL de reloj (funciona
+// aunque el juego esté en pausa). baseSpeed en unidades de mundo por segundo.
+inline FcVec3 fcStep(FcVec3 pos, float yaw, float pitch, const FcInput& in,
+                     float baseSpeed, float turboMul, float dtSeconds) {
+    FcVec3 d = fcMoveDir(yaw, pitch, in);
+    float speed = baseSpeed * (in.turbo ? turboMul : 1.0f);
+    float k = speed * dtSeconds;
+    FcVec3 out;
+    out.x = pos.x + d.x * k;
+    out.y = pos.y + d.y * k;
+    out.z = pos.z + d.z * k;
+    return out;
+}
+
+// Aplica un delta de rotación y CLAMPEA el pitch para no dar la vuelta de campana
+// (±~85°). yaw se deja libre (envuelve de forma natural en el seno/coseno).
+inline void fcApplyLook(float* yaw, float* pitch, float dYaw, float dPitch) {
+    const float PITCH_LIMIT = 1.48353f; // ~85 grados en radianes
+    *yaw += dYaw;
+    *pitch += dPitch;
+    if (*pitch >  PITCH_LIMIT) *pitch =  PITCH_LIMIT;
+    if (*pitch < -PITCH_LIMIT) *pitch = -PITCH_LIMIT;
+}
+
+} // namespace coop
+
+#endif // KENSHICOOP_FREECAM_MATH_H

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -271,6 +271,14 @@ void* markerCreate(Character* c, const char* text, int colorId);
 bool  markerUpdate(void* label, const char* text, int colorId);
 void  markerDestroy(void* label);
 
+// ---- Cámara libre local (capturas / vídeo) ----------------------------------
+// Modo de cámara libre reimplementado sobre 1.0.65 (el free-cam nativo solo
+// existe en 1.0.68). Llamado por-frame desde mainLoop_hook DESPUÉS del motor.
+// 'enabled' = master-switch de config (KENSHICOOP_FREE_CAMERA). La tecla F3
+// hace el toggle en runtime. 100% local/visual: no toca red ni sync. Definido
+// en FreeCamera.cpp; SEH-guarded internamente (no-op ante cualquier fallo).
+void freeCameraTick(GameWorld* gw, bool enabled);
+
 // ---- In-game co-op session panel ---------------------------------------------
 // Moved to EngineUi.h (Phase 5a domain split): CoopPanelState, CoopConnectFn,
 // CoopDisconnectFn, coopPanelTick, coopOverlayTick. The UI root (Plugin.cpp)

--- a/src/plugin/game/FreeCamera.cpp
+++ b/src/plugin/game/FreeCamera.cpp
@@ -1,0 +1,254 @@
+// FreeCamera.cpp - modo de cámara LIBRE local (feature de capturas / vídeo).
+//
+// Kenshi 1.0.68 añadió un free-camera nativo (tecla ';'), pero ese código NO
+// existe en el binario 1.0.65 sobre el que corre KenshiCoop: aquí se reimplementa
+// desde cero sobre la infraestructura que sí tenemos.
+//
+// Estrategia (independiente de versión): NO dependemos de ningún RVA de función
+// de CameraClass (los del header vendored no corresponden a 1.0.65). Usamos solo
+//   - los OFFSETS DE MIEMBRO de CameraClass (estables entre versiones): el
+//     Ogre::Camera* vive en +0x68 (cam->camera), su SceneNode en +0x70 (cam->node),
+//     y el estado orbital yaw/pitch/altitude en +0x18/+0x1C/+0x60;
+//   - la API pública de Ogre (OgreMain_x64.lib ya está enlazada).
+//
+// MECÁNICA: la Ogre::Camera cuelga del SceneNode +0x70 (confirmado en runtime:
+// getParentSceneNode() == cam->node). En vez de RE-ESTRUCTURAR el grafo de escena
+// (detachObject es frágil: ABI de Ogre + carrera con el hilo de render), cada
+// frame - DESPUÉS de que el update() orbital del motor haya corrido - sobre-
+// escribimos la POSICIÓN y ORIENTACIÓN de ese node. La cámara, que cuelga de él,
+// va donde la ponemos. Es exactamente lo que el propio motor hace en su update(),
+// así que es tan seguro respecto al hilo de render como el juego base. Mientras
+// nuestro tick corra cada frame, la cámara se queda libre; al desactivar, el
+// update() del motor reencuadra el node sobre el personaje al frame siguiente.
+//
+// 100% CLIENTE/VISUAL: no toca ningún canal de sync ni se replica al peer. Cada
+// jugador activa su propia cámara libre de forma independiente.
+//
+// Control (teclado puro, para no pelearse con el cursor RTS de Kenshi):
+//   F3            toggle on/off
+//   W/S/A/D       avanzar/retroceder/strafe en el plano de la cámara
+//   Q/E           bajar/subir en el eje vertical
+//   Flechas       orientar (yaw/pitch)
+//   Shift         turbo (x4 velocidad)
+// El delta de movimiento usa reloj REAL (GetTickCount), así la cámara se mueve
+// aunque el juego esté en pausa - lo natural para preparar una captura.
+
+#include "EngineInternal.h"
+#include <ogre/OgreSceneNode.h> // SceneNode::setPosition/setOrientation
+#include <ogre/OgreCamera.h>    // Camera::getDerivedPosition/getDerivedOrientation
+#include "../core/FreeCamMath.h"
+
+namespace coop {
+namespace engine {
+
+namespace {
+
+// ---- Estado (main-thread only; una cámara libre por cliente) ----------------
+bool             s_active   = false; // ¿cámara libre activa ahora mismo?
+bool             s_keyDown  = false; // último estado de F3 (para el flanco de subida)
+Ogre::Camera*    s_camera   = 0;     // la Ogre::Camera del cliente (== cam->camera al activar)
+Ogre::SceneNode* s_node     = 0;     // su SceneNode (cam->node, +0x70) - el que movemos
+FcVec3           s_pos       = { 0.0f, 0.0f, 0.0f }; // posición de la cámara libre
+float            s_yaw       = 0.0f; // orientación de la cámara libre (radianes)
+float            s_pitch     = 0.0f;
+unsigned long    s_lastMs    = 0;    // marca de tiempo del frame anterior (delta real)
+// Estado orbital guardado al entrar, restaurado al salir para que la vista normal
+// no quede en un ángulo raro (el update() del motor reencuadra desde estos).
+float            s_savedYaw  = 0.0f;
+float            s_savedPitch = 0.0f;
+float            s_savedAlt  = 0.0f;
+// Transform LOCAL del node guardado al entrar. El motor NO reencuadra el node por
+// sí solo tras salir (solo lo mueve ante input de cámara), así que restauramos su
+// posición/orientación exactas para devolver la vista normal sin residuos.
+Ogre::Vector3    s_savedNodePos;
+Ogre::Quaternion s_savedNodeOrient;
+
+const int   FREECAM_KEY = VK_F3;   // F2 ya lo usa el panel co-op; F3 queda libre
+const float BASE_SPEED  = 40.0f;   // unidades por segundo
+const float TURBO_MUL   = 4.0f;    // multiplicador con Shift
+const float LOOK_SPEED  = 1.6f;    // rad/s de giro con las flechas
+
+// ¿tecla física pulsada AHORA? (bit alto de GetAsyncKeyState).
+inline bool keyHeld(int vk) { return (GetAsyncKeyState(vk) & 0x8000) != 0; }
+
+// Obtiene el CameraClass* vivo del cliente (gw->player->camera) validado como
+// inicializado. Devuelve también el Ogre::Camera* actual para poder detectar un
+// cambio de mundo (recarga) sin volver a derreferenciar fuera del SEH del caller.
+// Sin SEH propio: el caller (freeCameraTick) provee el marco __try.
+bool readCameraClass(GameWorld* gw, CameraClass** outCam, Ogre::Camera** outOgre) {
+    *outCam = 0; *outOgre = 0;
+    if (!gw || !g_camIsInitFn) return false;
+    PlayerInterface* pl = gw->player;
+    if (!pl) return false;
+    CameraClass* cam = pl->camera;
+    if (!cam || !g_camIsInitFn(cam)) return false;
+    *outCam  = cam;
+    *outOgre = cam->camera; // miembro +0x68
+    return true;
+}
+
+// Reconstruye yaw/pitch (nuestra convención, ver FreeCamMath.h) desde la
+// orientación actual de la cámara, para que al activar no haya salto.
+void seedYawPitchFromCamera(Ogre::Camera* oc) {
+    Ogre::Quaternion q = oc->getDerivedOrientation();
+    Ogre::Vector3 dir = q * Ogre::Vector3::NEGATIVE_UNIT_Z; // la cámara mira a -Z local
+    float dy = dir.y;
+    if (dy >  1.0f) dy =  1.0f;
+    if (dy < -1.0f) dy = -1.0f;
+    s_pitch = (float)asin((double)dy);
+    // fcForward: x = sin(yaw)*cos(pitch), -z = cos(yaw)*cos(pitch) => yaw = atan2(x,-z)
+    s_yaw = (float)atan2((double)dir.x, (double)(-dir.z));
+}
+
+// ACTIVA la cámara libre: memoriza la cámara + su node y el estado orbital, y
+// siembra pos/yaw/pitch desde la vista actual. NO reestructura el grafo (no
+// detach). Sin SEH propio (caller lo provee).
+void enterFree(CameraClass* cam) {
+    Ogre::Camera* oc = cam->camera;         // +0x68
+    Ogre::SceneNode* node = cam->node;      // +0x70 (el node al que cuelga la cámara)
+    if (!oc || !node) { coop::logLine("[freecam] ABORT oc/node==0"); return; }
+
+    // Posición/orientación actuales (para arrancar sin salto).
+    Ogre::Vector3 wp = oc->getDerivedPosition();
+    seedYawPitchFromCamera(oc);
+    s_pos.x = wp.x; s_pos.y = wp.y; s_pos.z = wp.z;
+
+    // Guarda el estado orbital para restaurarlo al salir (miembros estables).
+    s_savedYaw   = cam->yaw;      // +0x18
+    s_savedPitch = cam->pitch;    // +0x1C
+    s_savedAlt   = cam->altitude; // +0x60
+    // Guarda el transform LOCAL del node para restaurarlo exactamente al salir.
+    s_savedNodePos    = node->getPosition();
+    s_savedNodeOrient = node->getOrientation();
+
+    s_node   = node;
+    s_camera = oc;
+    s_lastMs = GetTickCount();
+    s_active = true;
+    { char b[112]; _snprintf(b, sizeof(b)-1,
+        "[freecam] ON (camara libre; desacoplada del personaje) pos=%.1f,%.1f,%.1f",
+        wp.x, wp.y, wp.z); b[sizeof(b)-1]='\0'; coop::logLine(b); }
+}
+
+// DESACTIVA: restaura el estado orbital guardado; el update() del motor reencuadra
+// el node sobre el personaje al frame siguiente. 'cam' puede ser 0 (mundo
+// recargado): en ese caso solo limpiamos estado.
+void exitFree(CameraClass* cam) {
+    // Restaura el transform del node a su estado exacto pre-freecam (el motor no
+    // lo reencuadra solo), y los miembros orbitales por si el motor los relee.
+    if (s_node) {
+        s_node->setPosition(s_savedNodePos);
+        s_node->setOrientation(s_savedNodeOrient);
+    }
+    if (cam) {
+        cam->yaw      = s_savedYaw;
+        cam->pitch    = s_savedPitch;
+        cam->altitude = s_savedAlt;
+    }
+    s_active = false;
+    s_camera = 0;
+    s_node   = 0;
+    coop::logLine("[freecam] OFF (camara restaurada al personaje)");
+}
+
+// Un frame de cámara libre: lee el teclado, integra posición/orientación con el
+// delta de reloj REAL y sobre-escribe el transform del node de la cámara. Sin SEH
+// propio. Corre POST-motor, así que pisa lo que el update() orbital acaba de poner.
+void updateFree() {
+    if (!s_camera || !s_node) return;
+
+    unsigned long now = GetTickCount();
+    float dt = (float)(now - s_lastMs) / 1000.0f;
+    s_lastMs = now;
+    if (dt <= 0.0f) return;
+    if (dt > 0.25f) dt = 0.25f; // clampa picos de lag / primer frame
+
+    // Orientación con las flechas.
+    float dYaw = 0.0f, dPitch = 0.0f;
+    if (keyHeld(VK_LEFT))  dYaw   -= LOOK_SPEED * dt;
+    if (keyHeld(VK_RIGHT)) dYaw   += LOOK_SPEED * dt;
+    if (keyHeld(VK_UP))    dPitch += LOOK_SPEED * dt;
+    if (keyHeld(VK_DOWN))  dPitch -= LOOK_SPEED * dt;
+    fcApplyLook(&s_yaw, &s_pitch, dYaw, dPitch);
+
+    // Traslación con WASD + Q/E.
+    FcInput in;
+    in.fwd   = keyHeld('W');
+    in.back  = keyHeld('S');
+    in.left  = keyHeld('A');
+    in.right = keyHeld('D');
+    in.up    = keyHeld('E');
+    in.down  = keyHeld('Q');
+    in.turbo = keyHeld(VK_SHIFT);
+    s_pos = fcStep(s_pos, s_yaw, s_pitch, in, BASE_SPEED, TURBO_MUL, dt);
+
+    // Sobre-escribe el transform del node (la cámara cuelga de él). Construimos la
+    // orientación desde ejes con UP vertical fijo (no getRotationTo, que introduce
+    // roll/ladeo): la cámara mira -Z local, así que sus ejes locales en world son
+    // right/up/(-forward). Esto mantiene el horizonte nivelado al girar.
+    FcVec3 f = fcForward(s_yaw, s_pitch);
+    Ogre::Vector3 fwd(f.x, f.y, f.z);
+    Ogre::Vector3 right = fwd.crossProduct(Ogre::Vector3::UNIT_Y);
+    if (right.squaredLength() < 1e-6f) right = Ogre::Vector3::UNIT_X; // mirada casi vertical
+    right.normalise();
+    Ogre::Vector3 up = right.crossProduct(fwd);
+    up.normalise();
+    Ogre::Quaternion q(right, up, -fwd); // ejes X=right, Y=up, Z=-forward
+    s_node->setPosition(Ogre::Vector3(s_pos.x, s_pos.y, s_pos.z));
+    s_node->setOrientation(q);
+}
+
+} // namespace
+
+// Punto de entrada por-frame (llamado desde mainLoop_hook, POST-motor, para que
+// nuestra transformación sea la última que muestrea el renderer). 'enabled' es el
+// master-switch de config (KENSHICOOP_FREE_CAMERA). Todo el cuerpo va bajo SEH:
+// una cámara/nodo inesperado degrada a no-op en vez de crashear el juego.
+void freeCameraTick(GameWorld* gw, bool enabled) {
+    __try {
+        // Deshabilitada por config: si quedó activa, intenta restaurarla.
+        if (!enabled) {
+            if (s_active) {
+                CameraClass* cam = 0; Ogre::Camera* oc = 0;
+                readCameraClass(gw, &cam, &oc);
+                exitFree((cam && oc == s_camera) ? cam : 0);
+            }
+            s_keyDown = false;
+            return;
+        }
+
+        // Flanco de subida de F3.
+        bool k = keyHeld(FREECAM_KEY);
+        bool edge = (k && !s_keyDown);
+        s_keyDown = k;
+
+        CameraClass* cam = 0;
+        Ogre::Camera* oc = 0;
+        if (!readCameraClass(gw, &cam, &oc)) {
+            // Sin cámara válida (menú de título / world-swap en curso): si
+            // estábamos activos, suelta el estado SIN tocar la cámara vieja
+            // (puntero potencialmente colgante). El usuario re-activa con F3.
+            if (s_active) { s_active = false; s_camera = 0; s_node = 0; }
+            return;
+        }
+
+        // ¿El mundo se recargó bajo nosotros? (la Ogre::Camera es otra). Suelta el
+        // estado: la cámara nueva no está bajo nuestro control, solo reseteamos.
+        if (s_active && oc != s_camera) {
+            s_active = false; s_camera = 0; s_node = 0;
+        }
+
+        if (edge) {
+            if (!s_active) enterFree(cam);
+            else           exitFree(cam);
+        }
+
+        if (s_active) updateFree();
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        // Falla con gracia: abandona el modo libre sin arrastrar punteros dudosos.
+        s_active = false; s_camera = 0; s_node = 0;
+    }
+}
+
+} // namespace engine
+} // namespace coop

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -29,6 +29,7 @@
 #include "../plugin/core/OwnRanks.h"
 #include "../plugin/core/SteamId.h"
 #include "../plugin/core/WorkPose.h"
+#include "../plugin/core/FreeCamMath.h" // cámara libre: matemática pura de movimiento/vista
 #include "../plugin/core/DeathLatch.h"
 #include "../plugin/core/Inbound.h" // Phase 0 queue-lifecycle fixes (header-only)
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
@@ -1355,6 +1356,94 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- Free camera math (src/plugin/core/FreeCamMath.h) ------------------------
+// La misma lógica pura que FreeCamera.cpp vuelca en la Ogre::Camera real: vector
+// de vista desde yaw/pitch, ejes de movimiento y el paso de integración.
+static bool approx(float a, float b, float eps) {
+    float d = a - b; if (d < 0) d = -d; return d <= eps;
+}
+
+static void testFreeCamMath() {
+    std::printf("== free camera math (view vector + movement step) ==\n");
+
+    // 1. En reposo (yaw=0, pitch=0) la cámara mira a -Z (convención Ogre).
+    FcVec3 f0 = fcForward(0.0f, 0.0f);
+    CHECK("forward(0,0) mira a -Z",
+          approx(f0.x, 0.0f, 1e-5f) && approx(f0.y, 0.0f, 1e-5f) && approx(f0.z, -1.0f, 1e-5f));
+
+    // 2. El vector de vista es unitario para varios ángulos.
+    {
+        FcVec3 f = fcForward(0.7f, 0.3f);
+        float len = std::sqrt(f.x * f.x + f.y * f.y + f.z * f.z);
+        CHECK("forward es unitario", approx(len, 1.0f, 1e-4f));
+    }
+
+    // 3. forward (horizontal) y right son ortogonales -> strafe limpio.
+    {
+        FcVec3 fh = fcForward(1.1f, 0.0f); // pitch 0 => horizontal
+        FcVec3 r  = fcRight(1.1f);
+        float dot = fh.x * r.x + fh.y * r.y + fh.z * r.z;
+        CHECK("forward_h _|_ right", approx(dot, 0.0f, 1e-4f));
+        CHECK("right es horizontal (y=0)", approx(r.y, 0.0f, 1e-6f));
+    }
+
+    // 4. Avanzar (W) en reposo desplaza exactamente speed*dt hacia -Z.
+    {
+        FcInput in; std::memset(&in, 0, sizeof(in)); in.fwd = true;
+        FcVec3 o = { 0.0f, 0.0f, 0.0f };
+        FcVec3 p = fcStep(o, 0.0f, 0.0f, in, /*speed*/ 10.0f, /*turbo*/ 4.0f, /*dt*/ 0.5f);
+        CHECK("W avanza speed*dt hacia -Z",
+              approx(p.x, 0.0f, 1e-4f) && approx(p.y, 0.0f, 1e-4f) && approx(p.z, -5.0f, 1e-4f));
+    }
+
+    // 5. Subir (E) mueve +Y en world; el desplazamiento vale speed*dt.
+    {
+        FcInput in; std::memset(&in, 0, sizeof(in)); in.up = true;
+        FcVec3 o = { 1.0f, 2.0f, 3.0f };
+        FcVec3 p = fcStep(o, 2.0f, 0.5f, in, 8.0f, 4.0f, 0.25f);
+        CHECK("E sube +Y en world", approx(p.y, 2.0f + 2.0f, 1e-4f)); // 8*0.25 = 2
+        CHECK("E no cambia X/Z", approx(p.x, 1.0f, 1e-4f) && approx(p.z, 3.0f, 1e-4f));
+    }
+
+    // 6. Diagonal (W+D) NO va más rápido que recto: |desplazamiento| == speed*dt.
+    {
+        FcInput in; std::memset(&in, 0, sizeof(in)); in.fwd = true; in.right = true;
+        FcVec3 o = { 0.0f, 0.0f, 0.0f };
+        FcVec3 p = fcStep(o, 0.9f, 0.2f, in, 12.0f, 4.0f, 0.1f);
+        float dx = p.x - o.x, dy = p.y - o.y, dz = p.z - o.z;
+        float mag = std::sqrt(dx * dx + dy * dy + dz * dz);
+        CHECK("diagonal normalizada (|d|==speed*dt)", approx(mag, 12.0f * 0.1f, 1e-3f));
+    }
+
+    // 7. Turbo multiplica la velocidad por turboMul.
+    {
+        FcInput a; std::memset(&a, 0, sizeof(a)); a.fwd = true;
+        FcInput b = a; b.turbo = true;
+        FcVec3 o = { 0.0f, 0.0f, 0.0f };
+        FcVec3 pa = fcStep(o, 0.0f, 0.0f, a, 10.0f, 3.0f, 0.2f);
+        FcVec3 pb = fcStep(o, 0.0f, 0.0f, b, 10.0f, 3.0f, 0.2f);
+        CHECK("turbo x3", approx(pb.z, pa.z * 3.0f, 1e-4f));
+    }
+
+    // 8. Sin input, la posición no cambia.
+    {
+        FcInput in; std::memset(&in, 0, sizeof(in));
+        FcVec3 o = { 5.0f, 6.0f, 7.0f };
+        FcVec3 p = fcStep(o, 1.0f, 0.5f, in, 50.0f, 4.0f, 1.0f);
+        CHECK("sin input no se mueve",
+              approx(p.x, 5.0f, 1e-6f) && approx(p.y, 6.0f, 1e-6f) && approx(p.z, 7.0f, 1e-6f));
+    }
+
+    // 9. El pitch se clampa a ~±85° (no da la vuelta de campana).
+    {
+        float yaw = 0.0f, pitch = 0.0f;
+        fcApplyLook(&yaw, &pitch, 0.0f, 100.0f); // empuja el pitch muy arriba
+        CHECK("pitch clamp superior", pitch <= 1.4836f && pitch >= 1.4834f);
+        fcApplyLook(&yaw, &pitch, 0.0f, -100.0f);
+        CHECK("pitch clamp inferior", pitch >= -1.4836f && pitch <= -1.4834f);
+    }
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1372,6 +1461,7 @@ int main() {
     testOwnRanks();
     testSteamIdParse();
     testWorkPoseMatch();
+    testFreeCamMath();
     testTaskClear();
     testDeathRekey();
     testInboundLifecycle();


### PR DESCRIPTION
Kenshi 1.0.68 (the real latest version — we stay on 1.0.65 since that's what RE_Kenshi targets) added a free camera mode for screenshots/videos. Confirmed via string diff against the real 1.0.68 Steam binary that this is genuinely new code in 1.0.68, not something present-but-unused in 1.0.65 — so this PR reimplements the feature rather than hooking anything that exists in our target version.

### What this adds

A local free-camera toggle (F3 by default), fly around with WASD + Q/E, look with the arrow keys, Shift for a speed boost. Purely client-side/visual — doesn't touch any sync channel, doesn't replicate to the peer (each player toggles their own independently).

### How

Only the `CameraClass` **member offsets** are stable across game versions (unlike function RVAs, which differ between 1.0.65 and 1.0.68) — used those (`yaw@0x18`, `pitch@0x1C`, `center@0x58`, `camera@0x68`, `node@0x70`) plus the Ogre API already linked in.

Worth flagging the approach, since the obvious first attempt doesn't work: detaching the `Ogre::Camera*` from its SceneNode (`detachObject`) crashes — reproduced and confirmed via runtime traces, looks like it fights the render-thread/Ogre scene-graph ABI. What works instead: leave the node attached, and every frame (post game-tick) directly overwrite the camera node's transform (`setPosition`/`setOrientation`) — the same operation the engine's own `update()` does, so it's exactly as safe with respect to the render thread as the base game. On toggle-off, the exact node transform captured on toggle-on is restored (the engine doesn't re-frame on its own).

### Testing

- Unit: new `FreeCamMath.h` (pure), 12 checks — view-vector unit length, forward/right orthogonality, movement step math, normalized diagonal movement, speed boost, pitch clamp. Prototest 433/433 total.
- Live: screenshots across the full toggle cycle — normal orbital camera → F3 on (decoupled, flying free, log shows `[freecam] ON`) → F3 off (log shows `[freecam] OFF`, camera restored to the exact original framing). No crashes across the session.

### Scope notes

- Keyboard-only controls (no mouse-look) — deliberate, to avoid fighting Kenshi's RTS cursor and keep input handling simple/deterministic. Mouse-look (hold right-click) would be a natural follow-up if wanted.
- Saw one unrelated game crash during testing on a heavily-modded quicksave, with zero `[freecam]` log lines anywhere near it — not caused by this feature, flagging for transparency since it happened during the same test session.
