### PR TITLE
Save-native world items never stream: fixes the grey free-item duplicates and theft bypass

### DIFF
--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -794,7 +794,10 @@ struct WorldItemRaw {
 // SEH-guarded (host): enumerate free GROUND items within `radius` of the local leader
 // (interest scope) into out[] (up to maxOut), deduped by hand. Items inside inventories
 // are NOT enumerated by the engine's sphere query (confirmed by the W0 drop_probe), so
-// every result is a real world item. Returns the number written.
+// every result is a real world item. Items OWNED by a non-player faction (the "red"
+// stealing items placed in towns/shops) are excluded: they are save-natives both
+// clients already hold, and streaming one mints an unowned grey duplicate on the peer
+// (the theft-bypass dup, upstream #63/#66). Returns the number written.
 unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int maxOut,
                                float radius);
 

--- a/src/plugin/game/EngineInventory.cpp
+++ b/src/plugin/game/EngineInventory.cpp
@@ -1562,6 +1562,10 @@ unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int ma
         if (gw->player->playerCharacters.size() == 0) return 0;
         Character* ld = gw->player->playerCharacters[0];
         if (!ld) return 0;
+        // Player faction for the ownership filter below (0 tolerated: the filter
+        // then only skips items with SOME owner, which is still correct).
+        Faction* playerFac = 0;
+        __try { playerFac = gw->player->getFaction(); } __except (EXCEPTION_EXECUTE_HANDLER) { playerFac = 0; }
         Ogre::Vector3 center = ld->getPosition();
         // A dropped item enumerates under multiple category queries (W0 finding), so
         // scan WEAPON/ARMOUR/ITEM and DEDUPE by hand (index+serial) to avoid triples.
@@ -1579,6 +1583,30 @@ unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int ma
                 for (unsigned int j = 0; j < n; ++j)
                     if (out[j].hand[3] == hd[3] && out[j].hand[4] == hd[4]) { dup = true; break; }
                 if (dup) continue;
+                // OWNERSHIP FILTER: an item owned by a non-player faction is world
+                // furniture (shop stock / town placements - the "red" stealing items),
+                // NOT a session drop, and the peer already holds it as a save-native.
+                // Streaming one makes the peer fabricate an owner=0 proxy on top of
+                // its own red native: a grey duplicate that is free to take, and whose
+                // pickup CLAIM then destroys the author's real item - the theft bypass
+                // (upstream #63/#66). Skipping it here keeps it out of the tracker
+                // entirely (baseline seeding included); real drops still stream via
+                // the query-free drop hook, which does not pass through this scan.
+                // "Unowned" is NOT a null faction: the engine parks ownerless ground
+                // items (player drops and minted proxies included) on a real sentinel
+                // Faction whose GameData stringID is 'nofac' (measured on 1.0.65 -
+                // getFaction never returned null in the diagnostic runs). Comparing
+                // pointers alone therefore reads EVERYTHING as owned and blinds the
+                // scan entirely, so the sentinel must pass the filter too.
+                Faction* fac = 0;
+                __try { fac = o->getFaction(); } __except (EXCEPTION_EXECUTE_HANDLER) { fac = 0; }
+                bool owned = (fac != 0) && (fac != playerFac);
+                if (owned) {
+                    char facSid[16] = "";
+                    facSidOf(fac, facSid, sizeof(facSid));
+                    if (strcmp(facSid, "nofac") == 0) owned = false;
+                }
+                if (owned) continue;
                 GameData* gd = 0;
                 __try { gd = o->getGameData(); } __except (EXCEPTION_EXECUTE_HANDLER) { gd = 0; }
                 if (!gd) continue;

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -1436,13 +1436,16 @@ private:
     // row or a query-free drop-hook edge) so the item can be streamed and refreshed
     // by HANDLE resolution alone - no rescan needed. `seen` is retained only for the
     // legacy scan path; culling is now handle-based (engine::groundItemLiveness).
