### PR TITLE
Fix/join assassination sync

### DIFF
--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -24,7 +24,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 46;
+const u16 PROTOCOL_VERSION = 47;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -726,6 +726,10 @@ struct TreatmentPacket {
 // (blood + a frontal flesh wound), then the medical sim + vitals stream mirror
 // the result back. Idempotent-ish per hitId (log correlation only; the amounts
 // are deltas, so a dropped/duped datagram would mis-total - hence RELIABLE).
+enum CombatHitFlags {
+    COMBAT_HIT_KNOCKOUT = 1 << 0
+};
+
 struct CombatHitPacket {
     u8  type;    // = PKT_COMBAT_HIT
     u32 ownerId; // network player id of the sender (the ATTACKER's machine)
@@ -738,6 +742,8 @@ struct CombatHitPacket {
     u32 sSerial;
     f32 flesh;   // accumulated flesh damage to apply (frontal part)
     f32 blood;   // accumulated blood loss to apply
+    u8  flags;   // CombatHitFlags outcome bits
+    f32 koSkill;  // MedicalSystem::knockout(skill) input for KO duration
 };
 
 // Consensus game speed (pause/1x/2x/3x). As PKT_SPEED_REQ it carries one

--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -24,7 +24,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 45;
+const u16 PROTOCOL_VERSION = 46;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -408,19 +408,28 @@ struct InvItemEntry {
     char material[48];
 };
 
+// Protocol 46: identity of an inventory-bearing item relative to its stable
+// parent container. Recreated items have different raw hands on each peer, so
+// nested inventories (notably backpacks) are resolved by template + section +
+// same-template ordinal instead. Zero-filled for non-nested snapshots.
+struct NestedInvKey {
+    u32  itemType;
+    u16  section;
+    u8   ordinal;
+    char stringID[48];
+};
+
 // An inventory snapshot is: [InvSnapshotHeader][InvItemEntry * count]. The container
 // key identifies WHOSE inventory this is (a storage building, a character, a chest).
 // count == 0 is a valid "container is now empty" snapshot.
 struct InvSnapshotHeader {
     u8  type;    // = PKT_INV_SNAPSHOT
     u32 ownerId; // network player id of the authoritative sender
-    // Protocol 34: container identity kind. 0 = the c* fields are the raw
-    // (save-stable) hand - characters, baked chests, the previous implicit
-    // behaviour. 1 = the c* fields are the protocol-27 PLACER key of a
-    // session-placed building: the sender translated its local hand through
-    // its build maps (own placement = own hand; a minted proxy = the reverse
-    // map) and the receiver resolves through its own (peer key -> minted
-    // local hand; own key -> own hand) - the PKT_PROD identity approach.
+    // Protocol 34/46 container identity kind:
+    // 0 = raw save-stable hand (character, baked chest)
+    // 1 = protocol-27 placer key for a session-placed building
+    // 2 = nested item relative to a raw parent hand
+    // 3 = nested item relative to a parent placer key
     u8  keyKind;
     // container key (whose inventory; hand or placer key per keyKind)
     u32 cType;
@@ -428,6 +437,7 @@ struct InvSnapshotHeader {
     u32 cContainerSerial;
     u32 cIndex;
     u32 cSerial;
+    NestedInvKey nested;
     u8  count;   // number of InvItemEntry that follow
 };
 

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -1936,6 +1936,12 @@ void installEngineDetours() {
             // the damage its player-squad melee WOULD have dealt to driven world-NPC
             // copies; publishCombatHits forwards it and the host wounds the real body.
             g_repl.setReportCombat(!g_cfg.isHost);
+            if (!g_cfg.isHost) {
+                if (coop::engine::installKnockoutReportHook())
+                    coopLog("[dmg] knockout detour installed; assassination report ON");
+                else
+                    coopLog("[dmg] WARN knockout detour unavailable; assassination report OFF");
+            }
             coopLog(g_cfg.isHost
                 ? "[dmg] hitByMeleeAttack detour installed; damage guard ON (host, driven peer-squad bodies)"
                 : "[dmg] hitByMeleeAttack detour installed; damage guard ON + combat-hit report ON (join)");

--- a/src/plugin/core/Inbound.h
+++ b/src/plugin/core/Inbound.h
@@ -43,6 +43,7 @@ struct InboundInv {
     u32                       ownerId;
     u8                        keyKind;
     u32                       cKey[5]; // type, container, containerSerial, index, serial
+    NestedInvKey              nested;
     std::vector<InvItemEntry> items;
 };
 
@@ -420,12 +421,13 @@ public:
         EnterCriticalSection(&cs_); evt_.push_back(ievt); LeaveCriticalSection(&cs_);
     }
     // NET thread: one received container-contents snapshot, owner-tagged.
-    void pushInv(u32 ownerId, u8 keyKind, const u32 cKey[5],
+    void pushInv(u32 ownerId, u8 keyKind, const u32 cKey[5], const NestedInvKey& nested,
                  const InvItemEntry* items, unsigned int count) {
         InboundInv ii;
         ii.ownerId = ownerId;
         ii.keyKind = keyKind;
         for (int k = 0; k < 5; ++k) ii.cKey[k] = cKey[k];
+        ii.nested = nested;
         if (items && count > 0) ii.items.assign(items, items + count);
         EnterCriticalSection(&cs_); inv_.push_back(ii); LeaveCriticalSection(&cs_);
     }

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -293,6 +293,9 @@ void  markerDestroy(void* label);
 // knockDown drops a Character into (on=true) / out of (on=false) full-body
 // ragdoll - the join calls it to reproduce a host-authoritative down edge.
 bool knockDown(Character* c, bool on);
+// Apply a real engine-calculated knockout without replacing its duration with
+// the short forced timer used by the down-state replication scaffold.
+bool applyKnockout(Character* c, float skill);
 // Maintain an already-down body each tick by topping the KO timer (no re-collapse).
 // Prevents the get-up/flop flicker without re-triggering the ragdoll fall. Join-side.
 bool holdDown(Character* c);
@@ -944,6 +947,9 @@ void         setTaskSelectSpike(bool on);
 // Same pattern as the AI-suspend detour: pointer-compared set, rebuilt each tick
 // on the main thread, hook installed once.
 bool         installDamageGuardHook();
+// Join only: capture MedicalSystem::knockout calls on guarded world-NPC copies.
+// Assassinations bypass hitByMeleeAttack, so this is their combat-report edge.
+bool         installKnockoutReportHook();
 void         clearDamageGuard();
 void         addDamageGuard(Character* c);
 unsigned int damageGuardCount();
@@ -966,6 +972,7 @@ void         addReportAttacker(Character* c);
 // Drain the accumulated join-dealt damage for one victim copy (returns false if
 // nothing pending). flesh/blood are the summed deltas since the last drain.
 bool         takeReportedDamage(Character* c, float* outFlesh, float* outBlood);
+bool         takeReportedKnockout(Character* c, float* outSkill);
 
 // Read a character's current blood level by hand (medical.blood). The vitals
 // ground-truth read for the damage_guard conformance oracle: the HOST's victim

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -466,6 +466,20 @@ unsigned int captureContainerContents(GameWorld* gw, const unsigned int cHand[5]
                                       InvItemEntry* out, unsigned int maxOut,
                                       unsigned int* outHash);
 
+struct NestedContainerRead {
+    u32 hand[5];
+    NestedInvKey key;
+};
+
+// SEH-guarded: enumerate inventory-carrying items inside cHand, returning each
+// local object hand and a parent-relative locator suitable for the wire.
+unsigned int captureNestedContainers(GameWorld* gw, const unsigned int cHand[5],
+                                     NestedContainerRead* out, unsigned int maxOut);
+
+// SEH-guarded: resolve a parent-relative locator to this peer's local item hand.
+bool resolveNestedContainerHand(const unsigned int parentHand[5],
+                                const NestedInvKey& key, unsigned int outHand[5]);
+
 // SEH-guarded: reconcile the local container (cHand) to the desired item multiset:
 // add any shortfall (createItem of the template + tryAddItem) and remove any excess
 // (removeItemAutoDestroy), per (stringID, itemType) key. count==0 empties it.

--- a/src/plugin/game/EngineInternal.cpp
+++ b/src/plugin/game/EngineInternal.cpp
@@ -1127,6 +1127,21 @@ struct ReportedDmg { float flesh; float blood; ReportedDmg() : flesh(0.0f), bloo
 std::map<Character*, ReportedDmg> g_reportedDmg;
 std::set<Character*>              g_reportAttackers;
 bool                              g_combatReport = false;
+std::map<Character*, float>       g_reportedKnockouts;
+bool                              g_suppressKnockoutReport = false;
+
+MedFloatFn g_knockoutOrig = 0;
+void __fastcall knockout_hook(MedicalSystem* self, float skill) {
+    Character* victim = 0;
+    if (g_combatReport && !g_suppressKnockoutReport) {
+        for (std::set<Character*>::iterator it = g_damageGuarded.begin();
+             it != g_damageGuarded.end(); ++it) {
+            if (&(*it)->medical == self) { victim = *it; break; }
+        }
+    }
+    g_knockoutOrig(self, skill);
+    if (victim) g_reportedKnockouts[victim] = skill;
+}
 
 HitMaterialType __fastcall hitByMelee_hook(Character* self, CutDirection dir,
                                            Damages& damage, Character* who,
@@ -1977,6 +1992,13 @@ bool installDamageGuardHook() {
                               (void**)&g_hitByMeleeOrig) == KenshiLib::SUCCESS;
 }
 
+bool installKnockoutReportHook() {
+    intptr_t addr = KenshiLib::GetRealAddress(&MedicalSystem::knockout);
+    if (!addr) return false;
+    return KenshiLib::AddHook(addr, (void*)&knockout_hook,
+                              (void**)&g_knockoutOrig) == KenshiLib::SUCCESS;
+}
+
 bool installShopHook() {
     intptr_t addr = KenshiLib::GetRealAddress(&Inventory::buyItem);
     if (!addr) return false;
@@ -2220,7 +2242,10 @@ void damageGuardStats(unsigned long* outGuarded, unsigned long* outPassed) {
 
 void setCombatReport(bool on) {
     g_combatReport = on;
-    if (!on) g_reportedDmg.clear();
+    if (!on) {
+        g_reportedDmg.clear();
+        g_reportedKnockouts.clear();
+    }
 }
 void clearReportAttackers()          { g_reportAttackers.clear(); }
 void addReportAttacker(Character* c)  { if (c) g_reportAttackers.insert(c); }
@@ -2230,6 +2255,14 @@ bool takeReportedDamage(Character* c, float* outFlesh, float* outBlood) {
     if (outFlesh) *outFlesh = it->second.flesh;
     if (outBlood) *outBlood = it->second.blood;
     g_reportedDmg.erase(it);
+    return true;
+}
+
+bool takeReportedKnockout(Character* c, float* outSkill) {
+    std::map<Character*, float>::iterator it = g_reportedKnockouts.find(c);
+    if (it == g_reportedKnockouts.end()) return false;
+    if (outSkill) *outSkill = it->second;
+    g_reportedKnockouts.erase(it);
     return true;
 }
 

--- a/src/plugin/game/EngineInternal.h
+++ b/src/plugin/game/EngineInternal.h
@@ -350,6 +350,7 @@ extern EndActionFn     g_endActionFn;
 extern RagdollModeFn   g_ragdollModeFn;
 extern MedFloatFn      g_knockoutFn;
 extern MedFloatFn      g_knockoutForceFn;
+extern bool            g_suppressKnockoutReport;
 extern MedAmputateFn     g_medAmputateFn;
 extern MedCrushLimbFn    g_medCrushLimbFn;
 extern MedSetRobotLimbFn g_medSetRobotLimbFn;

--- a/src/plugin/game/EngineInventory.cpp
+++ b/src/plugin/game/EngineInventory.cpp
@@ -432,6 +432,99 @@ unsigned int captureContainerContents(GameWorld* gw, const unsigned int cHand[5]
     return n;
 }
 
+unsigned int captureNestedContainers(GameWorld* gw, const unsigned int cHand[5],
+                                     NestedContainerRead* out, unsigned int maxOut) {
+    if (!gw || !cHand || !out || maxOut == 0 || !g_getSectionsFn) return 0;
+    RootObject* ro = resolveObjectByHand(cHand);
+    if (!ro) return 0;
+    Inventory* inv = invOf(ro);
+    if (!inv) return 0;
+    unsigned int n = 0;
+    __try {
+        lektor<InventorySection*>* secs = g_getSectionsFn(inv);
+        unsigned int ns = secs ? secs->size() : 0;
+        for (unsigned int s = 0; s < ns && n < maxOut; ++s) {
+            InventorySection* sec = (*secs)[s];
+            if (!sec) continue;
+            // Nested containers live in container slots (backpack/cargo-style);
+            // skip plain loose sections and skip equipped-only sections that are
+            // not flagged as container slots.
+            if (!sec->containerSlot) continue;
+            const Ogre::vector<InventorySection::SectionItem>::type& its = sec->items;
+            unsigned int ni = (unsigned int)its.size();
+            for (unsigned int i = 0; i < ni && n < maxOut; ++i) {
+                Item* it = its[i].item;
+                if (!it) continue;
+                RootObject* iobj = reinterpret_cast<RootObject*>(it);
+                if (!invOf(iobj)) continue; // not an inventory-carrying item
+                GameData* gd = it->getGameData();
+                if (!gd) continue;
+                unsigned int h[5];
+                if (!readObjectHand(iobj, h)) continue;
+                bool dup = false;
+                for (unsigned int k = 0; k < n; ++k) {
+                    if (out[k].hand[0] == h[0] && out[k].hand[1] == h[1] &&
+                        out[k].hand[2] == h[2] && out[k].hand[3] == h[3] &&
+                        out[k].hand[4] == h[4]) {
+                        dup = true; break;
+                    }
+                }
+                if (dup) continue;
+                memset(&out[n], 0, sizeof(out[n]));
+                for (int k = 0; k < 5; ++k) out[n].hand[k] = h[k];
+                out[n].key.itemType = (u32)gd->type;
+                out[n].key.section = sectionNameHash(sec->name.c_str());
+                strncpy(out[n].key.stringID, gd->stringID.c_str(),
+                        sizeof(out[n].key.stringID) - 1);
+                unsigned int ordinal = 0;
+                for (unsigned int k = 0; k < n; ++k) {
+                    if (out[k].key.itemType == out[n].key.itemType &&
+                        out[k].key.section == out[n].key.section &&
+                        strcmp(out[k].key.stringID, out[n].key.stringID) == 0)
+                        ++ordinal;
+                }
+                out[n].key.ordinal = (u8)ordinal; // caller caps this enumeration at 32
+                ++n;
+            }
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return n;
+    }
+    return n;
+}
+
+bool resolveNestedContainerHand(const unsigned int parentHand[5],
+                                const NestedInvKey& key, unsigned int outHand[5]) {
+    if (!parentHand || !outHand || !g_getSectionsFn) return false;
+    RootObject* ro = resolveObjectByHand(parentHand);
+    if (!ro) return false;
+    Inventory* inv = invOf(ro);
+    if (!inv) return false;
+    __try {
+        lektor<InventorySection*>* secs = g_getSectionsFn(inv);
+        unsigned int ns = secs ? secs->size() : 0;
+        unsigned int ordinal = 0;
+        for (unsigned int s = 0; s < ns; ++s) {
+            InventorySection* sec = (*secs)[s];
+            if (!sec || !sec->containerSlot ||
+                sectionNameHash(sec->name.c_str()) != key.section) continue;
+            const Ogre::vector<InventorySection::SectionItem>::type& its = sec->items;
+            for (unsigned int i = 0; i < (unsigned int)its.size(); ++i) {
+                Item* it = its[i].item;
+                if (!it) continue;
+                RootObject* iobj = reinterpret_cast<RootObject*>(it);
+                if (!invOf(iobj)) continue;
+                GameData* gd = it->getGameData();
+                if (!gd || (u32)gd->type != key.itemType ||
+                    strcmp(gd->stringID.c_str(), key.stringID) != 0) continue;
+                if (ordinal++ != key.ordinal) continue;
+                return readObjectHand(iobj, outHand);
+            }
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+    return false;
+}
+
 bool applyContainerContents(GameWorld* gw, const unsigned int cHand[5],
                             const InvItemEntry* items, unsigned int count) {
     if (!gw) return false;

--- a/src/plugin/game/EngineSpawnCombat.cpp
+++ b/src/plugin/game/EngineSpawnCombat.cpp
@@ -989,7 +989,11 @@ bool knockDown(Character* c, bool on) {
             // well past the re-arm interval. Fall back to ragdoll if unresolved.
             if (g_knockoutFn || g_knockoutForceFn) {
                 MedicalSystem* med = &c->medical;
-                if (g_knockoutFn)      g_knockoutFn(med, 1.0f);
+                if (g_knockoutFn) {
+                    g_suppressKnockoutReport = true;
+                    g_knockoutFn(med, 1.0f);
+                    g_suppressKnockoutReport = false;
+                }
                 if (g_knockoutForceFn) g_knockoutForceFn(med, 8.0f);
                 return true;
             }
@@ -1001,6 +1005,22 @@ bool knockDown(Character* c, bool on) {
         if (g_ragdollModeFn)   g_ragdollModeFn(c, false, RagdollPart::WHOLE);
         return true;
     } __except (EXCEPTION_EXECUTE_HANDLER) {
+        g_suppressKnockoutReport = false;
+        return false;
+    }
+}
+
+bool applyKnockout(Character* c, float skill) {
+    if (!c || !g_knockoutFn) return false;
+    __try {
+        if (skill < 0.0f) skill = 0.0f;
+        if (skill > 1.0f) skill = 1.0f;
+        g_suppressKnockoutReport = true;
+        g_knockoutFn(&c->medical, skill);
+        g_suppressKnockoutReport = false;
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        g_suppressKnockoutReport = false;
         return false;
     }
 }

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -149,11 +149,14 @@ void NetLink::setOwnedEntities(u32 ownerId, const EntityState* arr, unsigned int
 void NetLink::queueEvent(const EventPacket& ev) { pushLocked(outCs_, outEvents_, ev); }
 
 void NetLink::queueInvSnapshot(u32 ownerId, u8 keyKind, const u32 cKey[5],
+                               const NestedInvKey* nested,
                                const InvItemEntry* items, unsigned int count) {
     OutInv oi;
+    std::memset(&oi.nested, 0, sizeof(oi.nested));
     oi.ownerId = ownerId;
     oi.keyKind = keyKind;
     for (int k = 0; k < 5; ++k) oi.cKey[k] = cKey[k];
+    if (nested) oi.nested = *nested;
     if (count > INV_ITEMS_MAX) count = INV_ITEMS_MAX;
     if (items && count > 0) oi.items.assign(items, items + count);
     pushLocked(outCs_, outInv_, oi);
@@ -548,7 +551,7 @@ void NetLink::threadLoop() {
                                                 hdr.cContainerSerial, hdr.cIndex, hdr.cSerial };
                                 const InvItemEntry* items =
                                     (hdr.count > 0) ? reinterpret_cast<const InvItemEntry*>(p) : 0;
-                                inbound_->pushInv(hdr.ownerId, hdr.keyKind, cKey,
+                                inbound_->pushInv(hdr.ownerId, hdr.keyKind, cKey, hdr.nested,
                                                   items, hdr.count);
                             }
                         }
@@ -981,6 +984,7 @@ void NetLink::threadLoop() {
             hdr.cContainerSerial = invs[i].cKey[2];
             hdr.cIndex           = invs[i].cKey[3];
             hdr.cSerial          = invs[i].cKey[4];
+            hdr.nested           = invs[i].nested;
             hdr.count            = (u8)count;
             std::memcpy(out->data, &hdr, sizeof(hdr));
             if (count > 0)

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -50,9 +50,9 @@ public:
     // thread serializes [InvSnapshotHeader][InvItemEntry*count] and sends it on the
     // RELIABLE channel next tick. count may be 0 ("container now empty"). Copied
     // under lock; only enqueued on content-change so the reliable channel stays cheap.
-    // keyKind (protocol 34): 0 = cKey is the raw container hand, 1 = cKey is the
-    // protocol-27 placer key of a session-placed building (receiver translates).
+    // keyKind: 0/1 = raw/placer container, 2/3 = nested under raw/placer parent.
     void queueInvSnapshot(u32 ownerId, u8 keyKind, const u32 cKey[5],
+                          const NestedInvKey* nested,
                           const InvItemEntry* items, unsigned int count);
 
     // MAIN thread: queue a reliable world-item snapshot (Phase W1). The net thread
@@ -229,8 +229,9 @@ private:
     // list. Guarded by outCs_.
     struct OutInv {
         u32                       ownerId;
-        u8                        keyKind; // protocol 34: 0 raw hand, 1 placer key
+        u8                        keyKind;
         u32                       cKey[5];
+        NestedInvKey              nested;
         std::vector<InvItemEntry> items;
     };
     std::vector<OutInv>      outInv_;

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -1244,7 +1244,13 @@ private:
     // damage into pendingHits_ (keyed by the copy's canonical hand), and
     // publishCombatHits forwards it to the host. nextHitId_ is a per-sender counter
     // for log correlation.
-    struct PendingHit { float flesh; float blood; PendingHit() : flesh(0.0f), blood(0.0f) {} };
+    struct PendingHit {
+        float flesh;
+        float blood;
+        float knockoutSkill;
+        bool knockout;
+        PendingHit() : flesh(0.0f), blood(0.0f), knockoutSkill(1.0f), knockout(false) {}
+    };
     bool                 reportCombat_;
     std::map<Key, PendingHit> pendingHits_;
     unsigned int         nextHitId_;

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -374,7 +374,7 @@ void Replicator::publishCombatHits(GameWorld* gw, NetLink& net, u32 ownerId) {
          it != pendingHits_.end(); ++it) {
         const Key&       k  = it->first;
         const PendingHit& ph = it->second;
-        if (ph.flesh <= 0.0f && ph.blood <= 0.0f) continue;
+        if (ph.flesh <= 0.0f && ph.blood <= 0.0f && !ph.knockout) continue;
         CombatHitPacket chp;
         memset(&chp, 0, sizeof(chp));
         chp.type    = (u8)PKT_COMBAT_HIT;
@@ -383,10 +383,13 @@ void Replicator::publishCombatHits(GameWorld* gw, NetLink& net, u32 ownerId) {
         chp.sType = k.t; chp.sContainer = k.c; chp.sContainerSerial = k.cs;
         chp.sIndex = k.i; chp.sSerial = k.s;
         chp.flesh = ph.flesh; chp.blood = ph.blood;
+        chp.flags = ph.knockout ? COMBAT_HIT_KNOCKOUT : 0;
+        chp.koSkill = ph.knockoutSkill;
         net.queueCombatHit(chp);
         char b[160]; _snprintf(b, sizeof(b) - 1,
-            "[combat] HIT SEND id=%u hand=%u,%u flesh=%.1f blood=%.1f",
-            chp.hitId, k.i, k.s, ph.flesh, ph.blood);
+            "[combat] HIT SEND id=%u hand=%u,%u flesh=%.1f blood=%.1f ko=%u skill=%.2f",
+            chp.hitId, k.i, k.s, ph.flesh, ph.blood, ph.knockout ? 1u : 0u,
+            ph.knockoutSkill);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
     pendingHits_.clear();
@@ -413,7 +416,13 @@ void Replicator::applyCombatHits(GameWorld* gw, Inbound& in) {
             continue;
         }
         unsigned int hand[5] = { k.t, k.c, k.cs, k.i, k.s };
-        bool applied = engine::applyReportedDamage(gw, hand, p.flesh, p.blood);
+        bool applied = false;
+        if (p.flesh > 0.0f || p.blood > 0.0f)
+            applied = engine::applyReportedDamage(gw, hand, p.flesh, p.blood);
+        if (p.flags & COMBAT_HIT_KNOCKOUT) {
+            Character* c = engine::resolveCharByHand(k.i, k.s, k.t, k.c, k.cs);
+            if (c && engine::applyKnockout(c, p.koSkill)) applied = true;
+        }
         // A wounded world NPC is definitionally combat-scoped: mark it so the NPC
         // vitals stream (publishMedical, Phase B) mirrors the authoritative drop
         // back to the join's cosmetic copy (link 6 - "damage reached the join").
@@ -421,8 +430,9 @@ void Replicator::applyCombatHits(GameWorld* gw, Inbound& in) {
         // never reflect the host-applied wound.
         if (applied && streamNpcs_) medNpc_[k] = nowMs();
         char b[160]; _snprintf(b, sizeof(b) - 1,
-            "[combat] HIT RECV id=%u hand=%u,%u flesh=%.1f blood=%.1f applied=%d",
-            p.hitId, k.i, k.s, p.flesh, p.blood, applied ? 1 : 0);
+            "[combat] HIT RECV id=%u hand=%u,%u flesh=%.1f blood=%.1f ko=%u skill=%.2f applied=%d",
+            p.hitId, k.i, k.s, p.flesh, p.blood,
+            (p.flags & COMBAT_HIT_KNOCKOUT) ? 1u : 0u, p.koSkill, applied ? 1 : 0);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 }

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -276,13 +276,22 @@ void Replicator::clearPeerReplicationState(GameWorld* gw) {
     // authority - or a freed pointer once the engine reaps it. SEH-guarded via
     // despawnProxyNpc so a single bad pointer can't take down the leave path.
     unsigned int cleared = 0;
+    unsigned int preservedSquad = 0;
     for (std::map<Key, Character*>::iterator it = proxyByKey_.begin();
          it != proxyByKey_.end(); ++it) {
-        if (gw && it->second && engine::despawnProxyNpc(gw, it->second))
-            ++cleared;
+        if (!gw || !it->second) continue;
+        // proxyByKey_ can temporarily bind real bodies after recruit/squad re-keys.
+        // Never destroy a live player-squad member on peer
+        // leave; those are save-authoritative world bodies, not disposable proxies.
+        if (engine::isPlayerSquad(gw, reinterpret_cast<RootObject*>(it->second))) {
+            ++preservedSquad;
+            continue;
+        }
+        if (engine::despawnProxyNpc(gw, it->second)) ++cleared;
     }
     char b[96];
-    _snprintf(b, sizeof(b) - 1, "[leave] cleared proxies=%u", cleared);
+    _snprintf(b, sizeof(b) - 1, "[leave] cleared proxies=%u keepSquad=%u",
+              cleared, preservedSquad);
     b[sizeof(b) - 1] = '\0';
     coop::logLine(b);
     // World-item proxies (Phase 3): the world stays LIVE across a peer leave /
@@ -356,7 +365,7 @@ void Replicator::ingestInv(Inbound& in) {
         // placement = our minted proxy). An unresolvable key (mint not
         // landed yet / refused / tombstoned) is dropped - the sender's 5 s
         // safety resend re-delivers once the mint exists.
-        if (it->keyKind == 1) {
+        if (it->keyKind == 1 || it->keyKind == 3) {
             std::map<Key, OwnBuild>::iterator ob = ownBuilds_.find(k);
             if (ob != ownBuilds_.end()) {
                 if (ob->second.removed) continue;
@@ -372,6 +381,14 @@ void Replicator::ingestInv(Inbound& in) {
                 k.cs = pb->second.localHand[2]; k.i = pb->second.localHand[3];
                 k.s = pb->second.localHand[4];
             }
+        }
+        if (it->keyKind == 2 || it->keyKind == 3) {
+            unsigned int parent[5] = { k.t, k.c, k.cs, k.i, k.s };
+            unsigned int local[5];
+            if (!engine::resolveNestedContainerHand(parent, it->nested, local))
+                continue;
+            k.t = local[0]; k.c = local[1]; k.cs = local[2];
+            k.i = local[3]; k.s = local[4];
         }
         InvRecv& r = invRecv_[k];
         r.ownerId = it->ownerId;

--- a/src/plugin/sync/ReplicatorDrive.cpp
+++ b/src/plugin/sync/ReplicatorDrive.cpp
@@ -281,10 +281,16 @@ void Replicator::applyTargets(GameWorld* gw) {
         // still drain it so the engine-side accumulator stays bounded.
         if (reportCombat_) {
             float rf = 0.0f, rb = 0.0f;
-            if (engine::takeReportedDamage(c, &rf, &rb) && !isSquad &&
-                (rf > 0.0f || rb > 0.0f)) {
+            bool haveDamage = engine::takeReportedDamage(c, &rf, &rb);
+            float koSkill = 1.0f;
+            bool knockout = engine::takeReportedKnockout(c, &koSkill);
+            if (!isSquad && ((haveDamage && (rf > 0.0f || rb > 0.0f)) || knockout)) {
                 PendingHit& ph = pendingHits_[it->first];
                 ph.flesh += rf; ph.blood += rb;
+                if (knockout) {
+                    ph.knockout = true;
+                    ph.knockoutSkill = koSkill;
+                }
             }
         }
 

--- a/src/plugin/sync/ReplicatorItems.cpp
+++ b/src/plugin/sync/ReplicatorItems.cpp
@@ -50,6 +50,29 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
         }
         owned.insert(censusContainers_.begin(), censusContainers_.end());
     }
+    // Protocol 46: publish nested inventory containers (worn backpacks / cargo
+    // items) independently, so their contents sync. Discover them from each
+    // authored top-level container's containerSlot sections and add them to this
+    // tick's authored set.
+    struct NestedWire { Key parent; NestedInvKey locator; };
+    std::map<Key, NestedWire> nestedWire;
+    if (!owned.empty()) {
+        const unsigned int MAX_NESTED = 32;
+        std::set<Key> nested;
+        engine::NestedContainerRead rows[MAX_NESTED];
+        for (std::set<Key>::iterator it = owned.begin(); it != owned.end(); ++it) {
+            unsigned int p[5] = { it->t, it->c, it->cs, it->i, it->s };
+            unsigned int n = engine::captureNestedContainers(gw, p, rows, MAX_NESTED);
+            for (unsigned int i = 0; i < n; ++i) {
+                Key k; k.t = rows[i].hand[0]; k.c = rows[i].hand[1];
+                k.cs = rows[i].hand[2]; k.i = rows[i].hand[3]; k.s = rows[i].hand[4];
+                nested.insert(k);
+                NestedWire nw; nw.parent = *it; nw.locator = rows[i].key;
+                nestedWire[k] = nw;
+            }
+        }
+        owned.insert(nested.begin(), nested.end());
+    }
     if (owned.empty()) return;
     const unsigned long INV_RESEND_MS = 5000; // periodic safety resend (loss/late join)
     // A changed snapshot must be STABLE this long before we publish it. A change that only
@@ -98,8 +121,27 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
         // protocol-27 placer key (own placement = our hand; a minted proxy =
         // the reverse map). Characters / baked containers stay raw (kind 0).
         u8 keyKind = 0;
+        const NestedInvKey* nestedKey = 0;
         u32 wireKey[5] = { it->t, it->c, it->cs, it->i, it->s };
-        if (ownBuilds_.find(*it) != ownBuilds_.end()) {
+        std::map<Key, NestedWire>::iterator nit = nestedWire.find(*it);
+        if (nit != nestedWire.end()) {
+            keyKind = 2;
+            Key parent = nit->second.parent;
+            wireKey[0] = parent.t; wireKey[1] = parent.c; wireKey[2] = parent.cs;
+            wireKey[3] = parent.i; wireKey[4] = parent.s;
+            if (ownBuilds_.find(parent) != ownBuilds_.end()) {
+                keyKind = 3;
+            } else {
+                std::map<Key, Key>::iterator pmit = mintByLocal_.find(parent);
+                if (pmit != mintByLocal_.end()) {
+                    keyKind = 3;
+                    wireKey[0] = pmit->second.t; wireKey[1] = pmit->second.c;
+                    wireKey[2] = pmit->second.cs; wireKey[3] = pmit->second.i;
+                    wireKey[4] = pmit->second.s;
+                }
+            }
+            nestedKey = &nit->second.locator;
+        } else if (ownBuilds_.find(*it) != ownBuilds_.end()) {
             keyKind = 1;
         } else {
             std::map<Key, Key>::iterator mit = mintByLocal_.find(*it);
@@ -110,7 +152,7 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
                 wireKey[4] = mit->second.s;
             }
         }
-        net.queueInvSnapshot(ownerId, keyKind, wireKey, items, n);
+        net.queueInvSnapshot(ownerId, keyKind, wireKey, nestedKey, items, n);
         pub.hash = hash; pub.lastSendMs = now; pub.lastSentN = n;
         if (changed) {
             char b[200];

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -78,7 +78,8 @@ static void testSizes() {
     CHECK_EQ("sizeof(EntityState)",             sizeof(EntityState),             79);
     CHECK_EQ("sizeof(EntityBatchHeader)",       sizeof(EntityBatchHeader),       14); // v35: +sendMs; v44: +epoch
     CHECK_EQ("sizeof(InvItemEntry)",            sizeof(InvItemEntry),            158); // v42: +locked+lockReserved
-    CHECK_EQ("sizeof(InvSnapshotHeader)",       sizeof(InvSnapshotHeader),       27); // v33: +keyKind
+    CHECK_EQ("sizeof(NestedInvKey)",            sizeof(NestedInvKey),            55);
+    CHECK_EQ("sizeof(InvSnapshotHeader)",       sizeof(InvSnapshotHeader),       82); // v46: +nested key
     CHECK_EQ("sizeof(WorldItemEntry)",          sizeof(WorldItemEntry),          73);
     CHECK_EQ("sizeof(WorldItemSnapshotHeader)", sizeof(WorldItemSnapshotHeader), 6);
     CHECK_EQ("sizeof(WorldItemRemoveHeader)",   sizeof(WorldItemRemoveHeader),   6);
@@ -220,7 +221,7 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v45: join-dealt combat-hit report)", (int)PROTOCOL_VERSION, 45);
+    CHECK_EQ("PROTOCOL_VERSION (v46: parent-relative nested inventory)", (int)PROTOCOL_VERSION, 46);
 }
 
 // ---- 2. readPacket / packetType round-trips -----------------------------------
@@ -1175,7 +1176,8 @@ static void testFlushWorldStateContract() {
     // --- Push one sentinel into every WORLD-STATE queue (28).
     in.pushEntity(1, 0, e);
     in.pushEvent(1, ev);
-    in.pushInv(1, 0, cKey, 0, 0);
+    NestedInvKey nested; std::memset(&nested, 0, sizeof(nested));
+    in.pushInv(1, 0, cKey, nested, 0, 0);
     in.pushWorldItems(1, 0, 0);
     in.pushWorldRemove(1, 0, 0);
     in.pushNpcCensus(1, 0, 0, 0);

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -90,7 +90,7 @@ static void testSizes() {
     CHECK_EQ("sizeof(MedPartEntry)",            sizeof(MedPartEntry),            19);
     CHECK_EQ("sizeof(MedicalPacket)",           sizeof(MedicalPacket),           467);
     CHECK_EQ("sizeof(TreatmentPacket)",         sizeof(TreatmentPacket),         77);
-    CHECK_EQ("sizeof(CombatHitPacket)",         sizeof(CombatHitPacket),         37);
+    CHECK_EQ("sizeof(CombatHitPacket)",         sizeof(CombatHitPacket),         42);
     CHECK_EQ("sizeof(SpeedPacket)",             sizeof(SpeedPacket),             14);
     CHECK_EQ("sizeof(StatsPacket)",             sizeof(StatsPacket),             194);
     CHECK_EQ("sizeof(StealthPacket)",           sizeof(StealthPacket),           427);
@@ -221,7 +221,8 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v46: parent-relative nested inventory)", (int)PROTOCOL_VERSION, 46);
+    CHECK_EQ("COMBAT_HIT_KNOCKOUT flag", (int)COMBAT_HIT_KNOCKOUT, 1);
+    CHECK_EQ("PROTOCOL_VERSION (v47: join assassination report + KO skill)", (int)PROTOCOL_VERSION, 47);
 }
 
 // ---- 2. readPacket / packetType round-trips -----------------------------------


### PR DESCRIPTION
## Summary

Fix join-side assassinations so the host applies the authoritative knockout with the correct unconscious duration.

## Problem

Join-side assassinations bypass `Character::hitByMeleeAttack`, so the existing join combat-report path never notified the host about the knockout.

Reporting only the knockout state was also insufficient. Applying it through the generic down-state helper replaced the engine-calculated duration with the short forced timer used for replication scaffolding.

## Solution

- Hook `MedicalSystem::knockout` on the join for guarded, host-owned NPC copies.
- Capture the engine-provided knockout skill input.
- Send the knockout flag and skill value through the existing reliable combat-hit channel.
- Resolve the authoritative victim and call the real knockout function on the host.
- Keep the forced eight-second timer limited to generic down-state reproduction.
- Suppress reports generated by replication-driven knockdowns to prevent feedback.
- Bump the protocol version to 47.

## Validation

- VC10 Harness plugin build passes.
- Prototest passes: 437/437 checks.
- Repository verification passes:
  - Unit layer: PASS
  - Contract fixtures: 29/29 PASS
  - Overall: PASS
- Manually tested with separate host and join installations.
- Confirmed a join-controlled character can assassinate a world NPC.
- Confirmed the host receives the knockout and preserves the expected unconscious duration.

## Dependency

This branch is based on `Sync nested backpack inventories across peers` (`08acf6c`), which uses protocol 46. This change follows it with protocol 47.

If the backpack PR is squash-merged, this branch will need to be rebased onto the updated `main` before merge.

## AI Disclosure

This change was developed with assistance from GitHub Copilot. The implementation was reviewed, built, and manually validated before submission.