### PR TITLE
Fix peer-disconnect save-data-loss + inventory/death crashes; add character-name & animal-age sync (protocol 46)

### DIFF
--- a/scripts/CoopHarness.psm1
+++ b/scripts/CoopHarness.psm1
@@ -56,6 +56,10 @@ $script:CoopDiagEnvKeys = @(
     # Forces the join to NACK a MATCHing LOAD_GO so the real folder-transfer path
     # runs on one machine (bootstrap_stream / stream_test.ps1).
     'KENSHICOOP_FORCE_STREAM'
+    # Widen the proxy mint radius (default 600u) so a scenario whose subject spawns
+    # far from the join's interest anchor (ident_sync on the 2-tab squad1) still
+    # mints it instead of deferring it as "far".
+    'KENSHICOOP_SPAWN_MINT_RADIUS'
 )
 
 function Get-CoopDiagEnvKeys {

--- a/scripts/CoopOracles.psm1
+++ b/scripts/CoopOracles.psm1
@@ -160,6 +160,9 @@ function Invoke-OneOracle {
         "medic_order"   { return (Test-MedicOrder      -HostFile $HostLog -JoinFile $JoinLog) }
         "limb_loss"     { return (Test-LimbLoss        -HostFile $HostLog -JoinFile $JoinLog) }
         "stats_sync"    { return (Test-StatsSync       -HostFile $HostLog -JoinFile $JoinLog) }
+        "name_sync"     { return (Test-NameSync        -HostFile $HostLog -JoinFile $JoinLog) }
+        "age_sync"      { return (Test-AgeSync         -HostFile $HostLog -JoinFile $JoinLog) }
+        "death_portrait" { return (Test-DeathPortrait  -HostFile $HostLog -JoinFile $JoinLog) }
         "carry_order"   { return (Test-CarryOrder      -HostFile $HostLog -JoinFile $JoinLog) }
         "npc_carry"     { return (Test-NpcCarry        -HostFile $HostLog -JoinFile $JoinLog) }
         "npc_vitals"    { return (Test-NpcVitals       -HostFile $HostLog -JoinFile $JoinLog) }

--- a/scripts/oracles/Medical.ps1
+++ b/scripts/oracles/Medical.ps1
@@ -391,3 +391,43 @@ function Test-MedicPose {
     return (Add-GateResult -Name "medic_pose" -Status PASS -Metrics $mtr)
 }
 
+
+# age_sync (protocol 46 regression, PR #28 fix #5): a growing squad animal kept
+# its mint-time size on the peer because age was only sent at mint. Age now rides
+# the periodic owner-authoritative StatsPacket ("[stats] SEND ... age=A" on the
+# owner; "[stats] RECV ... age=B" on the peer, B re-read after setAge). PASS iff
+# host and join agree on age for bodies both logged. SKIP if no age-bearing row
+# synced in the window (no aged/animal body) - a squad-animal fixture makes this
+# deterministic.
+function Test-AgeSync {
+    param([string]$HostFile, [string]$JoinFile)
+    $reS = "\[stats\] SEND hand=(\d+,\d+) .* age=([-\d.]+)"
+    $reR = "\[stats\] RECV hand=(\d+,\d+) .* age=([-\d.]+)"
+    $sent = @{}
+    foreach ($m in @(Select-String -Path $HostFile -Pattern $reS -ErrorAction SilentlyContinue)) {
+        $g = $m.Matches[0].Groups; $a = [double]$g[2].Value; if ($a -gt 0) { $sent[$g[1].Value] = $a }
+    }
+    $recv = @{}
+    foreach ($m in @(Select-String -Path $JoinFile -Pattern $reR -ErrorAction SilentlyContinue)) {
+        $g = $m.Matches[0].Groups; $a = [double]$g[2].Value; if ($a -gt 0) { $recv[$g[1].Value] = $a }
+    }
+    $shared = @($sent.Keys | Where-Object { $recv.ContainsKey($_) })
+    if ($shared.Count -eq 0) {
+        $d = "no age-bearing stats row synced in window (no aged/animal body) - no signal"
+        Write-Host "  AGE-SYNC SKIP - $d"
+        return (Add-GateResult -Name "age_sync" -Status SKIP -Metrics @{ sent = $sent.Count; recv = $recv.Count } -Detail $d)
+    }
+    $agree = 0; $disagree = 0; $tol = 0.05
+    foreach ($h in $shared) {
+        if ([math]::Abs($sent[$h] - $recv[$h]) -le $tol) { $agree++ } else { $disagree++ }
+    }
+    $met = @{ shared = $shared.Count; agree = $agree; disagree = $disagree }
+    if ($disagree -gt 0) {
+        $d = "$disagree/$($shared.Count) bodies disagree on age (host vs join > $tol)"
+        Write-Host "  AGE-SYNC FAIL - $d"
+        return (Add-GateResult -Name "age_sync" -Status FAIL -Metrics $met -Detail $d)
+    }
+    $d = "$agree body(ies) agree on replicated age (host == join)"
+    Write-Host "  AGE-SYNC PASS - $d"
+    return (Add-GateResult -Name "age_sync" -Status PASS -Metrics $met -Detail $d)
+}

--- a/scripts/oracles/Npc.ps1
+++ b/scripts/oracles/Npc.ps1
@@ -2181,3 +2181,87 @@ function Test-NpcCensus {
                             extraCulls = $extra; sent = $sent; recv = $recv } -Detail $detail)
 }
 