-    // `baseline` (Phase 3 item-dup fix): a ground item present at the FIRST
-    // post-load spatial scan is a SHARED save-native - both clients already hold
-    // it identically, so it must never be streamed (authoring it mints a proxy
-    // on top of the peer's own native = the rejoin/reload duplication). Baseline
-    // tracks are recorded for identity/liveness but skipped in the emit path;
-    // only items appearing AFTER the baseline (session drops, runtime spawns)
-    // stream. Re-seeded after every reload via worldSeeded_ in resetSession().
+    // `baseline` (Phase 3 item-dup fix): a SHARED save-native - both clients
+    // already hold it identically, so it must never be streamed (authoring it
+    // mints a proxy on top of the peer's own native = the rejoin/reload
+    // duplication). Baseline tracks are recorded for identity/liveness but
+    // skipped in the emit path. A ground item is a save-native unless the drop
+    // hook authored it (or it resolves an unresolved drop edge of ours, see
+    // pendingDrops_): the spatial scan alone can never promote an item to the
+    // stream, because natives keep popping into the scan long after load (a
+    // zone/interior finishing its stream-in 20+ s later looked exactly like a
+    // fresh drop and duped on the peer).
     struct WorldTrack {
         u32 netId; u32 hash; unsigned long lastSendMs; float x, y, z; bool seen;
         char stringID[48]; u32 itemType; u16 quantity; u16 quality; bool baseline;
@@ -1467,12 +1470,19 @@ private:
     // so netId spaces are per-sender and culls are scoped to their owner.
     std::map<std::pair<u32, u32>, WorldProxy> worldProxies_;
     u32                        nextWorldNetId_;
-    // First-scan-baseline latch (Phase 3): false after launch/reload; the first
-    // publishWorldItems pass seeds every in-range save-native as a baseline track
-    // (never-emit) and sets this true. resetSession() clears it so the reloaded
-    // world (which may now contain previously-dropped-then-baked items) re-baselines
-    // rather than re-streaming - closing the per-reload duplicate layering.
+    // Load-census latch: false after launch/reload; the first publishWorldItems
+    // pass whose scan sees the world populated logs the native census and sets
+    // this true. Bookkeeping only (every scan-only item is baseline regardless,
+    // see WorldTrack::baseline); resetSession() clears it so each reload logs
+    // its own census.
     bool                       worldSeeded_;
+    // Own drops the hook captured but could not key (unresolved item hand,
+    // logged DROP-CAP-SKIP): the ONE case where a scan-only sighting is a fresh
+    // drop and must stream. A new scan row that matches one of these by
+    // template + position (within PENDING_DROP_MS) is promoted to a streaming
+    // track; anything else the scan finds unannounced is a save-native.
+    struct PendingDrop { char stringID[48]; float x, y, z; unsigned long ms; };
+    std::vector<PendingDrop>   pendingDrops_;
 
     // Phase W2 conservation-drop state.
     // weaponCensus_: per OWNED character hand, the last-tick set of WEAPON copies it held,

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -255,7 +255,8 @@ void Replicator::resetSession() {
     censusContainers_.clear(); // protocol 34: re-censused in the new world
     worldTrack_.clear();
     worldProxies_.clear();
-    worldSeeded_ = false; // re-baseline the reloaded world's save-native items
+    worldSeeded_ = false; // re-census the reloaded world's save-native items
+    pendingDrops_.clear(); // unresolved drop edges belong to the old world
     weaponCensus_.clear();
     appliedDrops_.clear();
     appliedPickups_.clear();

--- a/src/plugin/sync/ReplicatorItems.cpp
+++ b/src/plugin/sync/ReplicatorItems.cpp
@@ -357,8 +357,10 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
     //   (1) the query-free drop hook (engine::drainItemDrops) - a drop captured at
     //       Inventory::dropItem, so a TOWN drop is found even when the spatial query
     //       misses it (the core town-reliability fix); and
-    //   (2) the spatial scan (captureWorldItems) - best-effort, for pre-existing save
-    //       items / host runtime drops the drop hook didn't author.
+    //   (2) the spatial scan (captureWorldItems) - the census: pre-existing save
+    //       items become never-emit baseline tracks (identity + liveness), and a
+    //       drop the hook captured but could not key is resolved here by template
+    //       + position (pendingDrops_). The scan never streams anything on its own.
     // Both key a track by the item's LOCAL engine hand, so a drop found by BOTH sources
     // converges on ONE track (one netId) - no duplicate proxy. CULLING is now HANDLE-
     // based (engine::groundItemLiveness): a track is removed only when its real item is
@@ -384,43 +386,32 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
         if (live) proxyObjs.insert(live);
     }
 
-    // ---- First-scan baseline (Phase 3 item-dup fix) ------------------------
-    // Every non-gear ground item present at the FIRST publish pass after a load
-    // is a SHARED save-native: the peer loaded the same save (or the host's
-    // connect-pushed save) and already holds an identical copy. Streaming it
-    // would mint a proxy on top of the peer's own native - the "rejoin/reload
-    // duplicated all items" report, compounding one layer per reload. Seed them
-    // as baseline tracks (identity + liveness only, NEVER emitted). Only items
-    // that appear AFTER this baseline (session drops via the hook, host runtime
-    // spawns) stream. resetSession() clears worldSeeded_ so each reload re-
-    // baselines the (possibly newly-baked) save-natives instead of re-streaming.
-    if (!worldSeeded_) {
-        worldSeeded_ = true;
-        engine::WorldItemRaw raw[WORLD_ITEMS_MAX];
-        unsigned int n = engine::captureWorldItems(gw, raw, WORLD_ITEMS_MAX, RADIUS);
-        unsigned int seeded = 0;
-        for (unsigned int i = 0; i < n; ++i) {
-            if (isGearType(raw[i].itemType)) continue;
-            if (!proxyObjs.empty() &&
-                proxyObjs.count(engine::resolveObjectByHand(raw[i].hand)) != 0)
-                continue; // already our proxy (defensive; unlikely at first scan)
-            Key k; k.t = raw[i].hand[0]; k.c = raw[i].hand[1]; k.cs = raw[i].hand[2];
-            k.i = raw[i].hand[3]; k.s = raw[i].hand[4];
-            if (worldTrack_.find(k) != worldTrack_.end()) continue;
-            WorldTrack t; memset(&t, 0, sizeof(t));
-            t.netId = nextWorldNetId_++; t.hash = 0; t.lastSendMs = 0;
-            t.x = raw[i].x; t.y = raw[i].y; t.z = raw[i].z; t.seen = true;
-            t.baseline = true; // never emit
-            strncpy(t.stringID, raw[i].stringID, sizeof(t.stringID) - 1);
-            t.stringID[sizeof(t.stringID) - 1] = '\0';
-            t.itemType = raw[i].itemType; t.quantity = raw[i].quantity; t.quality = raw[i].quality;
-            worldTrack_[k] = t;
-            ++seeded;
-        }
-        char b[96]; _snprintf(b, sizeof(b) - 1,
-            "[wi] BASELINE seeded=%u (save-native, never-stream)", seeded);
-        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
-    }
+    // ---- Save-native baseline (Phase 3 item-dup fix) ------------------------
+    // Every non-gear ground item the world holds that the DROP HOOK did not
+    // author is a SHARED save-native: the peer loaded the same save (or the
+    // host's connect-pushed save) and already holds an identical copy. Streaming
+    // it would mint a proxy on top of the peer's own native - the "rejoin/reload
+    // duplicated all items" report, compounding one layer per reload. Such items
+    // become baseline tracks (identity + liveness only, NEVER emitted).
+    //
+    // This used to be a one-shot FIRST-SCAN seed, and that raced the world:
+    // measured on 1.0.65, the first publish pass after a load routinely ran
+    // before the zone's items existed (scan n=0), so a baseline latched on it was
+    // empty and the natives that popped in 130-200 ms later streamed as fresh
+    // drops (14 grey duplicates on the peer). Widening the seed to a settle
+    // window was not enough either: an interior finishing its stream-in 20+ s
+    // after connect popped in another batch of natives on BOTH clients at the
+    // same instant, and each streamed them to the other. So the rule is now
+    // structural, not temporal: the spatial scan alone never promotes an item
+    // to the stream. The one exception is an own drop the hook captured but
+    // could not key (DROP-CAP-SKIP, below): it is remembered in pendingDrops_
+    // and the first scan row matching its template + position is the drop.
+    // (Discovery 1's hook detours Inventory::dropItem engine-wide, so every real
+    // drop - ours, an NPC's - is authored there; only save data and the peer's
+    // proxies, which the echo guard already filters, put items on the ground
+    // without it.)
+    const unsigned long PENDING_DROP_MS   = 5000;
+    const float         PENDING_DROP_DIST = 2.5f;
 
     // Gear (itemType WEAPON/ARMOUR) rides the W2 conservation drop/pickup channel
     // (the real shared-save object is relocated bag<->ground on each client), so the
@@ -432,23 +423,30 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
         unsigned int nde = engine::drainItemDrops(de, 64);
         for (unsigned int i = 0; i < nde; ++i) {
             if (isGearType(de[i].itemType)) continue;
+            // A drop from a PEER-owned squad copy is the peer's to author (it streams
+            // its own drop); authoring it here too would duplicate the proxy. World
+            // NPC (class 0) and our own squad (class 1) drops still stream.
+            if (ownerClassForHand(de[i].ownerHand) == 2) continue;
             if (de[i].itemHand[3] == 0 && de[i].itemHand[4] == 0) {
-                // Unresolved hand: this drop cannot be keyed, so the reliable discovery path
-                // gives up on it and only the (town-unreliable) spatial scan can still find
-                // it. That is the one way a non-gear drop silently never reaches the peer, so
-                // say so unconditionally - it is rare, and guessing at it from a silent log is
-                // what made "dropped here, absent there" impossible to pin down.
+                // Unresolved hand: this drop cannot be keyed here, so only the (town-
+                // unreliable) spatial scan can still find it. Remember its template +
+                // position: the scan row that matches is THIS drop and streams; every
+                // other scan-only row is a save-native. Say so unconditionally - it is
+                // rare, and guessing at it from a silent log is what made "dropped
+                // here, absent there" impossible to pin down.
                 char b[200]; _snprintf(b, sizeof(b) - 1,
                     "[wi] DROP-CAP-SKIP sid='%s' qty=%u pos=%.2f,%.2f,%.2f (unresolved item "
                     "hand; spatial scan is the only remaining chance)",
                     de[i].stringID, de[i].quantity, de[i].x, de[i].y, de[i].z);
                 b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+                if (pendingDrops_.size() < 32) {
+                    PendingDrop pd; memset(&pd, 0, sizeof(pd));
+                    strncpy(pd.stringID, de[i].stringID, sizeof(pd.stringID) - 1);
+                    pd.x = de[i].x; pd.y = de[i].y; pd.z = de[i].z; pd.ms = now;
+                    pendingDrops_.push_back(pd);
+                }
                 continue;
             }
-            // A drop from a PEER-owned squad copy is the peer's to author (it streams
-            // its own drop); authoring it here too would duplicate the proxy. World
-            // NPC (class 0) and our own squad (class 1) drops still stream.
-            if (ownerClassForHand(de[i].ownerHand) == 2) continue;
             Key k; k.t = de[i].itemHand[0]; k.c = de[i].itemHand[1]; k.cs = de[i].itemHand[2];
             k.i = de[i].itemHand[3]; k.s = de[i].itemHand[4];
             if (worldTrack_.find(k) != worldTrack_.end()) continue; // already tracked
@@ -466,10 +464,21 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
         }
     }
 
