### PR TITLE
A save-native picked up on one client vanishes on the other (native pickup notice, protocol 56)

### DIFF
--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -25,7 +25,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 55;
+const u16 PROTOCOL_VERSION = 56;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -76,7 +76,8 @@ enum PacketType {
     PKT_INV_XFER_ACK     = 45,// RELIABLE transfer verdict (protocol 50); InvXferAckPacket
     PKT_MONEY_DELTA      = 46,// RELIABLE join money-pool delta (join -> host, protocol 52); MoneyDeltaPacket
     PKT_DEED             = 47,// RELIABLE property-ownership row (protocol 54); DeedPacket
-    PKT_FIXTURE          = 48 // RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    PKT_FIXTURE          = 48,// RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    PKT_NATIVE_TAKEN     = 49 // RELIABLE save-native ground item consumed (protocol 56); WorldNativeTakenPacket
 };
 
 // One-shot transition events carried on the RELIABLE channel. Continuous state
@@ -621,6 +622,38 @@ struct WorldItemClaimHeader {
 
 // 16 * sizeof(WorldItemEntry)=1168 + header(6) stays under a 1400 B datagram.
 const unsigned int WORLD_ITEMS_MAX = 16;
+
+// ---- Protocol 56: save-native ground pickup notice --------------------------
+// The W1 CLAIM above mirrors pickups of STREAMED items (tracked, netId-keyed), but a
+// save-native world item - shop stock / town placements, exactly the owned items the
+// protocol-55 ownership filter keeps OUT of the stream - has no netId and no proxy.
+// When a character picked one up (stealing it), nothing told the peer, whose own
+// save-native copy stayed on the ground: the "host stole it but the join still sees
+// it" ghost (upstream #44). Both clients loaded the IDENTICAL save, so the item's
+// 5-field engine hand resolves on both machines; this notice names the consumed
+// native by hand and the receiver destroys its own still-on-ground copy. The receiver
+// only acts on an object that still reads as a LIVE GROUND item - a copy already in a
+// local bag, or already gone, is left alone - so a stale or echoed notice is a no-op.
+// takeId is monotonic per sender (idempotency under reliable resend).
+struct WorldNativeTakenPacket {
+    u8  type;    // = PKT_NATIVE_TAKEN
+    u32 ownerId; // network player id of the sender (whose side consumed the native)
+    u32 takeId;  // monotonic per-sender (idempotency)
+    // the consumed native's engine hand ON THE SENDER. Measured on 1.0.65: an item's
+    // (index, serial) is assigned per session, so this does NOT resolve on the
+    // other client even for the identical save; it is carried for the same-client
+    // fast path and for the log only.
+    u32 iType;
+    u32 iContainer;
+    u32 iContainerSerial;
+    u32 iIndex;
+    u32 iSerial;
+    // The shared identity: template + world position (the save data both clients
+    // loaded, which neither moved). The receiver destroys the LIVE ground item of
+    // this template nearest to this position, within a few units, or nothing.
+    char stringID[48];
+    f32 x, y, z;
+};
 
 // ---- Phase W2: conservation DROP intent ------------------------------------
 // A WEAPON cannot be rebuilt on a peer (RootObjectFactory::createItem returns null for all

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -1306,6 +1306,10 @@ void tickReplicateApply(GameWorld* gw, bool worldLive) {
             // Phase W3: re-home tracked ground copies into the picking character's bag, also
             // before the inventory reconcile (which can't refabricate a weapon into the proxy).
             g_repl.applyWeaponPickups(gw, g_inbound);
+            // Protocol 56: destroy our copy of any save-native ground item a peer just
+            // consumed (stole) - the pickup mirror the ownership filter (protocol 55)
+            // deliberately keeps out of the proxy stream.
+            g_repl.applyNativeTakes(gw, g_inbound);
         }
         // Protocol 37: relocate our copy of any cross-owner TRADED item between the
         // two containers BEFORE the inventory reconcile, so the conservation move

--- a/src/plugin/core/Inbound.h
+++ b/src/plugin/core/Inbound.h
@@ -97,6 +97,14 @@ struct InboundWorldPickup {
     WorldPickupPacket pkt;
 };
 
+// One received save-native pickup notice (protocol 56): a peer consumed a save-native
+// ground item (shop stock / town placement - never streamed, no netId). The receiver
+// destroys its OWN still-on-ground copy, located by template + position.
+struct InboundNativeTaken {
+    u32                   ownerId;
+    WorldNativeTakenPacket pkt;
+};
+
 // One received cross-owner TRANSFER intent (protocol 37): a peer performed a
 // direct UI drag between two containers, at least one of which it does not
 // author. The receiver relocates the REAL item between its own copies of the
@@ -423,7 +431,7 @@ public:
         wi_(worldReset_),         wir_(worldReset_),        wic_(worldReset_),
         npcCensus_(worldReset_),
         wd_(worldReset_),         invXfer_(worldReset_),    invXferAck_(worldReset_),
-        wp_(worldReset_),
+        wp_(worldReset_),         nativeTaken_(worldReset_),
         med_(worldReset_),        treat_(worldReset_),      combatHit_(worldReset_),
         speed_(worldReset_),
         stats_(worldReset_),      money_(worldReset_),      moneyDelta_(worldReset_),
@@ -524,6 +532,11 @@ public:
     void pushWorldPickup(u32 ownerId, const WorldPickupPacket& pkt) {
         InboundWorldPickup wp; wp.ownerId = ownerId; wp.pkt = pkt;
         EnterCriticalSection(&cs_); wp_.push_back(wp); LeaveCriticalSection(&cs_);
+    }
+    // NET thread: one received save-native pickup notice (protocol 56), owner-tagged.
+    void pushNativeTaken(u32 ownerId, const WorldNativeTakenPacket& pkt) {
+        InboundNativeTaken nt; nt.ownerId = ownerId; nt.pkt = pkt;
+        EnterCriticalSection(&cs_); nativeTaken_.push_back(nt); LeaveCriticalSection(&cs_);
     }
     // NET thread: one received cross-owner transfer intent (protocol 37), owner-tagged.
     void pushInvXfer(u32 ownerId, const InvXferPacket& pkt) {
@@ -727,6 +740,9 @@ public:
     void drainWorldPickups(std::deque<InboundWorldPickup>& out) {
         EnterCriticalSection(&cs_); out.swap(wp_); LeaveCriticalSection(&cs_);
     }
+    void drainNativeTaken(std::deque<InboundNativeTaken>& out) {
+        EnterCriticalSection(&cs_); out.swap(nativeTaken_); LeaveCriticalSection(&cs_);
+    }
     void drainInvXfers(std::deque<InboundInvXfer>& out) {
         EnterCriticalSection(&cs_); out.swap(invXfer_); LeaveCriticalSection(&cs_);
     }
@@ -876,6 +892,7 @@ private:
     WorldQ<InboundInvXfer>         invXfer_;
     WorldQ<InboundInvXferAck>      invXferAck_;
     WorldQ<InboundWorldPickup>     wp_;
+    WorldQ<InboundNativeTaken>     nativeTaken_;
     WorldQ<InboundMedical>         med_;
     WorldQ<InboundTreatment>       treat_;
     WorldQ<InboundCombatHit>       combatHit_;

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -798,8 +798,36 @@ struct WorldItemRaw {
 // stealing items placed in towns/shops) are excluded: they are save-natives both
 // clients already hold, and streaming one mints an unowned grey duplicate on the peer
 // (the theft-bypass dup, upstream #63/#66). Returns the number written.
+// A save-native owned item the scan SAW but excluded (protocol 56): just enough
+// identity for the native-pickup watch - the local hand (per-session; a fast path
+// on the same client only), the stringID and the world position (which together are
+// the notice's cross-client identity).
+struct WorldNativeRaw {
+    unsigned int hand[5];
+    char         stringID[48];
+    float        x, y, z;
+};
+
+// natOut/natMax/natCount (optional): receive the owned items the filter skipped, deduped
+// by (index, serial) like the main rows, so the caller can watch natives for local
+// pickups (protocol 56) without a second scan.
 unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int maxOut,
-                               float radius);
+                               float radius, WorldNativeRaw* natOut = 0,
+                               unsigned int natMax = 0, unsigned int* natCount = 0);
+
+// SEH-guarded (protocol 56): destroy OUR copy of a save-native ground item a peer
+// reported consumed. Identity is template + position (expectSid within posTol of
+// expectPos - an item's engine hand is per-session and does NOT resolve on the
+// other client; itemHand is only a same-client fast path and may be all-zero).
+// Destroys ONLY a LIVE GROUND item of that template nearest to expectPos within
+// posTol; already-bagged, already-gone or absent copies are left alone, so a
+// stale or echoed notice cannot delete anything a local actor holds. Returns 1 if
+// destroyed (outHand, optional, receives the destroyed object's LOCAL hand), 0 if
+// skipped (*whySkipped set to a static reason string when given).
+int destroyNativeGroundItem(GameWorld* gw, const unsigned int itemHand[5],
+                            const char* expectSid, const float expectPos[3],
+                            float posTol, unsigned int outHand[5],
+                            const char** whySkipped = 0);
 
 // ---- Phase W1b: query-free ground-drop capture (town reliability) ----------
 // The W1 stream above discovers ground items with getObjectsWithinSphere, which

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -794,7 +794,10 @@ struct WorldItemRaw {
 // SEH-guarded (host): enumerate free GROUND items within `radius` of the local leader
 // (interest scope) into out[] (up to maxOut), deduped by hand. Items inside inventories
 // are NOT enumerated by the engine's sphere query (confirmed by the W0 drop_probe), so
-// every result is a real world item. Returns the number written.
+// every result is a real world item. Items OWNED by a non-player faction (the "red"
+// stealing items placed in towns/shops) are excluded: they are save-natives both
+// clients already hold, and streaming one mints an unowned grey duplicate on the peer
+// (the theft-bypass dup, upstream #63/#66). Returns the number written.
 unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int maxOut,
                                float radius);
 

--- a/src/plugin/game/EngineInventory.cpp
+++ b/src/plugin/game/EngineInventory.cpp
@@ -1555,9 +1555,12 @@ unsigned int worldItemHash(const char* sid, unsigned int type, unsigned short qt
 } // namespace
 
 unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int maxOut,
-                               float radius) {
+                               float radius, WorldNativeRaw* natOut,
+                               unsigned int natMax, unsigned int* natCount) {
+    if (natCount) *natCount = 0;
     if (!gw || !gw->player || !out || maxOut == 0 || !g_getObjsFn) return 0;
     unsigned int n = 0;
+    unsigned int nn = 0; // natives written to natOut
     __try {
         if (gw->player->playerCharacters.size() == 0) return 0;
         Character* ld = gw->player->playerCharacters[0];
@@ -1606,7 +1609,32 @@ unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int ma
                     facSidOf(fac, facSid, sizeof(facSid));
                     if (strcmp(facSid, "nofac") == 0) owned = false;
                 }
-                if (owned) continue;
+                if (owned) {
+                    // Protocol 56: report the skipped native (deduped like the main
+                    // rows) so the caller can watch it for a local pickup.
+                    if (natOut && nn < natMax) {
+                        bool ndup = false;
+                        for (unsigned int j = 0; j < nn; ++j)
+                            if (natOut[j].hand[3] == hd[3] && natOut[j].hand[4] == hd[4]) { ndup = true; break; }
+                        if (!ndup) {
+                            GameData* ngd = 0;
+                            __try { ngd = o->getGameData(); } __except (EXCEPTION_EXECUTE_HANDLER) { ngd = 0; }
+                            Ogre::Vector3 np(0,0,0);
+                            __try { np = o->getPosition(); } __except (EXCEPTION_EXECUTE_HANDLER) {}
+                            WorldNativeRaw& nw = natOut[nn];
+                            for (int t = 0; t < 5; ++t) nw.hand[t] = hd[t];
+                            nw.stringID[0] = '\0';
+                            if (ngd) {
+                                strncpy(nw.stringID, ngd->stringID.c_str(), sizeof(nw.stringID) - 1);
+                                nw.stringID[sizeof(nw.stringID) - 1] = '\0';
+                            }
+                            nw.x = np.x; nw.y = np.y; nw.z = np.z;
+                            ++nn;
+                            if (natCount) *natCount = nn;
+                        }
+                    }
+                    continue;
+                }
                 GameData* gd = 0;
                 __try { gd = o->getGameData(); } __except (EXCEPTION_EXECUTE_HANDLER) { gd = 0; }
                 if (!gd) continue;
@@ -1929,6 +1957,98 @@ int groundItemLiveness(const unsigned int itemHand[5], float out[3]) {
     RootObject* ro = resolveObjectByHand(itemHand);
     if (!ro) return 0; // destroyed / no longer resolvable
     return groundObjectLiveness(ro, out, 0);
+}
+
+// Protocol 56: destroy OUR copy of a save-native ground item a peer consumed.
+//
+// IDENTITY. An item's engine hand is NOT save-stable across clients: measured on
+// 1.0.65, the same native carried index/serial 8955/2494995200 on the sender and
+// did not resolve at all on the receiver (both had loaded the identical save) -
+// the (index, serial) half is assigned per session. What IS shared is the save
+// data itself: template (GameData stringID) + world position, identical on both
+// clients because neither moved it. So the notice is matched by sid + position:
+// the sender's hand is tried first only as a fast path for the same-client case
+// (echo/replay), then the receiver queries the sphere around the sender's
+// position and takes the LIVE ground item of that template nearest to it, within
+// posTol. Two identical templates lying within posTol of each other are
+// interchangeable copies on both machines, so "the nearest" removes the same
+// logical thing the sender did.
+//
+// GUARDS. Only an object that reads as a LIVE GROUND item is destroyed. A copy
+// already inside a local bag (someone here picked it up too) or already gone is
+// left alone, and nothing matching within posTol is a logged no-op - so echoed,
+// replayed or stale notices cannot delete anything a local actor holds.
+// outHand (optional) receives the destroyed object's LOCAL hand so the caller can
+// retire its own track for it.
+int destroyNativeGroundItem(GameWorld* gw, const unsigned int itemHand[5],
+                            const char* expectSid, const float expectPos[3],
+                            float posTol, unsigned int outHand[5],
+                            const char** whySkipped) {
+    if (whySkipped) *whySkipped = "";
+    if (outHand) for (int t = 0; t < 5; ++t) outHand[t] = 0;
+    if (!gw || !expectSid || !expectSid[0] || !expectPos || posTol <= 0.0f) {
+        if (whySkipped) *whySkipped = "bad-args"; return 0;
+    }
+    RootObject* best = 0;
+    float bestD2 = posTol * posTol;
+    bool sawBagged = false;
+    // Fast path: the sender's hand names the same object here (same-client echo,
+    // or an engine build where hands do turn out shared). Must still pass every
+    // check the spatial match passes.
+    if (itemHand && (itemHand[3] != 0 || itemHand[4] != 0)) {
+        RootObject* ro = resolveObjectByHand(itemHand);
+        if (ro) {
+            bool sidOk = false;
+            __try {
+                GameData* gd = ro->getGameData();
+                sidOk = (gd && strcmp(gd->stringID.c_str(), expectSid) == 0);
+            } __except (EXCEPTION_EXECUTE_HANDLER) { sidOk = false; }
+            if (sidOk) {
+                bool pu = false; float here[3] = { 0.0f, 0.0f, 0.0f };
+                if (groundObjectLiveness(ro, here, &pu)) {
+                    float dx = here[0] - expectPos[0], dy = here[1] - expectPos[1], dz = here[2] - expectPos[2];
+                    float d2 = dx*dx + dy*dy + dz*dz;
+                    if (d2 <= bestD2) { best = ro; bestD2 = d2; }
+                } else if (pu) sawBagged = true;
+            }
+        }
+    }
+    // Spatial match: the shared identity.
+    if (!best && g_getObjsFn) {
+        __try {
+            Ogre::Vector3 center(expectPos[0], expectPos[1], expectPos[2]);
+            const itemType kinds[] = { ITEM, WEAPON, ARMOUR };
+            for (int k = 0; k < 3; ++k) {
+                g_npcQuery.clear();
+                g_getObjsFn(gw, &g_npcQuery, &center, posTol * 2.0f, kinds[k], 256, 0);
+                unsigned int total = g_npcQuery.size();
+                for (unsigned int i = 0; i < total; ++i) {
+                    RootObject* o = g_npcQuery[i]; if (!o) continue;
+                    bool sidOk = false;
+                    __try {
+                        GameData* gd = o->getGameData();
+                        sidOk = (gd && strcmp(gd->stringID.c_str(), expectSid) == 0);
+                    } __except (EXCEPTION_EXECUTE_HANDLER) { sidOk = false; }
+                    if (!sidOk) continue;
+                    bool pu = false; float here[3] = { 0.0f, 0.0f, 0.0f };
+                    if (!groundObjectLiveness(o, here, &pu)) { if (pu) sawBagged = true; continue; }
+                    float dx = here[0] - expectPos[0], dy = here[1] - expectPos[1], dz = here[2] - expectPos[2];
+                    float d2 = dx*dx + dy*dy + dz*dz;
+                    if (d2 <= bestD2) { best = o; bestD2 = d2; }
+                }
+            }
+        } __except (EXCEPTION_EXECUTE_HANDLER) { best = 0; }
+    }
+    if (!best) {
+        if (whySkipped) *whySkipped = sawBagged ? "in-local-bag" : "not-found";
+        return 0;
+    }
+    if (outHand) { unsigned int hd[5] = {0,0,0,0,0}; if (readObjectHand(best, hd)) for (int t = 0; t < 5; ++t) outHand[t] = hd[t]; }
+    if (!removeWorldItemProxy(gw, best)) {
+        if (whySkipped) *whySkipped = "destroy-failed";
+        return 0;
+    }
+    return 1;
 }
 
 // SEH-guarded (Phase W3): world position of a tracked Item* (as void*). The drop detector

--- a/src/plugin/game/EngineInventory.cpp
+++ b/src/plugin/game/EngineInventory.cpp
@@ -1562,6 +1562,10 @@ unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int ma
         if (gw->player->playerCharacters.size() == 0) return 0;
         Character* ld = gw->player->playerCharacters[0];
         if (!ld) return 0;
+        // Player faction for the ownership filter below (0 tolerated: the filter
+        // then only skips items with SOME owner, which is still correct).
+        Faction* playerFac = 0;
+        __try { playerFac = gw->player->getFaction(); } __except (EXCEPTION_EXECUTE_HANDLER) { playerFac = 0; }
         Ogre::Vector3 center = ld->getPosition();
         // A dropped item enumerates under multiple category queries (W0 finding), so
         // scan WEAPON/ARMOUR/ITEM and DEDUPE by hand (index+serial) to avoid triples.
@@ -1579,6 +1583,30 @@ unsigned int captureWorldItems(GameWorld* gw, WorldItemRaw* out, unsigned int ma
                 for (unsigned int j = 0; j < n; ++j)
                     if (out[j].hand[3] == hd[3] && out[j].hand[4] == hd[4]) { dup = true; break; }
                 if (dup) continue;
+                // OWNERSHIP FILTER: an item owned by a non-player faction is world
+                // furniture (shop stock / town placements - the "red" stealing items),
+                // NOT a session drop, and the peer already holds it as a save-native.
+                // Streaming one makes the peer fabricate an owner=0 proxy on top of
+                // its own red native: a grey duplicate that is free to take, and whose
+                // pickup CLAIM then destroys the author's real item - the theft bypass
+                // (upstream #63/#66). Skipping it here keeps it out of the tracker
+                // entirely (baseline seeding included); real drops still stream via
+                // the query-free drop hook, which does not pass through this scan.
+                // "Unowned" is NOT a null faction: the engine parks ownerless ground
+                // items (player drops and minted proxies included) on a real sentinel
+                // Faction whose GameData stringID is 'nofac' (measured on 1.0.65 -
+                // getFaction never returned null in the diagnostic runs). Comparing
+                // pointers alone therefore reads EVERYTHING as owned and blinds the
+                // scan entirely, so the sentinel must pass the filter too.
+                Faction* fac = 0;
+                __try { fac = o->getFaction(); } __except (EXCEPTION_EXECUTE_HANDLER) { fac = 0; }
+                bool owned = (fac != 0) && (fac != playerFac);
+                if (owned) {
+                    char facSid[16] = "";
+                    facSidOf(fac, facSid, sizeof(facSid));
+                    if (strcmp(facSid, "nofac") == 0) owned = false;
+                }
+                if (owned) continue;
                 GameData* gd = 0;
                 __try { gd = o->getGameData(); } __except (EXCEPTION_EXECUTE_HANDLER) { gd = 0; }
                 if (!gd) continue;

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -245,6 +245,7 @@ void NetLink::queueSpawnReq(const SpawnReqPacket& pkt) { pushLocked(outCs_, outS
 void NetLink::queueSpawnInfo(const SpawnInfoPacket& pkt) { pushLocked(outCs_, outSpawnInfo_, pkt); }
 
 void NetLink::queueWorldPickup(const WorldPickupPacket& pkt) { pushLocked(outCs_, outWorldPickups_, pkt); }
+void NetLink::queueNativeTaken(const WorldNativeTakenPacket& pkt) { pushLocked(outCs_, outNativeTaken_, pkt); }
 
 void NetLink::queueInvXfer(const InvXferPacket& pkt) { pushLocked(outCs_, outInvXfers_, pkt); }
 
@@ -622,6 +623,17 @@ void NetLink::threadLoop() {
                                 inbound_->pushWorldClaim(hdr.ownerId, hdr.authorId,
                                                          netIds, hdr.count);
                             }
+                        }
+                    } else if (type == PKT_NATIVE_TAKEN) {
+                        // A peer consumed a save-native ground item (protocol
+                        // 56) - never streamed, no netId - so WE destroy our
+                        // own still-on-ground copy, located by template +
+                        // position (the shared save data).
+                        if (ev.packet->dataLength >= sizeof(WorldNativeTakenPacket) && inbound_) {
+                            WorldNativeTakenPacket wnt;
+                            std::memcpy(&wnt, ev.packet->data, sizeof(wnt));
+                            wnt.stringID[sizeof(wnt.stringID) - 1] = '\0';
+                            inbound_->pushNativeTaken(wnt.ownerId, wnt);
                         }
                     } else if (type == PKT_NPC_CENSUS) {
                         // Reliable wide-radius NPC existence census (protocol
@@ -1075,6 +1087,23 @@ void NetLink::threadLoop() {
         LeaveCriticalSection(&outCs_);
         for (size_t i = 0; i < pickups.size(); ++i) {
             ENetPacket* out = enet_packet_create(&pickups[i], sizeof(WorldPickupPacket),
+                                                 ENET_PACKET_FLAG_RELIABLE);
+            if (isHost_) {
+                enet_host_broadcast(enetHost_, CH_RELIABLE, out);
+            } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
+                enet_peer_send(serverPeer_, CH_RELIABLE, out);
+            } else {
+                enet_packet_destroy(out);
+            }
+        }
+
+        // Drain + send any queued save-native pickup notices on CH_RELIABLE (protocol 56).
+        std::vector<WorldNativeTakenPacket> takes;
+        EnterCriticalSection(&outCs_);
+        takes.swap(outNativeTaken_);
+        LeaveCriticalSection(&outCs_);
+        for (size_t i = 0; i < takes.size(); ++i) {
+            ENetPacket* out = enet_packet_create(&takes[i], sizeof(WorldNativeTakenPacket),
                                                  ENET_PACKET_FLAG_RELIABLE);
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -88,6 +88,10 @@ public:
     // drop. The peer re-homes its tracked ground copy back into the character's bag.
     void queueWorldPickup(const WorldPickupPacket& pkt);
 
+    // MAIN thread: queue a reliable save-native pickup notice (protocol 56). The peer
+    // destroys its own still-on-ground copy of the consumed native, resolved by hand.
+    void queueNativeTaken(const WorldNativeTakenPacket& pkt);
+
     // MAIN thread: queue a reliable cross-owner TRANSFER intent (protocol 37). The peer
     // relocates the real item between its own copies of the two containers.
     void queueInvXfer(const InvXferPacket& pkt);
@@ -280,6 +284,8 @@ private:
     // Reliable conservation DROP intents (Phase W2), fixed-size PODs. Guarded by outCs_.
     std::vector<WorldDropPacket> outWorldDrops_;
     std::vector<WorldPickupPacket> outWorldPickups_;
+    // Reliable save-native pickup notices (protocol 56). Guarded by outCs_.
+    std::vector<WorldNativeTakenPacket> outNativeTaken_;
     // Reliable cross-owner transfer intents (protocol 37). Guarded by outCs_.
     std::vector<InvXferPacket>   outInvXfers_;
     // Reliable transfer verdicts (protocol 50). Guarded by outCs_.

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -263,6 +263,19 @@ public:
     // applyInventories so the re-home beats the inventory reconcile.
     void applyWeaponPickups(GameWorld* gw, Inbound& in);
 
+    // AFTER engine (protocol 56, BOTH clients): drain received save-native pickup
+    // notices - a peer consumed a ground item the stream never carries (an owned
+    // town/shop item the ownership filter excludes, or a free save-native both
+    // clients loaded) - and destroy OUR still-on-ground copy, located by the
+    // shared identity, template + position (an item's engine hand is per-session
+    // and does not resolve on the other client). Guarded: the match must be a
+    // LIVE ground item of the notice's sid within NATIVE_POS_TOL of the sender's
+    // position, and a copy already in a local bag or already gone is left alone,
+    // so replays, echoes and near-misses are no-ops.
+    void applyNativeTakes(GameWorld* gw, Inbound& in);
+    void sendNativeTaken(NetLink& net, u32 ownerId, const unsigned int ihand[5],
+                         const char* sid, float x, float y, float z, const char* kind);
+
     // BEFORE engine, every tick (Phase W3 convergence): keep groundedWeapons_ honest.
     // Nothing used to prune it, so a cached ground Item* survived the object's despawn and
     // a later re-home handed a dead pointer to the engine. Two jobs:
@@ -1470,6 +1483,17 @@ private:
     // so netId spaces are per-sender and culls are scoped to their owner.
     std::map<std::pair<u32, u32>, WorldProxy> worldProxies_;
     u32                        nextWorldNetId_;
+    // Protocol 56 native-pickup watch: the owned save-natives the spatial scan SAW but
+    // (correctly) excluded from the stream, keyed by their LOCAL hand. Each
+    // publish pass re-resolves every watched hand: entered-a-bag -> send a
+    // PKT_NATIVE_TAKEN notice; unloaded/despawned -> silently forget (never a notice -
+    // an unload must not delete the peer's copy). appliedNativeTakes_ dedupes received
+    // (ownerId, takeId) pairs under reliable resend. Both reset in resetSession().
+    struct NativeWatch { char stringID[48]; float x, y, z; unsigned long lastSeenMs; };
+    std::map<Key, NativeWatch>      nativeWatch_;
+    u32                             nextNativeTakeId_;
+    std::set<std::pair<u32, u32> >  appliedNativeTakes_;
+
     // Load-census latch: false after launch/reload; the first publishWorldItems
     // pass whose scan sees the world populated logs the native census and sets
     // this true. Bookkeeping only (every scan-only item is baseline regardless,

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -1436,13 +1436,16 @@ private:
     // row or a query-free drop-hook edge) so the item can be streamed and refreshed
     // by HANDLE resolution alone - no rescan needed. `seen` is retained only for the
     // legacy scan path; culling is now handle-based (engine::groundItemLiveness).
-    // `baseline` (Phase 3 item-dup fix): a ground item present at the FIRST
-    // post-load spatial scan is a SHARED save-native - both clients already hold
-    // it identically, so it must never be streamed (authoring it mints a proxy
-    // on top of the peer's own native = the rejoin/reload duplication). Baseline
-    // tracks are recorded for identity/liveness but skipped in the emit path;
-    // only items appearing AFTER the baseline (session drops, runtime spawns)
-    // stream. Re-seeded after every reload via worldSeeded_ in resetSession().
+    // `baseline` (Phase 3 item-dup fix): a SHARED save-native - both clients
+    // already hold it identically, so it must never be streamed (authoring it
+    // mints a proxy on top of the peer's own native = the rejoin/reload
+    // duplication). Baseline tracks are recorded for identity/liveness but
+    // skipped in the emit path. A ground item is a save-native unless the drop
+    // hook authored it (or it resolves an unresolved drop edge of ours, see
+    // pendingDrops_): the spatial scan alone can never promote an item to the
+    // stream, because natives keep popping into the scan long after load (a
+    // zone/interior finishing its stream-in 20+ s later looked exactly like a
+    // fresh drop and duped on the peer).
     struct WorldTrack {
         u32 netId; u32 hash; unsigned long lastSendMs; float x, y, z; bool seen;
         char stringID[48]; u32 itemType; u16 quantity; u16 quality; bool baseline;
@@ -1467,12 +1470,19 @@ private:
     // so netId spaces are per-sender and culls are scoped to their owner.
     std::map<std::pair<u32, u32>, WorldProxy> worldProxies_;
     u32                        nextWorldNetId_;
-    // First-scan-baseline latch (Phase 3): false after launch/reload; the first
-    // publishWorldItems pass seeds every in-range save-native as a baseline track
-    // (never-emit) and sets this true. resetSession() clears it so the reloaded
-    // world (which may now contain previously-dropped-then-baked items) re-baselines
-    // rather than re-streaming - closing the per-reload duplicate layering.
+    // Load-census latch: false after launch/reload; the first publishWorldItems
+    // pass whose scan sees the world populated logs the native census and sets
+    // this true. Bookkeeping only (every scan-only item is baseline regardless,
+    // see WorldTrack::baseline); resetSession() clears it so each reload logs
+    // its own census.
     bool                       worldSeeded_;
+    // Own drops the hook captured but could not key (unresolved item hand,
+    // logged DROP-CAP-SKIP): the ONE case where a scan-only sighting is a fresh
+    // drop and must stream. A new scan row that matches one of these by
+    // template + position (within PENDING_DROP_MS) is promoted to a streaming
+    // track; anything else the scan finds unannounced is a save-native.
+    struct PendingDrop { char stringID[48]; float x, y, z; unsigned long ms; };
+    std::vector<PendingDrop>   pendingDrops_;
 
     // Phase W2 conservation-drop state.
     // weaponCensus_: per OWNED character hand, the last-tick set of WEAPON copies it held,

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -255,7 +255,8 @@ void Replicator::resetSession() {
     censusContainers_.clear(); // protocol 34: re-censused in the new world
     worldTrack_.clear();
     worldProxies_.clear();
-    worldSeeded_ = false; // re-baseline the reloaded world's save-native items
+    worldSeeded_ = false; // re-census the reloaded world's save-native items
+    pendingDrops_.clear(); // unresolved drop edges belong to the old world
     weaponCensus_.clear();
     appliedDrops_.clear();
     appliedPickups_.clear();

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -42,7 +42,7 @@ Replicator::Replicator()
       gateSamples_(0), gateAgree_(0), gateLogTick_(0),
       probeRecruit_(false), probedCount_(0),
       aiSuspend_(false), aiLogTick_(0), nextEventId_(1),
-      nextWorldNetId_(1), worldSeeded_(false),
+      nextWorldNetId_(1), worldSeeded_(false), nextNativeTakeId_(0),
       nextDropId_(1), nextPickupId_(1), nextXferId_(1),
       xferScanMs_(0), nextTreatId_(1),
       quietRelapse_(0), crawlPhysRestore_(0),
@@ -257,6 +257,11 @@ void Replicator::resetSession() {
     worldProxies_.clear();
     worldSeeded_ = false; // re-census the reloaded world's save-native items
     pendingDrops_.clear(); // unresolved drop edges belong to the old world
+    // Protocol 56: the reloaded world re-mints its natives; stale watches and
+    // received-take dedupe belong to the old world. (nextNativeTakeId_ keeps
+    // counting so a late reliable resend from before the swap can't collide.)
+    nativeWatch_.clear();
+    appliedNativeTakes_.clear();
     weaponCensus_.clear();
     appliedDrops_.clear();
     appliedPickups_.clear();

--- a/src/plugin/sync/ReplicatorItems.cpp
+++ b/src/plugin/sync/ReplicatorItems.cpp
@@ -15,6 +15,12 @@
 
 namespace coop {
 
+// Protocol 56: how far the receiver lets a native-taken notice's position disagree
+// with the object its hand resolves to before it refuses to destroy anything. A
+// save-native does not move; both clients hold it at the same coordinates, so a
+// few units covers float noise and physics settle without admitting a neighbour.
+static const float NATIVE_POS_TOL = 4.0f;
+
 void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
     // Author the inventory of every container we OWN. ownHands_ is the per-tick set of
     // owned squad-member hands (a character's own hand IS its personal-inventory
@@ -477,7 +483,38 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
             else ++p;
         }
         engine::WorldItemRaw raw[WORLD_ITEMS_MAX];
-        unsigned int n = engine::captureWorldItems(gw, raw, WORLD_ITEMS_MAX, RADIUS);
+        engine::WorldNativeRaw nraw[WORLD_ITEMS_MAX];
+        unsigned int nn = 0;
+        unsigned int n = engine::captureWorldItems(gw, raw, WORLD_ITEMS_MAX, RADIUS,
+                                                   nraw, WORLD_ITEMS_MAX, &nn);
+        // Protocol 56: refresh the native-pickup watch with every owned item the scan
+        // saw (and skipped). First sighting captures the sid; a re-sighting only bumps
+        // lastSeenMs. Bounded: beyond 256 watched natives the stalest sightings fall
+        // off - an unwatched native still can't dupe, its pickup just isn't mirrored.
+        // ECHO GUARD (same rule as the publish rows): a peer-authored proxy must never
+        // enter the watch - its hand is LOCAL mint identity, not save identity, so a
+        // NATIVE-TAKEN naming it could resolve to an unrelated object on the peer.
+        for (unsigned int i = 0; i < nn; ++i) {
+            if (!proxyObjs.empty() &&
+                proxyObjs.count(engine::resolveObjectByHand(nraw[i].hand)) != 0)
+                continue;
+            Key k; k.t = nraw[i].hand[0]; k.c = nraw[i].hand[1]; k.cs = nraw[i].hand[2];
+            k.i = nraw[i].hand[3]; k.s = nraw[i].hand[4];
+            NativeWatch& w = nativeWatch_[k];
+            if (w.lastSeenMs == 0) {
+                strncpy(w.stringID, nraw[i].stringID, sizeof(w.stringID) - 1);
+                w.stringID[sizeof(w.stringID) - 1] = '\0';
+            }
+            w.x = nraw[i].x; w.y = nraw[i].y; w.z = nraw[i].z;
+            w.lastSeenMs = now;
+        }
+        while (nativeWatch_.size() > 256) {
+            std::map<Key, NativeWatch>::iterator oldest = nativeWatch_.begin();
+            for (std::map<Key, NativeWatch>::iterator wi2 = nativeWatch_.begin();
+                 wi2 != nativeWatch_.end(); ++wi2)
+                if (wi2->second.lastSeenMs < oldest->second.lastSeenMs) oldest = wi2;
+            nativeWatch_.erase(oldest);
+        }
         unsigned int natives = 0;
         for (unsigned int i = 0; i < n; ++i) {
             if (isGearType(raw[i].itemType)) continue;
@@ -550,13 +587,30 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
         unsigned int ihand[5] = { it->first.t, it->first.c, it->first.cs, it->first.i, it->first.s };
         float pos[3] = { tr.x, tr.y, tr.z };
         // Query-free liveness: is the real item still on the ground (not gone/picked-up)?
-        if (!engine::groundItemLiveness(ihand, pos)) {
+        bool live, pickedUp = false;
+        if (tr.baseline) {
+            // Save-native: the peer holds the same object, so a local PICKUP must be
+            // named to it (protocol 56) - "picked up here, still lying there on the
+            // other client" is upstream #44 for free items exactly as for stolen ones.
+            // Only a bag entry counts; a destroy/unload is silent (same rule as the
+            // owned watch and the CLAIM half: an unload must never delete the peer's
+            // copy). The object is re-resolved through the hand every pass.
+            RootObject* ro = engine::resolveObjectByHand(ihand);
+            live = ro && engine::groundObjectLiveness(ro, pos, &pickedUp) != 0;
+        } else {
+            live = engine::groundItemLiveness(ihand, pos) != 0;
+        }
+        if (!live) {
             // Baseline (save-native) tracks were never streamed, so the peer has
-            // no proxy to remove - just drop our track. Streamed tracks emit a
-            // remove so the peer despawns its proxy.
+            // no proxy to remove; if it was bagged here, the native-taken notice
+            // carries the news instead. Streamed tracks emit a remove so the peer
+            // despawns its proxy.
             if (!tr.baseline) { if (nr < 256) removed[nr++] = tr.netId; }
-            if (dumpWi) { char b[112]; _snprintf(b, sizeof(b) - 1,
-                "[wi] CULL netId=%u (gone/picked-up) baseline=%d", tr.netId, tr.baseline ? 1 : 0);
+            else if (pickedUp)
+                sendNativeTaken(net, ownerId, ihand, tr.stringID, tr.x, tr.y, tr.z, "free");
+            if (dumpWi) { char b[128]; _snprintf(b, sizeof(b) - 1,
+                "[wi] CULL netId=%u (%s) baseline=%d", tr.netId,
+                pickedUp ? "picked-up" : "gone", tr.baseline ? 1 : 0);
                 b[sizeof(b) - 1] = '\0'; coop::logLine(b); }
             worldTrack_.erase(it++);
             continue;
@@ -650,6 +704,96 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
              ci != claims.end(); ++ci)
             net.queueWorldClaim(ownerId, ci->first, &ci->second[0],
                                 (unsigned int)ci->second.size());
+    }
+
+    // ---- Native-pickup half (protocol 56): a watched save-native went into a bag ----
+    // The ownership filter (protocol 55, upstream #63/#66) keeps owned town/shop items
+    // out of the stream, which also means a local pickup of one (stealing it) never
+    // produced a cull: the peer's identical save-native copy stayed on its ground - the
+    // "stole it here, still lying there on the other client" ghost (upstream #44).
+    // Watch the natives the scan skipped; when one stops reading as a live ground item
+    // BECAUSE it entered an inventory, name it to the peer by template + position
+    // (the save data both clients loaded; an item hand is per-session). An
+    // unload or engine despawn reads as "not picked up" and just drops off the watch -
+    // a zone unload must never delete the peer's copy (same rule as the CLAIM half).
+    for (std::map<Key, NativeWatch>::iterator ni = nativeWatch_.begin();
+         ni != nativeWatch_.end(); ) {
+        unsigned int ihand[5] = { ni->first.t, ni->first.c, ni->first.cs,
+                                  ni->first.i, ni->first.s };
+        RootObject* ro = engine::resolveObjectByHand(ihand);
+        if (!ro) { nativeWatch_.erase(ni++); continue; } // despawned/unloaded: silent
+        bool pickedUp = false;
+        float here[3] = { 0.0f, 0.0f, 0.0f };
+        if (engine::groundObjectLiveness(ro, here, &pickedUp)) { // still grounded
+            ni->second.x = here[0]; ni->second.y = here[1]; ni->second.z = here[2];
+            ++ni; continue;
+        }
+        if (pickedUp) {
+            sendNativeTaken(net, ownerId, ihand, ni->second.stringID,
+                            ni->second.x, ni->second.y, ni->second.z, "owned");
+        } else if (dumpWi) {
+            char b[200]; _snprintf(b, sizeof(b) - 1,
+                "[wi] NATIVE-WATCH drop sid='%s' hand=%u,%u,%u,%u,%u (left ground, not bagged)",
+                ni->second.stringID, ihand[0], ihand[1], ihand[2], ihand[3], ihand[4]);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        }
+        // Bagged (reported) or destroyed (silent): either way it left the ground.
+        nativeWatch_.erase(ni++);
+    }
+}
+
+// Protocol 56: name a consumed save-native to the peer. The hand is the identity
+// (both clients loaded the identical save); the sid and the last ground position
+// travel with it as the receiver's checksum before it destroys anything.
+void Replicator::sendNativeTaken(NetLink& net, u32 ownerId, const unsigned int ihand[5],
+                                 const char* sid, float x, float y, float z,
+                                 const char* kind) {
+    WorldNativeTakenPacket pkt; memset(&pkt, 0, sizeof(pkt));
+    pkt.type = (u8)PKT_NATIVE_TAKEN; pkt.ownerId = ownerId;
+    pkt.takeId = ++nextNativeTakeId_;
+    pkt.iType = ihand[0]; pkt.iContainer = ihand[1]; pkt.iContainerSerial = ihand[2];
+    pkt.iIndex = ihand[3]; pkt.iSerial = ihand[4];
+    strncpy(pkt.stringID, sid ? sid : "", sizeof(pkt.stringID) - 1);
+    pkt.stringID[sizeof(pkt.stringID) - 1] = '\0';
+    pkt.x = x; pkt.y = y; pkt.z = z;
+    net.queueNativeTaken(pkt);
+    char b[240]; _snprintf(b, sizeof(b) - 1,
+        "[wi] NATIVE-TAKEN send takeId=%u kind=%s sid='%s' hand=%u,%u,%u,%u,%u pos=%.2f,%.2f,%.2f",
+        pkt.takeId, kind, pkt.stringID, ihand[0], ihand[1], ihand[2], ihand[3], ihand[4], x, y, z);
+    b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+}
+
+void Replicator::applyNativeTakes(GameWorld* gw, Inbound& in) {
+    std::deque<InboundNativeTaken> got;
+    in.drainNativeTaken(got);
+    if (got.empty()) return;
+    for (std::deque<InboundNativeTaken>::iterator it = got.begin(); it != got.end(); ++it) {
+        const WorldNativeTakenPacket& p = it->pkt;
+        std::pair<u32, u32> id(p.ownerId, p.takeId);
+        if (appliedNativeTakes_.count(id) != 0) continue; // idempotent (reliable resend)
+        appliedNativeTakes_.insert(id);
+        if (appliedNativeTakes_.size() > 4096) appliedNativeTakes_.erase(appliedNativeTakes_.begin());
+        unsigned int ihand[5] = { p.iType, p.iContainer, p.iContainerSerial,
+                                  p.iIndex, p.iSerial };
+        // The sender's hand is per-session (it does not resolve here); the notice
+        // is matched by template + position. destroyNativeGroundItem hands back
+        // the LOCAL hand of what it destroyed so our own track/watch for that
+        // object is retired too. (A destroy reads as "gone", not "bagged", so the
+        // cull could not echo it anyway - this just keeps the maps honest.)
+        const char* why = "";
+        const float expectPos[3] = { p.x, p.y, p.z };
+        unsigned int gone[5] = { 0, 0, 0, 0, 0 };
+        int destroyed = engine::destroyNativeGroundItem(gw, ihand, p.stringID, expectPos,
+                                                        NATIVE_POS_TOL, gone, &why);
+        if (destroyed) {
+            Key k; k.t = gone[0]; k.c = gone[1]; k.cs = gone[2]; k.i = gone[3]; k.s = gone[4];
+            nativeWatch_.erase(k);
+            worldTrack_.erase(k);
+        }
+        char b[240]; _snprintf(b, sizeof(b) - 1,
+            "[wi] NATIVE-TAKEN apply from=%u takeId=%u sid='%s' pos=%.2f,%.2f,%.2f destroyed=%d why='%s'",
+            p.ownerId, p.takeId, p.stringID, p.x, p.y, p.z, destroyed, destroyed ? "ok" : why);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 }
 

--- a/src/plugin/sync/ReplicatorItems.cpp
+++ b/src/plugin/sync/ReplicatorItems.cpp
@@ -357,8 +357,10 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
     //   (1) the query-free drop hook (engine::drainItemDrops) - a drop captured at
     //       Inventory::dropItem, so a TOWN drop is found even when the spatial query
     //       misses it (the core town-reliability fix); and
-    //   (2) the spatial scan (captureWorldItems) - best-effort, for pre-existing save
-    //       items / host runtime drops the drop hook didn't author.
+    //   (2) the spatial scan (captureWorldItems) - the census: pre-existing save
+    //       items become never-emit baseline tracks (identity + liveness), and a
+    //       drop the hook captured but could not key is resolved here by template
+    //       + position (pendingDrops_). The scan never streams anything on its own.
     // Both key a track by the item's LOCAL engine hand, so a drop found by BOTH sources
     // converges on ONE track (one netId) - no duplicate proxy. CULLING is now HANDLE-
     // based (engine::groundItemLiveness): a track is removed only when its real item is
@@ -384,43 +386,32 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
         if (live) proxyObjs.insert(live);
     }
 
-    // ---- First-scan baseline (Phase 3 item-dup fix) ------------------------
-    // Every non-gear ground item present at the FIRST publish pass after a load
-    // is a SHARED save-native: the peer loaded the same save (or the host's
-    // connect-pushed save) and already holds an identical copy. Streaming it
-    // would mint a proxy on top of the peer's own native - the "rejoin/reload
-    // duplicated all items" report, compounding one layer per reload. Seed them
-    // as baseline tracks (identity + liveness only, NEVER emitted). Only items
-    // that appear AFTER this baseline (session drops via the hook, host runtime
-    // spawns) stream. resetSession() clears worldSeeded_ so each reload re-
-    // baselines the (possibly newly-baked) save-natives instead of re-streaming.
-    if (!worldSeeded_) {
-        worldSeeded_ = true;
-        engine::WorldItemRaw raw[WORLD_ITEMS_MAX];
-        unsigned int n = engine::captureWorldItems(gw, raw, WORLD_ITEMS_MAX, RADIUS);
-        unsigned int seeded = 0;
-        for (unsigned int i = 0; i < n; ++i) {
-            if (isGearType(raw[i].itemType)) continue;
-            if (!proxyObjs.empty() &&
-                proxyObjs.count(engine::resolveObjectByHand(raw[i].hand)) != 0)
-                continue; // already our proxy (defensive; unlikely at first scan)
-            Key k; k.t = raw[i].hand[0]; k.c = raw[i].hand[1]; k.cs = raw[i].hand[2];
-            k.i = raw[i].hand[3]; k.s = raw[i].hand[4];
-            if (worldTrack_.find(k) != worldTrack_.end()) continue;
-            WorldTrack t; memset(&t, 0, sizeof(t));
-            t.netId = nextWorldNetId_++; t.hash = 0; t.lastSendMs = 0;
-            t.x = raw[i].x; t.y = raw[i].y; t.z = raw[i].z; t.seen = true;
-            t.baseline = true; // never emit
-            strncpy(t.stringID, raw[i].stringID, sizeof(t.stringID) - 1);
-            t.stringID[sizeof(t.stringID) - 1] = '\0';
-            t.itemType = raw[i].itemType; t.quantity = raw[i].quantity; t.quality = raw[i].quality;
-            worldTrack_[k] = t;
-            ++seeded;
-        }
-        char b[96]; _snprintf(b, sizeof(b) - 1,
-            "[wi] BASELINE seeded=%u (save-native, never-stream)", seeded);
-        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
-    }
+    // ---- Save-native baseline (Phase 3 item-dup fix) ------------------------
+    // Every non-gear ground item the world holds that the DROP HOOK did not
+    // author is a SHARED save-native: the peer loaded the same save (or the
+    // host's connect-pushed save) and already holds an identical copy. Streaming
+    // it would mint a proxy on top of the peer's own native - the "rejoin/reload
+    // duplicated all items" report, compounding one layer per reload. Such items
+    // become baseline tracks (identity + liveness only, NEVER emitted).
+    //
+    // This used to be a one-shot FIRST-SCAN seed, and that raced the world:
+    // measured on 1.0.65, the first publish pass after a load routinely ran
+    // before the zone's items existed (scan n=0), so a baseline latched on it was
+    // empty and the natives that popped in 130-200 ms later streamed as fresh
+    // drops (14 grey duplicates on the peer). Widening the seed to a settle
+    // window was not enough either: an interior finishing its stream-in 20+ s
+    // after connect popped in another batch of natives on BOTH clients at the
+    // same instant, and each streamed them to the other. So the rule is now
+    // structural, not temporal: the spatial scan alone never promotes an item
+    // to the stream. The one exception is an own drop the hook captured but
+    // could not key (DROP-CAP-SKIP, below): it is remembered in pendingDrops_
+    // and the first scan row matching its template + position is the drop.
+    // (Discovery 1's hook detours Inventory::dropItem engine-wide, so every real
+    // drop - ours, an NPC's - is authored there; only save data and the peer's
+    // proxies, which the echo guard already filters, put items on the ground
+    // without it.)
+    const unsigned long PENDING_DROP_MS   = 5000;
+    const float         PENDING_DROP_DIST = 2.5f;
 
     // Gear (itemType WEAPON/ARMOUR) rides the W2 conservation drop/pickup channel
     // (the real shared-save object is relocated bag<->ground on each client), so the
@@ -432,23 +423,30 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
         unsigned int nde = engine::drainItemDrops(de, 64);
         for (unsigned int i = 0; i < nde; ++i) {
             if (isGearType(de[i].itemType)) continue;
+            // A drop from a PEER-owned squad copy is the peer's to author (it streams
+            // its own drop); authoring it here too would duplicate the proxy. World
+            // NPC (class 0) and our own squad (class 1) drops still stream.
+            if (ownerClassForHand(de[i].ownerHand) == 2) continue;
             if (de[i].itemHand[3] == 0 && de[i].itemHand[4] == 0) {
-                // Unresolved hand: this drop cannot be keyed, so the reliable discovery path
-                // gives up on it and only the (town-unreliable) spatial scan can still find
-                // it. That is the one way a non-gear drop silently never reaches the peer, so
-                // say so unconditionally - it is rare, and guessing at it from a silent log is
-                // what made "dropped here, absent there" impossible to pin down.
+                // Unresolved hand: this drop cannot be keyed here, so only the (town-
+                // unreliable) spatial scan can still find it. Remember its template +
+                // position: the scan row that matches is THIS drop and streams; every
+                // other scan-only row is a save-native. Say so unconditionally - it is
+                // rare, and guessing at it from a silent log is what made "dropped
+                // here, absent there" impossible to pin down.
                 char b[200]; _snprintf(b, sizeof(b) - 1,
                     "[wi] DROP-CAP-SKIP sid='%s' qty=%u pos=%.2f,%.2f,%.2f (unresolved item "
                     "hand; spatial scan is the only remaining chance)",
                     de[i].stringID, de[i].quantity, de[i].x, de[i].y, de[i].z);
                 b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+                if (pendingDrops_.size() < 32) {
+                    PendingDrop pd; memset(&pd, 0, sizeof(pd));
+                    strncpy(pd.stringID, de[i].stringID, sizeof(pd.stringID) - 1);
+                    pd.x = de[i].x; pd.y = de[i].y; pd.z = de[i].z; pd.ms = now;
+                    pendingDrops_.push_back(pd);
+                }
                 continue;
             }
-            // A drop from a PEER-owned squad copy is the peer's to author (it streams
-            // its own drop); authoring it here too would duplicate the proxy. World
-            // NPC (class 0) and our own squad (class 1) drops still stream.
-            if (ownerClassForHand(de[i].ownerHand) == 2) continue;
             Key k; k.t = de[i].itemHand[0]; k.c = de[i].itemHand[1]; k.cs = de[i].itemHand[2];
             k.i = de[i].itemHand[3]; k.s = de[i].itemHand[4];
             if (worldTrack_.find(k) != worldTrack_.end()) continue; // already tracked
@@ -466,10 +464,21 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
         }
     }
 
-    // ---- Discovery 2: the spatial scan (best-effort) -----------------------
+    // ---- Discovery 2: the spatial scan (census + liveness identity) --------
+    // Every in-range ground item gets a track (identity + liveness), but a row
+    // the scan finds UNANNOUNCED is a save-native and is recorded as baseline
+    // (never emit). Only a row that resolves a pending unresolved own drop is
+    // promoted to a streaming track.
     {
+        // Age out pending unresolved drops the scan never found.
+        for (size_t p = 0; p < pendingDrops_.size(); ) {
+            if (now - pendingDrops_[p].ms > PENDING_DROP_MS)
+                pendingDrops_.erase(pendingDrops_.begin() + p);
+            else ++p;
+        }
         engine::WorldItemRaw raw[WORLD_ITEMS_MAX];
         unsigned int n = engine::captureWorldItems(gw, raw, WORLD_ITEMS_MAX, RADIUS);
+        unsigned int natives = 0;
         for (unsigned int i = 0; i < n; ++i) {
             if (isGearType(raw[i].itemType)) continue;
             if (!proxyObjs.empty() &&
@@ -485,7 +494,24 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
                 strncpy(t.stringID, raw[i].stringID, sizeof(t.stringID) - 1);
                 t.stringID[sizeof(t.stringID) - 1] = '\0';
                 t.itemType = raw[i].itemType; t.quantity = raw[i].quantity; t.quality = raw[i].quality;
+                // Attribute: an own drop the hook could not key, now found by the scan?
+                bool isDrop = false;
+                for (size_t p = 0; p < pendingDrops_.size(); ++p) {
+                    const PendingDrop& pd = pendingDrops_[p];
+                    float dx = raw[i].x - pd.x, dy = raw[i].y - pd.y, dz = raw[i].z - pd.z;
+                    if (strcmp(pd.stringID, raw[i].stringID) == 0 &&
+                        dx*dx + dy*dy + dz*dz <= PENDING_DROP_DIST * PENDING_DROP_DIST) {
+                        pendingDrops_.erase(pendingDrops_.begin() + p);
+                        isDrop = true; break;
+                    }
+                }
+                t.baseline = !isDrop; // unannounced = save-native, never emit
+                if (t.baseline) ++natives;
                 worldTrack_[k] = t;
+                if (dumpWi) { char b[200]; _snprintf(b, sizeof(b) - 1,
+                    "[wi] SCAN-%s netId=%u sid='%s' qty=%u pos=%.2f,%.2f,%.2f",
+                    isDrop ? "DROP" : "NATIVE", t.netId, t.stringID, t.quantity, t.x, t.y, t.z);
+                    b[sizeof(b) - 1] = '\0'; coop::logLine(b); }
             } else {
                 // Refresh the description (a re-stack can change qty/quality).
                 WorldTrack& tr = tit->second;
@@ -493,6 +519,15 @@ void Replicator::publishWorldItems(GameWorld* gw, NetLink& net, u32 ownerId) {
                 tr.stringID[sizeof(tr.stringID) - 1] = '\0';
                 tr.itemType = raw[i].itemType; tr.quantity = raw[i].quantity; tr.quality = raw[i].quality;
             }
+        }
+        // Load census: log the first populated scan after a load/reload once (the
+        // natives keep arriving after this - each is baselined as it appears).
+        if (!worldSeeded_ && n > 0) {
+            worldSeeded_ = true;
+            char b[112]; _snprintf(b, sizeof(b) - 1,
+                "[wi] BASELINE seeded=%u (save-native, never-stream; first populated scan n=%u)",
+                natives, n);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
         }
     }
 

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -310,8 +310,31 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v55: runtime-fixture identity)",
-             (int)PROTOCOL_VERSION, 55);
+    CHECK_EQ("PROTOCOL_VERSION (v56: save-native pickup notice)",
+             (int)PROTOCOL_VERSION, 56);
+
+    // Protocol 56: save-native pickup notice. The ownership filter (protocol 55)
+    // keeps owned town/shop items out of the stream, so their pickup needs its own
+    // mirror: a notice keyed by template + position (the shared save data).
+    CHECK_EQ("PKT_NATIVE_TAKEN id", (int)PKT_NATIVE_TAKEN, 49);
+    CHECK("PKT_NATIVE_TAKEN distinct",
+          PKT_NATIVE_TAKEN != PKT_WORLD_ITEM_CLAIM &&
+          PKT_NATIVE_TAKEN != PKT_WORLD_PICKUP &&
+          PKT_NATIVE_TAKEN != PKT_WORLD_ITEM_REMOVE &&
+          PKT_NATIVE_TAKEN != PKT_FIXTURE);
+    {
+        WorldNativeTakenPacket nt; std::memset(&nt, 0, sizeof(nt));
+        nt.type = (u8)PKT_NATIVE_TAKEN; nt.ownerId = 2u; nt.takeId = 9u;
+        nt.iType = 0; nt.iContainer = 2069; nt.iContainerSerial = 11111;
+        nt.iIndex = 469; nt.iSerial = 346801760u;
+        nt.x = -51174.32f; nt.y = 1594.71f; nt.z = 2718.17f;
+        CHECK("native-taken carries the 5-field hand",
+              nt.iContainer == 2069 && nt.iSerial == 346801760u && nt.takeId == 9u);
+        // The receiver's identity checksum rides along: sid + the sender's ground
+        // position (a hand alone can name a different object on the other client).
+        CHECK("native-taken carries the position checksum",
+              nt.x < -51174.0f && nt.y > 1594.0f && nt.z > 2718.0f);
+    }
 
     // Protocol 52: the shared money pool. The two players spend from ONE wallet,
     // so the join reports CHANGES and the host the authoritative TOTAL - swap
@@ -466,6 +489,7 @@ static void testRoundTrips() {
     roundTrip<EventPacket>("EventPacket", (u8)PKT_EVENT);
     roundTrip<WorldDropPacket>("WorldDropPacket", (u8)PKT_WORLD_DROP);
     roundTrip<WorldPickupPacket>("WorldPickupPacket", (u8)PKT_WORLD_PICKUP);
+    roundTrip<WorldNativeTakenPacket>("WorldNativeTakenPacket", (u8)PKT_NATIVE_TAKEN);
     roundTrip<InvXferPacket>("InvXferPacket", (u8)PKT_INV_XFER);
     roundTrip<MedicalPacket>("MedicalPacket", (u8)PKT_MEDICAL);
     roundTrip<TreatmentPacket>("TreatmentPacket", (u8)PKT_TREATMENT);


### PR DESCRIPTION
Fixes #44. Stacked on #69 (merge that first — this PR's first two commits are #69).

## The gap

With save-natives correctly kept out of the W1 proxy stream (#69), nothing mirrors their **pickup**: taking a native on one client — a red item stolen off a shop floor, or a free loot item both players can see — removes it locally, but the peer's identical copy stays on its ground. That's the "picked it up here, still lying there on the other client" ghost, and it's exactly what lets both players pick up the same item (#44). Natives have no netId and no proxy, so neither the CLAIM channel (protocol 47) nor the conservation drop/pickup intents (W2/W3) can carry this; it needs its own notice.

## The fix (protocol 56)

- Both clients **watch the natives they hold**: the owned items the scan skips (`captureWorldItems` now reports them) and the free loose ones already tracked as baseline rows. Each publish pass re-resolves them; one that stopped reading as a live ground item **because it entered an inventory** (`Item::isInInventory` — the same probe the CLAIM half uses) is named to the peer in a reliable `PKT_NATIVE_TAKEN`. Unloads/despawns read as not-picked-up and silently fall off the watch — a zone unload must never delete the peer's copy (the CLAIM half's rule, kept).
- The receiver destroys its own copy **only if** it still reads as a live ground item; already-bagged (someone here took it too), already-gone, or absent copies are logged no-ops, so replays and echoes are harmless.

**Identity is template + position, not the engine hand.** The first cut keyed the notice by the item's engine hand on the assumption it was save-stable across clients — it isn't for items: measured on 1.0.65, `(index, serial)` is assigned per session, and the receiver logged `unresolved` for a hand the sender had just read off the identical save. What both clients *do* share is the save data itself: the GameData stringID and the world position, which neither client moved. So the notice carries sid + position, and the receiver queries the sphere around that position and destroys the **live ground item of that template nearest to it, within 4 units** — or nothing. (Two identical templates within 4 u of each other are interchangeable copies on both machines, so "the nearest" removes the same logical thing the sender did.) The sender's hand still rides along as a same-client fast path and for the log.

`PROTOCOL_VERSION` bumps to 56 (both players must run the same build; the HELLO gate enforces it, as usual).

## Testing

- Protocol/unit layer: prototest updated (packet id/shape/position round-trip + version checks), 529/529 passing.
- Full smoke tier on this exact build: functionally green — including the world-item family (`world_item_burst`, `world_item_stale`, `world_pickup_mirror`, the drop/regear scenarios), which exercises the scan, stream, claim, and conservation paths around the new watch.
- Manual two-client session (bar-town save with loose natives on the floor), all read off the `[wi]` log:
  - host picks up a native → join `NATIVE-TAKEN apply ... destroyed=1 why='ok'` 13 ms later; join picks one up → host `destroyed=1` 59 ms later — the item vanishes from the other window;
  - normal drops still stream both ways (`DROP-CAP` → peer `SPAWN`), picking a streamed drop back up still removes it on the peer (`CLAIM-APPLY destroyed=1` / `CULL`);
  - no unexpected `SEND`s, no duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