+
+# name_sync (protocol 46 regression, PR #28 fix #4): runtime-minted proxies used
+# to show Kenshi's default "Name" because the mod never replicated the name. The
+# host now sends it on SpawnInfoPacket ("[spawn] INFO send ... name='X'") and the
+# join sets it on the minted proxy ("[spawn] proxy BOUND ... name='X'"). PASS iff
+# every proxy the join minted carries a non-default name, matching the host's sent
+# name for that hand. FAIL if any minted proxy shows "Name" (the regression).
+function Test-NameSync {
+    param([string]$HostFile, [string]$JoinFile)
+    $reSend  = "\[spawn\] INFO send hand=(\d+,\d+,\d+,\d+,\d+) .* name='([^']*)'"
+    $reBound = "\[spawn\] proxy BOUND hand=(\d+,\d+,\d+,\d+,\d+) .* name='([^']*)'"
+    $sent = @{}
+    foreach ($m in @(Select-String -Path $HostFile -Pattern $reSend -ErrorAction SilentlyContinue)) {
+        $g = $m.Matches[0].Groups; $sent[$g[1].Value] = $g[2].Value
+    }
+    $bound = @{}
+    foreach ($m in @(Select-String -Path $JoinFile -Pattern $reBound -ErrorAction SilentlyContinue)) {
+        $g = $m.Matches[0].Groups; $bound[$g[1].Value] = $g[2].Value
+    }
+    if ($bound.Count -eq 0) {
+        $d = "no proxy minted on the join (npc scene did not stream a proxy) - no signal"
+        Write-Host "  NAME-SYNC SKIP - $d"
+        return (Add-GateResult -Name "name_sync" -Status SKIP -Metrics @{ minted = 0 } -Detail $d)
+    }
+    $bad = 0; $mismatch = 0; $good = 0
+    foreach ($h in $bound.Keys) {
+        $y = $bound[$h]
+        if ($y -eq "" -or $y -eq "Name") { $bad++; continue }
+        if ($sent.ContainsKey($h) -and $sent[$h] -ne "" -and $sent[$h] -ne $y) { $mismatch++; continue }
+        $good++
+    }
+    $met = @{ minted = $bound.Count; good = $good; defaultName = $bad; mismatch = $mismatch }
+    if ($bad -gt 0 -or $mismatch -gt 0) {
+        $d = "$bad proxy(ies) show default 'Name', $mismatch disagree with host (of $($bound.Count) minted)"
+        Write-Host "  NAME-SYNC FAIL - $d"
+        return (Add-GateResult -Name "name_sync" -Status FAIL -Metrics $met -Detail $d)
+    }
+    $d = "$good minted prox(ies) carry the host's replicated name (no default 'Name')"
+    Write-Host "  NAME-SYNC PASS - $d"
+    return (Add-GateResult -Name "name_sync" -Status PASS -Metrics $met -Detail $d)
+}
+
+# death_portrait (protocol 46 regression, PR #28 fix #3): a dying squad member
+# used to re-key + re-join to the player squad, derefing a null PortraitData
+# (MainBarGUI crash) and leaving a phantom "Name" corpse. The fix skips the
+# re-join on a death-latched rekey ("[..] MEMBER skip .. (death-latched corpse)")
+# and suppresses the unnamed corpse mint. FAIL on a phantom 'Name' corpse or a
+# death-latched rekey that still re-joined (no skip); PASS when a death occurred
+# without those symptoms (strong when the skip path actually fired). SKIP if no
+# death in window. health_* separately catches an outright crash.
+function Test-DeathPortrait {
+    param([string]$HostFile, [string]$JoinFile)
+    # Count deaths the JOIN actually witnessed (EVT_DEATH crossed to its proxy) -
+    # NOT the host's "kill issued", which proves nothing about the join's corpse
+    # handling. No join-side death => no signal => SKIP (never a false PASS). The
+    # line is "[event] RECV id=<n> ev=2 owner=..." (ev=2 = EVT_DEATH).
+    $deaths = @(Select-String -Path $JoinFile -Pattern "\[event\] RECV id=\d+ ev=2\b" -ErrorAction SilentlyContinue).Count
+    $rekeys = @(Select-String -Path $JoinFile -Pattern "\[event\] REKEY-LATCH .* death=1" -ErrorAction SilentlyContinue).Count
+    $skips  = @(Select-String -Path $JoinFile -Pattern "MEMBER skip .* \(death-latched corpse\)" -ErrorAction SilentlyContinue).Count
+    $nameCorpse = @(Select-String -Path $JoinFile -Pattern "\[spawn\] proxy BOUND .* name='Name'" -ErrorAction SilentlyContinue).Count
+    $met = @{ deaths = $deaths; rekeyLatched = $rekeys; memberSkips = $skips; nameCorpse = $nameCorpse }
+    if ($deaths -eq 0 -and $rekeys -eq 0) {
+        $d = "no death occurred in window - no signal"
+        Write-Host "  DEATH-PORTRAIT SKIP - $d"
+        return (Add-GateResult -Name "death_portrait" -Status SKIP -Metrics $met -Detail $d)
+    }
+    if ($nameCorpse -gt 0) {
+        $d = "$nameCorpse corpse proxy(ies) minted with default 'Name' (phantom-portrait regression)"
+        Write-Host "  DEATH-PORTRAIT FAIL - $d"
+        return (Add-GateResult -Name "death_portrait" -Status FAIL -Metrics $met -Detail $d)
+    }
+    if ($rekeys -gt 0 -and $skips -eq 0) {
+        $d = "$rekeys death-latched rekey(s) but corpse re-joined (no MEMBER skip) - null-portrait crash path"
+        Write-Host "  DEATH-PORTRAIT FAIL - $d"
+        return (Add-GateResult -Name "death_portrait" -Status FAIL -Metrics $met -Detail $d)
+    }
+    if ($rekeys -gt 0 -and $skips -gt 0) {
+        $d = "$rekeys death-latched rekey(s), all skipped from re-join ($skips) - no null-portrait path, no 'Name' corpse"
+    } else {
+        $d = "$deaths death(s), no phantom 'Name' corpse (death-latched rekey did not re-trigger in-window)"
+    }
+    Write-Host "  DEATH-PORTRAIT PASS - $d"
+    return (Add-GateResult -Name "death_portrait" -Status PASS -Metrics $met -Detail $d)
+}

--- a/scripts/scenarios.psd1
+++ b/scripts/scenarios.psd1
@@ -110,6 +110,53 @@
             Tier = 'smoke'; WanVariant = $true
         }
 
+        # ident_sync (protocol 46 regression for PR #28 fixes #4 name-sync + #5
+        # animal-age-sync): squad1 + the 'npc' setup scene has the host spawn a
+        # world NPC that the join mints as a proxy - name_sync asserts the minted
+        # proxy carries the host's replicated name (not the default "Name"), and
+        # age_sync asserts the StatsPacket age agrees host<->join. name_sync is the
+        # PrimaryGate (the mint is the always-present signal); age_sync SKIPs
+        # cleanly if no aged body is under sync (a squad-animal fixture would make
+        # #5 deterministic). Tier 'none' = run explicitly (-Scenario ident_sync).
+        ident_sync = @{
+            Save = 'squad1'; Setup = 'recruit'; Tolerance = 3.0
+            # The 'recruit' setup scene has the host spawn + recruit a world NPC, so
+            # it becomes an OWNED member that publishOwned streams and the join MINTS
+            # as a proxy - a deterministic runtime mint. name_sync (PrimaryGate)
+            # asserts that minted proxy carries the host's replicated name, never the
+            # default "Name" (PR #28 fix #4). age_sync asserts the StatsPacket age
+            # agrees host<->join (fix #5). Tier 'none' = run explicitly.
+            PrimaryGate = 'name_sync'
+            Gating   = @('name_sync', 'age_sync')
+            Advisory = @('clock_sync')
+            # squad1 is a 2-tab save with the tabs far apart, so the recruited NPC
+            # spawns ~1.4ku from the JOIN's interest anchor - past the default 600u
+            # mint radius (bodies defer as "far"). Widen it so the proxy mints and
+            # name_sync gets its signal (census radius is 2000).
+            DiagEnv = @{ KENSHICOOP_SPAWN_MINT_RADIUS = '2000' }
+            Tier = 'none'; WanVariant = $false
+        }
+
+        # death_portrait (regression for the death-portrait crash fix): the repro is
+        # a player's own character dying (1 char per player; the host's char died and
+        # both clients crashed). The host's char is already a proxy on the join from
+        # the shared squad1 save, so the scenario bleeds the HOST-OWNED leader out via
+        # LIMB wounds (the game runs its own point-of-no-return death - a forced kill
+        # would bypass the death sequence), and the death crosses instantly on the
+        # join's proxy. The corpse re-keys + the mod would rebuild a portrait for the
+        # dead hand and deref a null PortraitData (the MainBarGUI crash + phantom
+        # "Name") - the fix SKIPs that re-join. death_portrait requires the join to
+        # WITNESS the death, then asserts no phantom 'Name' corpse + (if the
+        # death-latched rekey fires) the skip; health_* asserts no crash. Tier 'none'
+        # = run explicitly.
+        death_portrait = @{
+            Save = 'squad1'; Setup = ''; Tolerance = 3.0
+            PrimaryGate = 'death_portrait'
+            Gating   = @('death_portrait')
+            Advisory = @('clock_sync')
+            Tier = 'none'; WanVariant = $false
+        }
+
         # split_interest (step 5): the host's tab leaves the bar; bar NPCs must keep
         # streaming via the second interest sphere (the join's tab leader). The join
         # walks nothing - its member IS the remote anchor. Save 'sync' (the bar