-    // ---- Discovery 2: the spatial scan (best-effort) -----------------------
+    // ---- Discovery 2: the spatial scan (census + liveness identity) --------
+    // Every in-range ground item gets a track (identity + liveness), but a row
+    // the scan finds UNANNOUNCED is a save-native and is recorded as baseline
+    // (never emit). Only a row that resolves a pending unresolved own drop is
+    // promoted to a streaming track.
     {
+        // Age out pending unresolved drops the scan never found.
+        for (size_t p = 0; p < pendingDrops_.size(); ) {
+            if (now - pendingDrops_[p].ms > PENDING_DROP_MS)
+                pendingDrops_.erase(pendingDrops_.begin() + p);
+            else ++p;
+        }
         engine::WorldItemRaw raw[WORLD_ITEMS_MAX];
         unsigned int n = engine::captureWorldItems(gw, raw, WORLD_ITEMS_MAX, RADIUS);
+        unsigned int natives = 0;
         for (unsigned int i = 0; i < n; ++i) {
             if (isGearType(raw[i].itemType)) continue;
             if (!proxyObjs.empty() &&
@@ -485,7 +494,24 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
                 strncpy(t.stringID, raw[i].stringID, sizeof(t.stringID) - 1);
                 t.stringID[sizeof(t.stringID) - 1] = '\0';
                 t.itemType = raw[i].itemType; t.quantity = raw[i].quantity; t.quality = raw[i].quality;
+                // Attribute: an own drop the hook could not key, now found by the scan?
+                bool isDrop = false;
+                for (size_t p = 0; p < pendingDrops_.size(); ++p) {
+                    const PendingDrop& pd = pendingDrops_[p];
+                    float dx = raw[i].x - pd.x, dy = raw[i].y - pd.y, dz = raw[i].z - pd.z;
+                    if (strcmp(pd.stringID, raw[i].stringID) == 0 &&
+                        dx*dx + dy*dy + dz*dz <= PENDING_DROP_DIST * PENDING_DROP_DIST) {
+                        pendingDrops_.erase(pendingDrops_.begin() + p);
+                        isDrop = true; break;
+                    }
+                }
+                t.baseline = !isDrop; // unannounced = save-native, never emit
+                if (t.baseline) ++natives;
                 worldTrack_[k] = t;
+                if (dumpWi) { char b[200]; _snprintf(b, sizeof(b) - 1,
+                    "[wi] SCAN-%s netId=%u sid='%s' qty=%u pos=%.2f,%.2f,%.2f",
+                    isDrop ? "DROP" : "NATIVE", t.netId, t.stringID, t.quantity, t.x, t.y, t.z);
+                    b[sizeof(b) - 1] = '\0'; coop::logLine(b); }
             } else {
                 // Refresh the description (a re-stack can change qty/quality).
                 WorldTrack& tr = tit->second;
@@ -493,6 +519,15 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
                 tr.stringID[sizeof(tr.stringID) - 1] = '\0';
                 tr.itemType = raw[i].itemType; tr.quantity = raw[i].quantity; tr.quality = raw[i].quality;
             }
+        }
+        // Load census: log the first populated scan after a load/reload once (the
+        // natives keep arriving after this - each is baselined as it appears).
+        if (!worldSeeded_ && n > 0) {
+            worldSeeded_ = true;
+            char b[112]; _snprintf(b, sizeof(b) - 1,
+                "[wi] BASELINE seeded=%u (save-native, never-stream; first populated scan n=%u)",
+                natives, n);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
         }
     }
 