--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -780,6 +780,7 @@ struct StatsPacket {
     f32 stats[STATS_SLOT_MAX]; // by StatsEnumerated index (-1 = unreadable)
     f32 xp;                    // CharStats::xp (-1 = unreadable)
     f32 freeAttributePoints;   // CharStats::freeAttributePoints (int on wire as f32; -1 = unreadable)
+    f32 age;                   // Character::getAge (protocol 46); animals scale body size by age. <= 0 = unreadable
 };
 
 // ---- Protocol 22: per-tab wallet snapshot -----------------------------------

--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -24,7 +24,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 45;
+const u16 PROTOCOL_VERSION = 46;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -1012,6 +1012,7 @@ struct SpawnInfoPacket {
     u32 hSerial;
     char charSid[48]; // character template GameData stringID
     char facSid[48];  // faction GameData stringID ("" = unknown -> join fallback)
+    char name[48];    // host body's display name (protocol 46); "" = unnamed
     f32 x;            // world transform at reply time
     f32 y;
     f32 z;

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -911,6 +911,16 @@ void tickSetupScene(GameWorld* gw) {
                 "SETUP(inventory): container hand=%u,%u,%u,%u,%u - SAVE 'inv1' now",
                 ch[0], ch[1], ch[2], ch[3], ch[4]); b[sizeof(b) - 1] = '\0'; coopLog(b); }
             else coopLog("SETUP(inventory): container prep FAILED");
+        } else if (g_cfg.setupScene == "recruit") {
+            // Recruit LIVE (name_sync regression, PR #28 fix #4): spawn a world
+            // NPC and recruit it into the HOST's squad so it becomes an OWNED
+            // member - publishOwned then streams it and the join MINTS it as a
+            // proxy carrying the replicated name. A runtime-minted proxy must NOT
+            // show Kenshi's default "Name" (the bug this fix closed).
+            Character* npc = coop::engine::spawnNpcInFront(gw, 2.5f, 1.0f);
+            bool ok = npc && coop::engine::recruitNpc(gw, npc);
+            coopLog(ok ? "SETUP: spawned + recruited world NPC (owned member)"
+                       : "SETUP: recruit spawn FAILED");
         } else {
             RootObject* seat = 0;
             bool ok = coop::engine::spawnSeatInFront(gw, 7.0f, 0.0f, &seat);

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -1237,6 +1237,16 @@ bool amputateSubjectLimb(GameWorld* gw, const unsigned int subjHand[5], int limb
 bool woundSubjectLimbs(GameWorld* gw, const unsigned int subjHand[5],
                        float flesh, float blood);
 
+// The host's own squad leader (playerCharacters[0]) - host-owned, already a proxy
+// on the join. 0 on fault/empty. Used by the death-portrait regression.
+Character* hostOwnedLeader(GameWorld* gw);
+
+// Bleed a body out lethally (high currentBleedRate + low blood) so the GAME runs
+// its own natural death sequence - unlike killSubject, which forces med->dead and
+// skips it. Operates on the Character* directly; re-assert each tick. Used by the
+// death-portrait regression to reproduce a natural squad-member death.
+bool bleedOutCharacter(GameWorld* gw, Character* c);
+
 // Protocol 45 (host applies join-dealt damage): unlike woundSubjectLimbs (which
 // sets ABSOLUTE floor levels for the medic scaffold), this SUBTRACTS cumulative
 // deltas - the join reports the damage EACH suppressed swing would have dealt, and

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -276,6 +276,10 @@ void* markerCreate(Character* c, const char* text, int colorId);
 bool  markerUpdate(void* label, const char* text, int colorId);
 void  markerDestroy(void* label);
 
+// True while any inventory/trade window is open (the engine UI holds Item
+// pointers). Inventory-sync must not free items during this window. SEH-guarded.
+bool  inventoryUiOpen();
+
 // ---- In-game co-op session panel ---------------------------------------------
 // Moved to EngineUi.h (Phase 5a domain split): CoopPanelState, CoopConnectFn,
 // CoopDisconnectFn, coopPanelTick, coopOverlayTick. The UI root (Plugin.cpp)

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -328,7 +328,8 @@ bool describeCharacter(Character* c, char* charSid, unsigned int charSidLen,
 // cosmetic; combat outcomes stay host-authoritative + damage-guarded. Returns
 // the proxy Character* or 0.
 Character* spawnProxyNpc(GameWorld* gw, const char* charSid, const char* facSid,
-                         float x, float y, float z, float heading, float age);
+                         float x, float y, float z, float heading, float age,
+                         const char* name);
 
 // SEH-guarded (Phase 1 spawn parity, game/ZoneQuery.cpp): is the world block at
 // (x,y,z) fully LOADED locally (loaded and not mid-load)? Within a loaded block

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -331,6 +331,11 @@ Character* spawnProxyNpc(GameWorld* gw, const char* charSid, const char* facSid,
                          float x, float y, float z, float heading, float age,
                          const char* name);
 
+// Age read/write (protocol 46 animal-scale sync). SEH-guarded; charAge returns
+// <= 0 on fault, setCharAge no-ops a non-finite/<=0 value.
+float charAge(Character* c);
+void  setCharAge(Character* c, float age);
+
 // SEH-guarded (Phase 1 spawn parity, game/ZoneQuery.cpp): is the world block at
 // (x,y,z) fully LOADED locally (loaded and not mid-load)? Within a loaded block
 // every baked shared-save NPC resolves by hand, so an unresolvable census hand

--- a/src/plugin/game/EngineSpawnCombat.cpp
+++ b/src/plugin/game/EngineSpawnCombat.cpp
@@ -656,6 +656,53 @@ bool killSubject(GameWorld* gw, const unsigned int subjHand[5]) {
     }
 }
 
+// The host's own squad leader (playerCharacters[0]) - a HOST-OWNED body that the
+// join already holds as a proxy from the shared save, so its death crosses the
+// wire immediately (no recruit / far-mint). Used by the death-portrait regression
+// to reproduce "a player's own character dies". SEH-guarded; 0 on fault/empty.
+Character* hostOwnedLeader(GameWorld* gw) {
+    if (!gw || !gw->player) return 0;
+    __try {
+        if (gw->player->playerCharacters.size() == 0) return 0;
+        return gw->player->playerCharacters[0];
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+}
+
+// Bleed a body out LETHALLY without forcing death: set a high currentBleedRate +
+// low blood so the game's own medical tick drains it to zero and runs its NATURAL
+// death sequence (which re-keys the corpse + refreshes the squad portrait - the
+// null-PortraitData path the death fix guards). killSubject sets med->dead
+// directly and BYPASSES that sequence, so it can't reproduce the crash. Operates
+// on the Character* directly (no hand round-trip), re-assertable each tick so
+// clotting never lowers the rate before the body finishes bleeding out.
+bool bleedOutCharacter(GameWorld* gw, Character* c) {
+    (void)gw;
+    if (!c) return false;
+    __try {
+        MedicalSystem* med = &c->medical;
+        // Setting currentBleedRate directly is futile - the game recomputes it every
+        // frame from the per-part wound state (getExtraBleedingAmount reads the
+        // part's derivedFleshHealthPercent). So WOUND every part deep: force both
+        // flesh and the derived percent hard negative (re-asserted each tick so an
+        // update() re-derive can't clot it), and pull the starting blood down so the
+        // game's OWN bloodloss update drains the rest to 0 and runs its natural
+        // point-of-no-return death (corpse re-key + portrait refresh). No med->dead
+        // poke - that is what makes killSubject bypass the death sequence.
+        unsigned int n = med->anatomy.count;
+        for (unsigned int i = 0; i < n; ++i) {
+            MedicalSystem::HealthPartStatus* p =
+                med->anatomy.stuff ? med->anatomy.stuff[i] : 0;
+            if (!p) continue;
+            p->flesh = -500.0f;                    // deep open wound
+            p->derivedFleshHealthPercent = -5.0f;  // what the bloodloss check reads
+        }
+        if (med->blood > 30.0f) med->blood = 30.0f; // low start; game bleeds it to 0
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
 // combat_kill bias (NOT a kill): lower the subject's blood so an ongoing REAL melee
 // downs it decisively within the test window, without collapsing it ourselves (no
 // unconcious/dead set, no ragdoll) - the opponent's hits + bleeding do the takedown,

--- a/src/plugin/game/EngineSpawnCombat.cpp
+++ b/src/plugin/game/EngineSpawnCombat.cpp
@@ -127,8 +127,21 @@ Character* sameTemplateNear(GameWorld* gw, const char* charSid,
     }
 }
 
+// setName takes a std::string (destructor forbids __try in-frame): the POD-only
+// shim wraps the non-POD callee, mirroring charName/charNameCopy.
+void setProxyNameCopy(Character* c, const char* name) {
+    c->setName(std::string(name));
+}
+void setProxyNameGuarded(Character* c, const char* name) {
+    if (!c || !name || !name[0]) return;
+    __try {
+        setProxyNameCopy(c, name);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+}
+
 Character* spawnProxyNpc(GameWorld* gw, const char* charSid, const char* facSid,
-                         float x, float y, float z, float heading, float age) {
+                         float x, float y, float z, float heading, float age,
+                         const char* name) {
     if (!gw || !gw->theFactory || !g_createCharFn || !charSid || !charSid[0]) return 0;
     // Creature-size sync (protocol 39): animals scale body size by age, so the
     // proxy must be CREATED at the host's age or it spawns full-grown (the
@@ -175,6 +188,9 @@ Character* spawnProxyNpc(GameWorld* gw, const char* charSid, const char* facSid,
     // authority for a proxy (AI-suspend re-asserts this every driven tick).
     detachFromTownAI(c);
     clearGoals(c);
+    // Name sync (protocol 45): give the proxy the host body's name so runtime
+    // NPCs/recruits don't show Kenshi's default "Name" on the peer.
+    setProxyNameGuarded(c, name);
     return c;
 }
 

--- a/src/plugin/game/EngineSpawnCombat.cpp
+++ b/src/plugin/game/EngineSpawnCombat.cpp
@@ -139,6 +139,21 @@ void setProxyNameGuarded(Character* c, const char* name) {
     } __except (EXCEPTION_EXECUTE_HANDLER) {}
 }
 
+// Age read/write for the stats-channel animal-scale sync (protocol 46). Age
+// drives CharacterAnimal body scale; humans return a cosmetic age (harmless).
+float charAge(Character* c) {
+    if (!c) return -1.0f;
+    __try {
+        return c->getAge();
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return -1.0f; }
+}
+void setCharAge(Character* c, float age) {
+    if (!c || !(age > 0.0f && age < 1.0e6f)) return;
+    __try {
+        c->setAge(age);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+}
+
 Character* spawnProxyNpc(GameWorld* gw, const char* charSid, const char* facSid,
                          float x, float y, float z, float heading, float age,
                          const char* name) {

--- a/src/plugin/game/EngineUi.cpp
+++ b/src/plugin/game/EngineUi.cpp
@@ -105,6 +105,19 @@ void markerDestroy(void* label) {
     markerDestroySeh(g, (ScreenLabel*)label);
 }
 
+// True while any inventory/trade window is open. Callers defer inventory
+// mutation so the reconcile never frees an Item the open UI still holds
+// (Inventory::removeItem UAF, crash on entering cities/shops).
+bool inventoryUiOpen() {
+    ForgottenGUI* g = ::gui; // KenshiLib data export (spike 46)
+    if (!g) return false;
+    __try {
+        return g->getNumOpenInventoryWindows() > 0;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
 // ---- In-game co-op session panel (config-driven, spike-50 DatapanelGUI stack) -
 // A native DatapanelGUI window toggled with F2. The player picks role + transport
 // (toggle BUTTONS - the only DatapanelGUI control with a callable RVA callback;

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -1638,6 +1638,12 @@ private:
     // syncSpawns runs a ~1 s liveness sweep: SEH-read each pointer's current
     // hand and resolve it back; anything but the same pointer unbinds the
     // entry untouched.
+    // Minted-proxy discriminator (keyed by pointer): only bodies WE created via
+    // spawnProxyNpc may be destroyed on cleanup. rekeyPeerBody also binds REAL
+    // save-stable bodies into proxyByKey_ (a recruit/squad-move rebind), and
+    // destroying one on peer-leave crashes (freed body still in playerCharacters)
+    // and bakes it out of the save. Membership survives key migration for free.
+    std::set<Character*> mintedProxies_;
     // JOIN: per-hand request state - debounce, retry cap, negative-reply
     // backoff (deniedMs = when the host said "can't resolve either" or the
     // local proxy spawn failed; retried only after a long cooldown).

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -468,10 +468,10 @@ void Replicator::publishStats(GameWorld* gw, NetLink& net, u32 ownerId) {
             // player watches; the full vector is in the packet regardless.
             // StatsEnumerated: STRENGTH=1 STEALTH=16 ATHLETICS=17 DEXTERITY=18
             // TOUGHNESS=21 (Enums.h).
-            char b[200]; _snprintf(b, sizeof(b) - 1,
-                "[stats] SEND hand=%u,%u str=%.1f dex=%.1f tough=%.1f stealth=%.1f athl=%.1f xp=%.0f fap=%.0f",
+            char b[224]; _snprintf(b, sizeof(b) - 1,
+                "[stats] SEND hand=%u,%u str=%.1f dex=%.1f tough=%.1f stealth=%.1f athl=%.1f xp=%.0f fap=%.0f age=%.2f",
                 k.i, k.s, sr.stats[1], sr.stats[18], sr.stats[21], sr.stats[16],
-                sr.stats[17], sr.xp, sr.freeAttribPts);
+                sr.stats[17], sr.xp, sr.freeAttribPts, pkt.age);
             b[sizeof(b) - 1] = '\0'; coop::logLine(b);
         }
     }
@@ -509,10 +509,10 @@ void Replicator::applyStats(GameWorld* gw, Inbound& in) {
             float cur = engine::charAge(c);
             if (cur < 0.0f || fabs(cur - p.age) > 0.01f) engine::setCharAge(c, p.age);
         }
-        char b[200]; _snprintf(b, sizeof(b) - 1,
-            "[stats] RECV hand=%u,%u ok=%d str=%.1f dex=%.1f tough=%.1f stealth=%.1f athl=%.1f xp=%.0f",
+        char b[224]; _snprintf(b, sizeof(b) - 1,
+            "[stats] RECV hand=%u,%u ok=%d str=%.1f dex=%.1f tough=%.1f stealth=%.1f athl=%.1f xp=%.0f age=%.2f",
             k.i, k.s, ok ? 1 : 0, p.stats[1], p.stats[18], p.stats[21],
-            p.stats[16], p.stats[17], p.xp);
+            p.stats[16], p.stats[17], p.xp, (ok ? engine::charAge(c) : p.age));
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 }

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -458,6 +458,10 @@ void Replicator::publishStats(GameWorld* gw, NetLink& net, u32 ownerId) {
             pkt.stats[i] = (i < n) ? sr.stats[i] : -1.0f;
         pkt.xp                  = sr.xp;
         pkt.freeAttributePoints = sr.freeAttribPts;
+        {
+            Character* c = engine::resolveCharByHand(k.i, k.s, k.t, k.c, k.cs);
+            pkt.age = c ? engine::charAge(c) : -1.0f;
+        }
         net.queueStats(pkt);
         if (changed) { // periodic resends stay silent; changes are the signal
             // str/dex/tough/stealth/athletics cover the scenario + the stats a
@@ -499,6 +503,12 @@ void Replicator::applyStats(GameWorld* gw, Inbound& in) {
         w.xp            = p.xp;
         w.freeAttribPts = p.freeAttributePoints;
         bool ok = engine::writeStats(c, w);
+        // Animal-scale sync (protocol 46): apply the owner's age only when it
+        // has drifted, so a growing squad animal matches size on the peer.
+        if (p.age > 0.0f && p.age < 1.0e6f) {
+            float cur = engine::charAge(c);
+            if (cur < 0.0f || fabs(cur - p.age) > 0.01f) engine::setCharAge(c, p.age);
+        }
         char b[200]; _snprintf(b, sizeof(b) - 1,
             "[stats] RECV hand=%u,%u ok=%d str=%.1f dex=%.1f tough=%.1f stealth=%.1f athl=%.1f xp=%.0f",
             k.i, k.s, ok ? 1 : 0, p.stats[1], p.stats[18], p.stats[21],

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -161,6 +161,7 @@ void Replicator::resetSession() {
     canonicalOf_.clear();      // capture-translation reverse map (same pointers)
     jailObs_.clear();          // jail-observe spike per-captive last sample
     proxyByKey_.clear();
+    mintedProxies_.clear();
     suppressed_.clear();
     midBand_.clear();          // host mid-band round-robin (rebuilt by next census)
     midCursor_ = 0; midSliceMs_ = 0;
@@ -278,7 +279,8 @@ void Replicator::clearPeerReplicationState(GameWorld* gw) {
     unsigned int cleared = 0;
     for (std::map<Key, Character*>::iterator it = proxyByKey_.begin();
          it != proxyByKey_.end(); ++it) {
-        if (gw && it->second && engine::despawnProxyNpc(gw, it->second))
+        if (gw && it->second && mintedProxies_.count(it->second) &&
+            engine::despawnProxyNpc(gw, it->second))
             ++cleared;
     }
     char b[96];

--- a/src/plugin/sync/ReplicatorItems.cpp
+++ b/src/plugin/sync/ReplicatorItems.cpp
@@ -140,6 +140,13 @@ void Replicator::applyInventories(GameWorld* gw) {
         unsigned int cHand[5] = { k.t, k.c, k.cs, k.i, k.s };
         const InvItemEntry* items = it->second.items.empty() ? 0 : &it->second.items[0];
         unsigned int n = (unsigned int)it->second.items.size();
+        // Defer the reconcile while an inventory/trade UI is open: freeing items
+        // the UI holds is a use-after-free (Inventory::removeItem crash on city
+        // entry). Idempotent - re-arm dirty and retry once the window closes.
+        if (engine::inventoryUiOpen()) {
+            it->second.dirty = true;
+            continue;
+        }
         // Protocol 37 (the race that blinded the detector in run 141024): if this
         // peer container's LOCAL contents differ from the transfer detector's
         // baseline, a user mutation (possibly one end of a cross-owner drag) has not

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -64,6 +64,7 @@ void Replicator::syncSpawns(GameWorld* gw, Inbound& in, NetLink& net, u32 ownerI
                 b[sizeof(b) - 1] = '\0'; coop::logLine(b);
                 spawnReq_.erase(it->first); // allow a fresh REQ/mint cycle
                 lifeSet(it->first, LIFE_UNKNOWN, "proxy-despawned");
+                mintedProxies_.erase(it->second);
                 proxyByKey_.erase(it++);
                 continue;
             }
@@ -77,7 +78,10 @@ void Replicator::syncSpawns(GameWorld* gw, Inbound& in, NetLink& net, u32 ownerI
             const Key& bk = it->first;
             Character* orig = engine::resolveCharByHand(bk.i, bk.s, bk.t, bk.c, bk.cs);
             if (orig && orig != it->second) {
-                engine::despawnProxyNpc(gw, it->second);
+                if (mintedProxies_.count(it->second)) {
+                    engine::despawnProxyNpc(gw, it->second);
+                    mintedProxies_.erase(it->second);
+                }
                 char b[176]; _snprintf(b, sizeof(b) - 1,
                     "[spawn] proxy DUPE-HEAL hand=%u,%u,%u,%u,%u (original resolved; "
                     "proxy destroyed, proxies=%u)",
@@ -405,6 +409,7 @@ void Replicator::syncSpawns(GameWorld* gw, Inbound& in, NetLink& net, u32 ownerI
             }
         }
         proxyByKey_[k] = proxy;
+        mintedProxies_.insert(proxy);
         ++mintedThisTick;
         lifeSet(k, LIFE_RESOLVED, "mint");
         // Dead on arrival: latch the down state now (the same reliable-latch
@@ -689,6 +694,8 @@ void Replicator::applyEvents(GameWorld* gw, Inbound& in) {
                 if ((nk.t | nk.c | nk.cs | nk.i | nk.s) == 0) {
                     pinPeer_.erase(k);
                     pinOwned_.erase(k);
+                    { std::map<Key, Character*>::iterator pf = proxyByKey_.find(k);
+                      if (pf != proxyByKey_.end()) mintedProxies_.erase(pf->second); }
                     proxyByKey_.erase(k);
                     targets_.erase(k);
                     rekeyedOld_[k] = nowMs(); // no REQ for the dead key's tail
@@ -830,8 +837,12 @@ void Replicator::rekeyPeerBody(GameWorld* gw, const Key& oldK, const Key& newK,
         // proxy - destroy it with the NPC-correct SEH-guarded despawnProxyNpc
         // (removeWorldItemProxy is for world Item* proxies and mis-handles a
         // Character body; the same rekey path already uses despawnProxyNpc for
-        // its control-flip phantom cull below).
-        culled = engine::despawnProxyNpc(gw, mint) ? 1 : 0;
+        // its control-flip phantom cull below). Only if WE minted it - a rebased
+        // real body under this key must never be destroyed.
+        if (mintedProxies_.count(mint)) {
+            culled = engine::despawnProxyNpc(gw, mint) ? 1 : 0;
+            mintedProxies_.erase(mint);
+        }
         repaired = 1;
     }
     if (c) {
@@ -929,8 +940,9 @@ void Replicator::rekeyPeerBody(GameWorld* gw, const Key& oldK, const Key& newK,
             // stray proxy and drop its binding (manual 2026-07-17: Squint).
             std::map<Key, Character*>::iterator px = proxyByKey_.find(newK);
             if (px != proxyByKey_.end()) {
-                if (px->second && px->second != c)
+                if (px->second && px->second != c && mintedProxies_.count(px->second))
                     engine::despawnProxyNpc(gw, px->second);
+                mintedProxies_.erase(px->second);
                 proxyByKey_.erase(px);
             }
             char cf[176]; _snprintf(cf, sizeof(cf) - 1,

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -938,6 +938,15 @@ void Replicator::rekeyPeerBody(GameWorld* gw, const Key& oldK, const Key& newK,
                 (tag ? tag : "squad"), newK.t, newK.c, newK.cs, newK.i, newK.s);
             cf[sizeof(cf) - 1] = '\0'; coop::logLine(cf);
         }
+    } else if (carryDeath) {
+        // Dead body with no local copy: don't force-REQ/mint. Minting spawns a
+        // fresh unnamed corpse (the "Name" portrait that appears after a death,
+        // since proxy names aren't replicated). Suppress any in-flight reply mint.
+        rekeyedOld_[newK] = nowMs();
+        char fb[176]; _snprintf(fb, sizeof(fb) - 1,
+            "[%s] REKEY-DEAD skip-mint new=%u,%u,%u,%u,%u",
+            (tag ? tag : "squad"), newK.t, newK.c, newK.cs, newK.i, newK.s);
+        fb[sizeof(fb) - 1] = '\0'; coop::logLine(fb);
     } else {
         // ok=0: no local body at the OLD hand and no proxy to migrate. The
         // recruit/move fired while this hand was OUTSIDE our interest (the

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -897,7 +897,18 @@ void Replicator::rekeyPeerBody(GameWorld* gw, const Key& oldK, const Key& newK,
         // into our squad), insertPeerMember pins the actual local hand OWNED so
         // publishOwned streams it and the local player controls it. Idempotent +
         // tab-aware, so a squad-move re-containers an existing member too.
-        insertPeerMember(gw, c, newK, tag, destOwned);
+        // Don't re-join a dead body to the player squad: joinPlayerSquadAt
+        // triggers the squad-portrait refresh, and a portrait for a dead/re-keyed
+        // hand derefs a null PortraitData (MainBarGUI crash on death). The corpse
+        // stays down via the death latch on targets_[newK]. KO'd members still insert.
+        if (carryDeath) {
+            char sk[176]; _snprintf(sk, sizeof(sk) - 1,
+                "[%s] MEMBER skip new=%u,%u,%u,%u,%u (death-latched corpse)",
+                (tag ? tag : "squad"), newK.t, newK.c, newK.cs, newK.i, newK.s);
+            sk[sizeof(sk) - 1] = '\0'; coop::logLine(sk);
+        } else {
+            insertPeerMember(gw, c, newK, tag, destOwned);
+        }
         if (destOwned) {
             // Control hand-off: drop every residual DRIVE artifact so publishOwned
             // streams the body immediately and applyTargets never fights our own

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -129,9 +129,9 @@ void Replicator::syncSpawns(GameWorld* gw, Inbound& in, NetLink& net, u32 ownerI
             if (found) engine::charName(c, pkt.name, sizeof(pkt.name));
             net.queueSpawnInfo(pkt);
             char b[224]; _snprintf(b, sizeof(b) - 1,
-                "[spawn] INFO send hand=%u,%u,%u,%u,%u found=%d dead=%d age=%.2f sid='%s' fac='%s'",
+                "[spawn] INFO send hand=%u,%u,%u,%u,%u found=%d dead=%d age=%.2f sid='%s' fac='%s' name='%s'",
                 k.t, k.c, k.cs, k.i, k.s, pkt.found, pkt.dead, pkt.age,
-                pkt.charSid, pkt.facSid);
+                pkt.charSid, pkt.facSid, pkt.name);
             b[sizeof(b) - 1] = '\0'; coop::logLine(b);
         }
     }
@@ -420,12 +420,12 @@ void Replicator::syncSpawns(GameWorld* gw, Inbound& in, NetLink& net, u32 ownerI
         if (p.dead) targets_[k].deathLatched = true;
         // mintDist (Phase 1 telemetry): how far from our squad the proxy
         // appeared - the spawn-parity oracle gates its distribution.
-        char b[224]; _snprintf(b, sizeof(b) - 1,
+        char b[248]; _snprintf(b, sizeof(b) - 1,
             "[spawn] proxy BOUND hand=%u,%u,%u,%u,%u sid='%s' fac='%s' dead=%d "
-            "age=%.2f pos=%.1f,%.1f,%.1f mintDist=%.0f cen=%d (proxies=%u)",
+            "age=%.2f pos=%.1f,%.1f,%.1f mintDist=%.0f cen=%d (proxies=%u) name='%s'",
             k.t, k.c, k.cs, k.i, k.s, p.charSid, p.facSid, p.dead ? 1 : 0,
             p.age, p.x, p.y, p.z, mintDist, rq.fromCensus ? 1 : 0,
-            (unsigned)proxyByKey_.size());
+            (unsigned)proxyByKey_.size(), p.name);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
         // Phase 1b: a recruit/move whose ok=0 rekey enrolled a force-REQ (the
         // interest-split recruit) now has its proxy body - make it a real squad

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -126,6 +126,7 @@ void Replicator::syncSpawns(GameWorld* gw, Inbound& in, NetLink& net, u32 ownerI
             pkt.found = found ? 1 : 0;
             pkt.dead  = dead ? 1 : 0;
             pkt.age   = age; // animals scale body size by age (protocol 39)
+            if (found) engine::charName(c, pkt.name, sizeof(pkt.name));
             net.queueSpawnInfo(pkt);
             char b[224]; _snprintf(b, sizeof(b) - 1,
                 "[spawn] INFO send hand=%u,%u,%u,%u,%u found=%d dead=%d age=%.2f sid='%s' fac='%s'",
@@ -376,7 +377,8 @@ void Replicator::syncSpawns(GameWorld* gw, Inbound& in, NetLink& net, u32 ownerI
             }
         }
         Character* proxy = engine::spawnProxyNpc(gw, p.charSid, p.facSid,
-                                                 p.x, p.y, p.z, p.heading, p.age);
+                                                 p.x, p.y, p.z, p.heading, p.age,
+                                                 p.name);
         if (!proxy) {
             // Local mint failed (template/faction absent here - modded host?).
             // Back off hard; retrying in seconds cannot succeed.

--- a/src/plugin/test/ScenarioProbes.cpp
+++ b/src/plugin/test/ScenarioProbes.cpp
@@ -1650,6 +1650,71 @@ private:
     unsigned int  ownHand_[5];
 };
 
+// ===========================================================================
+// IdentSyncScenario (protocol 46 regression: character-name + animal-age sync)
+// - PASSIVE. With the 'npc' setup scene the host spawns a world NPC, which the
+// join MINTS as a proxy carrying the host's replicated name ("[spawn] proxy
+// BOUND ... name='..'") - the name_sync oracle asserts it is not the default
+// "Name". The periodic StatsPacket carries the owner's age ("[stats] SEND/RECV
+// ... age=..") - the age_sync oracle asserts host and join agree. This scenario
+// only holds the armed run open so those edges fire, then reports PASS as a
+// liveness marker (the real verdict is the two oracles'). Identical host + join.
+// ===========================================================================
+class IdentSyncScenario : public Scenario {
+public:
+    const char* name() const { return "ident_sync"; }
+    void onStart(const ScenarioContext&) {}
+    bool onTick(const ScenarioContext& ctx) { return ctx.elapsedMs >= 45000; }
+    bool passed() const { return true; }
+};
+
+// ===========================================================================
+// DeathPortraitScenario (regression for the death-portrait crash fix): the repro
+// is "a player's own character dies" (1 char per player - the host's char died and
+// both clients crashed). The host's char is already a proxy on the join from the
+// shared save, so its death crosses instantly (no recruit / far-mint). This bleeds
+// the HOST-OWNED leader out via LIMB wounds (bleedOutCharacter skips the fatal
+// torso/head so the game bleeds it over time rather than dying instantly), letting
+// the game run its OWN point-of-no-return death - which the join witnesses on its
+// proxy, re-keys the corpse + refreshes the squad portrait (the null-PortraitData
+// deref the fix guards). The death_portrait oracle requires the join to witness the
+// death (EVT_DEATH), then asserts no phantom 'Name' corpse + (if the death-latched
+// rekey fires) the MEMBER skip; health_* asserts no crash. PASS here is a liveness
+// marker (the verdict is the oracle's + health's).
+// ===========================================================================
+class DeathPortraitScenario : public Scenario {
+public:
+    DeathPortraitScenario() : subj_(0), bled_(false) {}
+    const char* name() const { return "death_portrait"; }
+    void onStart(const ScenarioContext& ctx) {
+        if (ctx.isHost) {
+            subj_ = engine::hostOwnedLeader(ctx.gw);
+            coop::logLine(subj_ ? "SCENARIO death-portrait subject = host leader"
+                                : "SCENARIO death-portrait NO host leader");
+        }
+    }
+    bool onTick(const ScenarioContext& ctx) {
+        // Bleed the host's own char out (LIMB wounds -> the game bleeds it over
+        // time into its natural death). Re-asserted each tick so an update() re-derive
+        // can't heal the wounds before it finishes. killSubject would force med->dead
+        // and BYPASS the death sequence, so it can't reproduce the bug.
+        if (ctx.isHost && subj_ && ctx.elapsedMs >= 15000) {
+            bool ok = false;
+            __try { ok = engine::bleedOutCharacter(ctx.gw, subj_); }
+            __except (EXCEPTION_EXECUTE_HANDLER) { ok = false; }
+            if (!bled_ && ok) {
+                coop::logLine("SCENARIO DEATH bleed-out started (death-portrait host char)");
+                bled_ = true;
+            }
+        }
+        return ctx.elapsedMs >= 130000; // room for the bleed-out + death propagation
+    }
+    bool passed() const { return true; }
+private:
+    Character* subj_;
+    bool       bled_;
+};
+
 } // namespace
 
 Scenario* makeProbeScenario(const std::string& name) {
@@ -1668,6 +1733,8 @@ Scenario* makeProbeScenario(const std::string& name) {
     if (name == "time_sync")     return new TimeProbeScenario(false);
     if (name == "hunger_probe")  return new HungerProbeScenario(true);
     if (name == "hunger_sync")   return new HungerProbeScenario(false);
+    if (name == "ident_sync")    return new IdentSyncScenario();
+    if (name == "death_portrait") return new DeathPortraitScenario();
     return 0;
 }
 

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -94,7 +94,7 @@ static void testSizes() {
     CHECK_EQ("sizeof(StatsPacket)",             sizeof(StatsPacket),             194);
     CHECK_EQ("sizeof(StealthPacket)",           sizeof(StealthPacket),           427);
     CHECK_EQ("sizeof(SpawnReqPacket)",          sizeof(SpawnReqPacket),          25);
-    CHECK_EQ("sizeof(SpawnInfoPacket)",         sizeof(SpawnInfoPacket),         143);
+    CHECK_EQ("sizeof(SpawnInfoPacket)",         sizeof(SpawnInfoPacket),         191);
     CHECK_EQ("sizeof(MoneyPacket)",             sizeof(MoneyPacket),             13);
     CHECK_EQ("sizeof(FactionPacket)",           sizeof(FactionPacket),           61);
     CHECK_EQ("sizeof(TimePacket)",              sizeof(TimePacket),              17);
@@ -220,7 +220,7 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v45: join-dealt combat-hit report)", (int)PROTOCOL_VERSION, 45);
+    CHECK_EQ("PROTOCOL_VERSION (v46: character name sync)", (int)PROTOCOL_VERSION, 46);
 }
 
 // ---- 2. readPacket / packetType round-trips -----------------------------------

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -91,7 +91,7 @@ static void testSizes() {
     CHECK_EQ("sizeof(TreatmentPacket)",         sizeof(TreatmentPacket),         77);
     CHECK_EQ("sizeof(CombatHitPacket)",         sizeof(CombatHitPacket),         37);
     CHECK_EQ("sizeof(SpeedPacket)",             sizeof(SpeedPacket),             14);
-    CHECK_EQ("sizeof(StatsPacket)",             sizeof(StatsPacket),             194);
+    CHECK_EQ("sizeof(StatsPacket)",             sizeof(StatsPacket),             198);
     CHECK_EQ("sizeof(StealthPacket)",           sizeof(StealthPacket),           427);
     CHECK_EQ("sizeof(SpawnReqPacket)",          sizeof(SpawnReqPacket),          25);
     CHECK_EQ("sizeof(SpawnInfoPacket)",         sizeof(SpawnInfoPacket),         191);
@@ -220,7 +220,7 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v46: character name sync)", (int)PROTOCOL_VERSION, 46);
+    CHECK_EQ("PROTOCOL_VERSION (v46: character name + animal age sync)", (int)PROTOCOL_VERSION, 46);
 }
 
 // ---- 2. readPacket / packetType round-trips -----------------------------------


### PR DESCRIPTION
**Base:** `nhoral/KenshiCoop:main` (v0.46) **←** `ChainsLunatic/KenshiCoop`
**Protocol:** 45 → **46** (single bump; folds both new wire features)
**Verification:** `scripts/build_plugin.cmd Release` green; `prototest 435/435 PASS`. Rebased cleanly onto v0.46.

Five commits, each atomic. First three are **crash / data-loss fixes with no wire change**; last two are **additive sync features** under a single protocol bump (45→46).

### Crash / data-loss (no protocol change)

**1. Peer disconnect destroys a recruited save-native character → crash + permanent save loss** (`mintedProxies_`)
`proxyByKey_` had no minted-vs-real discriminator. `rekeyPeerBody` binds a *real* save-stable body into it on a recruit (`destOwned` is only true for squad-*moves*), and `clearPeerReplicationState` then `GameWorld::destroy`s **every** entry on disconnect - killing a real character (freed pointer still in `playerCharacters`/MainBarGUI → crash; or baked out of the save).
*Fix:* a `std::set<Character*> mintedProxies_` populated only at the genuine mint; every `despawnProxyNpc` on a `proxyByKey_` entry is gated on membership.
*Repro:* co-op from a shared save → host recruits a save-native NPC → host disconnects → join crashes / loses the recruit.

**2. Inventory use-after-free entering cities/shops** (`Inventory::removeItem`)
The `[inv] APPLY` reconcile frees `Item`s (`removeItemAutoDestroy`) while the engine's trade/inventory UI holds pointers into the same container.
*Fix:* defer the reconcile while `engine::inventoryUiOpen()` (`ForgottenGUI::getNumOpenInventoryWindows() > 0`); it's idempotent and retries.

**3. Squad-portrait null-deref on character death** (`MainBarGUI::getPortrait`)
On death the body re-keys; the mod re-joined it to the player squad, and building a portrait for a dead/re-keyed hand derefs a null `PortraitData`. A follow-on symptom left a placeholder **"Name"** portrait.
*Fix:* skip `insertPeerMember`/`joinPlayerSquadAt` on a death-latched rekey, and suppress the fresh unnamed corpse-proxy mint.

### Sync features (protocol 46)

**4. Character-name sync**
Runtime-minted proxies (recruits, roaming NPCs, dialog ambushes) showed Kenshi's default **"Name"** - the mod never replicated names.
*Fix:* add `name[48]` to `SpawnInfoPacket`; host fills via `charName`, join `setName`s the minted proxy.

**5. Squad-animal age sync**
Animal body scale is age-driven and only sent at mint, so a growing squad animal kept its mint-time size on the peer.
*Fix:* carry `age` on the periodic owner-authoritative `StatsPacket`; apply `setAge` when it drifts.

### Provenance (how each issue was found)
Two of the crashes were diagnosed from **real minidumps** (`crashDump1.0.65_x64.dmp`), symbolicated by mapping the faulting `kenshi_x64.exe` RVA against the KenshiLib PDB annotations:
- **2. inventory UAF** - dump 2026-07-21 22:47: `ACCESS_VIOLATION` reading `0xFFFFFFFFFFFFFFFF` at `kenshi_x64.exe+0x74898F` → **`Inventory::removeItem`** (RVA 0x748810), the faulting op a virtual call on a freed inventory element. The plugin log showed an `[inv] APPLY` storm immediately before the fault; repro is entering a city/shop.
- **3. death portrait** - dump 2026-07-22 00:08: `ACCESS_VIOLATION` reading `0x40` at `kenshi_x64.exe+0x4129F6` → **`MainBarGUI::getPortrait`/`updatePortrait`** (0x412970 region), a null `PortraitData` deref. The log showed `REKEY-LATCH death=1` + `[squad] MEMBER insert` right before; repro is a character dying. The **"Name" phantom (3b)** was then observed in-game once the crash was gone.
- **1. peer-disconnect data loss** - found by **static audit** (three parallel passes + line-by-line verification), not a specific dump, but it produces the *same* `MainBarGUI` freed-pointer signature as item 3 plus permanent save-file loss; every link (`rekeyPeerBody` → `proxyByKey_` → `clearPeerReplicationState` → `GameWorld::destroy`) was confirmed in source.
- **4/5. name & animal-age** - sync-completeness audit against `Wire.h`, not crashes.