### PR DESCRIPTION
Fixes #63, fixes #66 (the "red items go grey / duplicate / free to steal" reports).

Two commits, two distinct ways save-native ground items were getting streamed to the peer as grey duplicates. Both were found by instrumenting a two-client session in a bar-town save and reading the `[wi]` log; each is described with the measurement that pinned it.

## Commit 1 — faction-owned items were streamed (theft bypass)

`captureWorldItems` (the W1 ground-item spatial scan) enumerated **every** free ground item within 60m of the leader with no ownership read at all. Any faction-owned town/shop item the scan encountered was treated as a fresh session drop and streamed.

The peer's `spawnWorldItemProxy` then fabricated a proxy with `owner=0` — an unowned, **grey**, freely-takeable duplicate stacked on top of the peer's own red native. The stream is bidirectional, so both clients minted grey copies of each other's town items. Worse, picking up the grey proxy fired the CLAIM channel (protocol 47), telling the author to destroy its **real** red item — an engine destroy, no crime. The theft system was fully bypassed.

**Fix (2 files):** `captureWorldItems` reads each scanned item's owner faction (SEH-guarded `getFaction()`) and **skips any item owned by a non-player faction**. Owned items are world furniture both clients already hold from the shared save; they are never a session drop.

**One measured subtlety (1.0.65):** "unowned" is *not* a null faction — the engine parks ownerless ground items (player drops and minted proxies included) on a real sentinel `Faction` whose GameData stringID is `nofac`; `getFaction` never returned null in instrumented runs. A pointer-only comparison therefore reads *everything* as owned and blinds the scan entirely (caught by the `world_pickup_mirror` smoke scenario, which stopped finding the proxy it was supposed to pick up). The filter explicitly treats the `nofac` sentinel as unowned.

## Commit 2 — the first-scan baseline raced the world (late-load duplicates)

With owned items out of the stream, a second duplicate source became visible. The stream's only defence against re-streaming *unowned* save-natives (loose loot lying in the save) was a **one-shot first-scan baseline**: whatever the first publish pass after a load found was "native, never emit"; anything the scan found later was a fresh drop. Measured on 1.0.65 that races the engine twice over:

- the first publish pass after a load routinely runs **before the zone's items exist** — the log shows `BASELINE seeded=0`, then 14 `SEND` rows 130–200 ms later on *both* clients, and 14 grey `SPAWN`s on the peer;
- even after widening the seed into a settle window, an interior finishing its stream-in **20+ s after connect** popped a further batch of natives into the scan on both clients at the same instant, and each streamed them to the other (a different subset each time).

**Fix (structural, not temporal):** the spatial scan alone never promotes an item to the stream. Discovery 1's hook detours `Inventory::dropItem` engine-wide, so every real drop — ours or an NPC's — is authored there; only save data and the peer's proxies (already echo-guarded) put items on the ground without it. A scan-only row is recorded as a baseline track (identity + liveness, never emit). The one legitimate scan-only drop — an own drop the hook captured but could not key (`DROP-CAP-SKIP`) — is remembered by template + position for 5 s and the first matching scan row is promoted to a streaming track. `BASELINE seeded=` survives as the load census line; `SCAN-NATIVE`/`SCAN-DROP` rows are logged under `KENSHICOOP_INV_DUMP`.

Not touched: wire protocol (stays 55-compatible), gear/conservation channels, drop hook, claim channel.

## Testing

- Full toolchain build (v100/Harness), clean compile; prototest green.
- Smoke regression tier (15 scenarios incl. `world_item_burst`, `world_item_stale`, `world_pickup_mirror`, the drop/pickup/regear family): functionally green.
- Manual two-client sessions (UDP loopback, bar-town save):
  - Red items stay red in **both** windows (alt-held); picking up a red item flags stealing correctly.
  - No grey duplicates at connect, after 30+ s, or after walking through the late-loading interior — the log shows every unannounced scan row classified `SCAN-NATIVE` and **zero** `SEND`/`SPAWN` rows on either side, where the previous build showed 14+ per client.
  - Player drops still sync in both directions **inside a town** (the over-filtering risk case), and picking a streamed drop back up removes it on the peer (`[wi] CLAIM-APPLY ... destroyed=1`).

## Known related issue, deliberately out of scope

With natives correctly out of the stream, a native **picked up** on one client (stolen or free) disappears only locally — the peer's identical copy stays on its ground (that's #44's territory, a different mechanism: natives have no netId/proxy, so pickup needs its own hand-keyed notice). A follow-up PR stacked on this one adds that notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
