### PR TITLE
Fix orphaned ownership on peer-minted placed buildings

### DIFF
--- a/src/plugin/KenshiCoop.vcxproj
+++ b/src/plugin/KenshiCoop.vcxproj
@@ -199,6 +199,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CoopLog.h" />
+    <ClInclude Include="core\BuildOwnership.h" />
     <ClInclude Include="core\Config.h" />
     <ClInclude Include="core\Inbound.h" />
     <ClInclude Include="net\NetLink.h" />

--- a/src/plugin/core/BuildOwnership.h
+++ b/src/plugin/core/BuildOwnership.h
@@ -1,0 +1,25 @@
+// BuildOwnership.h - pure policy for ownership of protocol-27 placed builds.
+//
+// A peer-side copy is created from a runtime placement key.  The factory mint
+// alone does not make that copy a player-owned building, so the receiver must
+// claim it through the same engine state write used by property deeds.  Runtime
+// building hands are client-local, however, and must never leak into the deed
+// channel, whose raw-hand identity is valid only for save-resident buildings.
+
+#ifndef COOP_BUILD_OWNERSHIP_H
+#define COOP_BUILD_OWNERSHIP_H
+
+namespace coop {
+
+inline bool peerBuildNeedsOwnership(int minted, bool removed,
+                                    bool ownershipApplied) {
+    return minted == 1 && !removed && !ownershipApplied;
+}
+
+inline bool deedMayPublishRawHand(bool sessionPlaced) {
+    return !sessionPlaced;
+}
+
+} // namespace coop
+
+#endif // COOP_BUILD_OWNERSHIP_H

--- a/src/plugin/game/EngineWorld.cpp
+++ b/src/plugin/game/EngineWorld.cpp
@@ -962,8 +962,16 @@ int placeBuildingAt(GameWorld* gw, const char* sid, float x, float y, float z,
         // engine NESTS a createBuilding per extra floor inside this call - those
         // nested ones re-enter the capture hook and would echo this mint back.
         ++g_buildCaptureSuppress;
+        // Protocol-27 copies represent a PLAYER placement.  Passing a null
+        // owner created a visually present but orphaned workbench on the peer:
+        // Kenshi then rejected normal use as though nobody owned it.  Give the
+        // factory this client's corresponding player faction, matching the
+        // native build-menu creation path.  applyBuilds verifies the result and
+        // falls back to the deed state writer if this engine path leaves only a
+        // partial ownership state.
+        Faction* playerOwner = playerFactionOf(gw);
         Building* bld = g_createBldgFn(
-            gw->theFactory, tmpl, pos, /*town*/0, /*owner*/0, rot, /*cb*/0,
+            gw->theFactory, tmpl, pos, /*town*/0, playerOwner, rot, /*cb*/0,
             /*furnitureOf*/0, /*isDoorOf*/0, /*saveState*/0, /*isIndoorsOf*/0,
             /*invisible*/false, completed, /*isFoliage*/false,
             /*floor*/0, /*isOutsideFurniture*/false);

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -2002,7 +2002,15 @@ private:
         unsigned int localHand[5];
         int minted; u32 seqSeen;
         bool removed; // proxy destroyed on a REMOVE: tombstone (rows skip)
-        PeerBuild() : minted(0), seqSeen(0), removed(false) { memset(localHand, 0, sizeof(localHand)); }
+        // Latch only after the engine confirms the local copy is player-owned.
+        // The factory receives the local player faction; the deed writer is a
+        // fallback for partial initialization.  Until confirmation, PLACE
+        // resends and STATE rows retry the check/claim.
+        bool ownershipApplied;
+        PeerBuild() : minted(0), seqSeen(0), removed(false),
+                      ownershipApplied(false) {
+            memset(localHand, 0, sizeof(localHand));
+        }
     };
     std::map<Key, OwnBuild>  ownBuilds_;
     std::map<Key, PeerBuild> peerBuilds_;
@@ -2024,6 +2032,8 @@ private:
     //     whether we placed it (ownBuilds_) or minted it (peerBuilds_).
     bool buildKeyForLocalHand(const Key& local, Key& outWire) const;
     bool localHandForBuildKey(const Key& wire, unsigned int out[5]) const;
+    bool ensurePeerBuildOwnership(GameWorld* gw, const Key& wire,
+                                  PeerBuild& peerBuild);
     u32           buildSeqOut_;
     unsigned long buildSampleMs_;
     bool          buildSync_;

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -11,6 +11,7 @@
 // PowerShell oracles (see resources/CODE_MAP.md, log-tag index).
 
 #include "ReplicatorUtil.h"
+#include "../core/BuildOwnership.h"
 
 namespace coop {
 
@@ -1168,6 +1169,17 @@ void Replicator::publishDeeds(const SyncContext& ctx) {
         const engine::DeedRead& r = rows[i];
         Key k; k.t = r.hand[0]; k.c = r.hand[1]; k.cs = r.hand[2];
         k.i = r.hand[3]; k.s = r.hand[4];
+        // Raw deed hands are cross-client identities only for save-resident
+        // buildings.  A protocol-27 placement has a different runtime hand on
+        // each client and its ownership is established when the peer copy is
+        // minted below.  Publishing that local hand as a deed can resolve to
+        // nothing (or, worse, an unrelated runtime object) on the peer.
+        Key buildWire;
+        const bool sessionPlaced = buildKeyForLocalHand(k, buildWire);
+        if (!deedMayPublishRawHand(sessionPlaced)) {
+            deedRows_.erase(k); // also remove a row seeded by older code
+            continue;
+        }
         live.insert(k);
         DeedRow& dr = deedRows_[k];
         bool changed = (dr.knownOwned != 1);
@@ -1283,6 +1295,12 @@ void Replicator::applyDeeds(const SyncContext& ctx) {
         const DeedPacket& p = it->pkt;
         Key k; k.t = p.hand[0]; k.c = p.hand[1]; k.cs = p.hand[2];
         k.i = p.hand[3]; k.s = p.hand[4];
+        // A mixed-version peer may still publish a runtime placed-building
+        // hand through the deed channel.  Protocol 27 owns that identity; do
+        // not let a raw-hand deed collide with a local runtime object.
+        if (ownBuilds_.find(k) != ownBuilds_.end() ||
+            peerBuilds_.find(k) != peerBuilds_.end())
+            continue;
         DeedRow& dr = deedRows_[k];
         if (!sync::gateSeqAccept(dr.seqSeen, p.seq)) continue; // stale/dup row
         dr.seqSeen = p.seq;
@@ -1507,6 +1525,41 @@ bool Replicator::localHandForBuildKey(const Key& wire, unsigned int out[5]) cons
     return false; // unknown / refused / tombstoned key
 }
 
+bool Replicator::ensurePeerBuildOwnership(GameWorld* gw, const Key& wire,
+                                          PeerBuild& pb) {
+    if (!peerBuildNeedsOwnership(pb.minted, pb.removed,
+                                 pb.ownershipApplied))
+        return pb.ownershipApplied;
+
+    // The native factory was given the local player faction.  Prefer that
+    // result and avoid inserting every placed chair/bench into the separate
+    // property-deed set when the normal creation path already made it owned.
+    engine::DeedRead cur;
+    if (engine::readDeedByHand(gw, pb.localHand, &cur) && cur.owned == 1) {
+        pb.ownershipApplied = true;
+        return true;
+    }
+
+    // Backstop for engine/template variants where the factory sets only part
+    // of the ownership state.  This is idempotent and uses the same proven
+    // state write as protocol 54 without replaying a purchase or charging cats.
+    engine::DeedRead post;
+    bool ok = engine::writeDeedByHand(gw, pb.localHand, /*wantOwned*/1,
+                                      /*ownerSid*/"", &post);
+    pb.ownershipApplied = ok && post.owned == 1;
+
+    char b[224];
+    _snprintf(b, sizeof(b) - 1,
+              "[build] OWNER-CLAIM key=%u.%u.%u.%u.%u "
+              "local=%u.%u.%u.%u.%u ok=%d owned=%d",
+              wire.t, wire.c, wire.cs, wire.i, wire.s,
+              pb.localHand[0], pb.localHand[1], pb.localHand[2],
+              pb.localHand[3], pb.localHand[4], ok ? 1 : 0,
+              ok ? post.owned : -1);
+    b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    return pb.ownershipApplied;
+}
+
 void Replicator::publishBuilds(const SyncContext& ctx) {
     NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
     if (!buildSync_) return;
@@ -1635,8 +1688,14 @@ void Replicator::applyBuilds(const SyncContext& ctx) {
         if (p.sid[0] == '\0') continue;
         Key k; k.t = p.key[0]; k.c = p.key[1]; k.cs = p.key[2];
         k.i = p.key[3]; k.s = p.key[4];
-        if (peerBuilds_.find(k) != peerBuilds_.end())
+        std::map<Key, PeerBuild>::iterator existing = peerBuilds_.find(k);
+        if (existing != peerBuilds_.end()) {
+            // A PLACE safety resend is also an ownership retry.  The factory
+            // mint may succeed one tick before the ownership subsystem is
+            // ready; deduping the packet must not leave a permanent orphan.
+            ensurePeerBuildOwnership(gw, k, existing->second);
             continue; // already minted (or mint already refused) - dedupe
+        }
         PeerBuild& pb = peerBuilds_[k];
         // Mint INCOMPLETE always: the placer's STATE rows drive progress from
         // here (a real UI placement starts at 0 anyway).
@@ -1649,6 +1708,7 @@ void Replicator::applyBuilds(const SyncContext& ctx) {
             Key lk; lk.t = pb.localHand[0]; lk.c = pb.localHand[1];
             lk.cs = pb.localHand[2]; lk.i = pb.localHand[3]; lk.s = pb.localHand[4];
             mintByLocal_[lk] = k;
+            ensurePeerBuildOwnership(gw, k, pb);
         }
         char b[240];
         _snprintf(b, sizeof(b) - 1,
@@ -1670,6 +1730,9 @@ void Replicator::applyBuilds(const SyncContext& ctx) {
             continue; // mint refused or key unknown - skip silently
         PeerBuild& pb = f->second;
         if (pb.removed) continue; // tombstoned (REMOVE already applied)
+        // Retry before the seq gate: even a duplicate safety row is useful if
+        // the previous ownership write ran before the engine was ready.
+        ensurePeerBuildOwnership(gw, k, pb);
         if (!sync::gateSeqAccept(pb.seqSeen, p.seq)) continue; // stale/dup row
         pb.seqSeen = p.seq;
         engine::BuildRead cur;

--- a/src/plugin/test/ScenarioBuildings.cpp
+++ b/src/plugin/test/ScenarioBuildings.cpp
@@ -404,12 +404,13 @@ private:
 // distinct spots); each side then ramps its OWN site's progress +0.25 every
 // 3 s until complete. The probe gates only that the script ran (a REFUSED
 // placement is a finding, not a failure); the sync variant also requires
-// the local place + ramp-to-complete to have worked.
+// the local place + ramp-to-complete to have worked and at least one peer site
+// to be observed as player-owned (the usable-copy regression gate).
 class BuildProbeScenario : public TimedScenario {
 public:
     explicit BuildProbeScenario(bool probe)
         : TimedScenario(probe ? "build_probe" : "build_sync", /*evidenceMs=*/1000),
-          probe_(probe), censusLogged_(0),
+          probe_(probe), censusLogged_(0), peerOwnedObserved_(false),
           placed_(false), placeOk_(false), rampStep_(0), rampDoneOk_(false),
           nextRampMs_(0) {
         memset(ownHand_, 0, sizeof(ownHand_));
@@ -440,7 +441,9 @@ public:
             passed_ = placed_ && (censusLogged_ > 0);
             // The gated variant requires the whole local leg to have worked
             // (the probe only requires the script to have run and logged).
-            if (!probe_) passed_ = passed_ && placeOk_ && rampDoneOk_;
+            if (!probe_)
+                passed_ = passed_ && placeOk_ && rampDoneOk_ &&
+                          peerOwnedObserved_;
             return true;
         }
         return false;
@@ -463,6 +466,27 @@ private:
                       r.sid, r.progress, r.complete, r.name, r.x, r.y, r.z,
                       ctx.elapsedMs);
             b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+
+            // Ownership is part of a usable peer copy, not merely cosmetic
+            // placement.  A protocol-27 mint used to pass owner=0, producing a
+            // bench that existed on screen but behaved as nobody's property.
+            // In this controlled two-site scenario, any site whose hand is not
+            // our own is the peer copy.  Latch the first owned observation so
+            // completion (which removes it from enumSitesNear) cannot erase the
+            // evidence before the final gate.
+            const bool own = memcmp(r.hand, ownHand_, sizeof(ownHand_)) == 0;
+            engine::DeedRead deed;
+            const bool deedRead = engine::readDeedByHand(ctx.gw, r.hand, &deed);
+            if (!own && deedRead && deed.owned == 1)
+                peerOwnedObserved_ = true;
+            char ob[192];
+            _snprintf(ob, sizeof(ob) - 1,
+                      "SCENARIO BUILDOWNER hand=%u.%u.%u.%u.%u own=%d "
+                      "read=%d owned=%d t=%lu",
+                      r.hand[0], r.hand[1], r.hand[2], r.hand[3], r.hand[4],
+                      own ? 1 : 0, deedRead ? 1 : 0,
+                      deedRead ? deed.owned : -1, ctx.elapsedMs);
+            ob[sizeof(ob) - 1] = '\0'; coop::logLine(ob);
         }
         if (n > 0) ++censusLogged_;
     }
@@ -516,6 +540,7 @@ private:
 
     bool          probe_;
     unsigned int  censusLogged_;
+    bool          peerOwnedObserved_;
     bool          placed_;
     bool          placeOk_;
     unsigned int  rampStep_;

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -34,6 +34,7 @@
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
+#include "../plugin/core/BuildOwnership.h" // protocol-27 peer-copy ownership policy
 #include "../plugin/sync/SaveXfer.h"     // Part A: real save-transfer receiver end-to-end
 
 #include <set>
@@ -50,6 +51,7 @@ namespace coop {
     void logLine(const char*) {}
     void logErrLine(const char*) {}
 }
+
 
 static int g_failed = 0;
 static int g_total  = 0;
@@ -1766,6 +1768,28 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+static void testBuildOwnershipPolicy() {
+    std::printf("== placed-building ownership policy ==\n");
+
+    CHECK("successful peer mint needs an ownership claim",
+          peerBuildNeedsOwnership(/*minted*/1, /*removed*/false,
+                                  /*ownershipApplied*/false));
+    CHECK("refused mint cannot be claimed",
+          !peerBuildNeedsOwnership(/*minted*/0, /*removed*/false,
+                                   /*ownershipApplied*/false));
+    CHECK("removed proxy is never reclaimed",
+          !peerBuildNeedsOwnership(/*minted*/1, /*removed*/true,
+                                   /*ownershipApplied*/false));
+    CHECK("confirmed ownership latches",
+          !peerBuildNeedsOwnership(/*minted*/1, /*removed*/false,
+                                   /*ownershipApplied*/true));
+
+    CHECK("save-resident building may publish a raw deed hand",
+          deedMayPublishRawHand(/*sessionPlaced*/false));
+    CHECK("session placement must use its translated build key",
+          !deedMayPublishRawHand(/*sessionPlaced*/true));
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1789,6 +1813,7 @@ int main() {
     testInboundLifecycle();
     testFlushWorldStateContract();
     testTeardownOrdering();
+    testBuildOwnershipPolicy();
     std::printf("\nprototest: %d/%d checks passed%s\n",
                 g_total - g_failed, g_total, g_failed ? " - FAIL" : " - PASS");
     return g_failed;


### PR DESCRIPTION
## Summary

- create each protocol-27 peer copy with the local player faction instead of owner = 0
- confirm ownership after minting and retry the existing deed-state write idempotently when factory initialization is partial
- keep session-only runtime building hands out of the save-stable raw deed channel
- add small policy tests and require the build_sync scenario to observe the peer building as owned

## Problem

A placed building can replicate successfully while the peer-side factory call creates it with no owner. In practice that can leave a Join-created workbench visible inside the house but unusable, as if it belongs to neither player.

References #13 and #38.

Scope boundary: this does **not** implement queued production/recipe authority and does not replace #21. It fixes the lower-level ownership state that a replicated bench needs before either player can use it normally.

## Authority and compatibility

This deliberately keeps the existing authority and wire model:

- no new network message
- no protocol bump
- no transfer of the host's world authority to the Join
- ownership repair is idempotent and does not replay purchases or cats
- runtime object hands are not persisted as save-stable deed identities

## Validation performed

- patch applies cleanly to main at 5a761e19a4184b42315e96ea7e92e3c1403d54db
- all seven uploaded Git blobs match the locally reviewed files exactly
- source/policy invariants pass
- Wire.h is unchanged
- the official prototype build could not run on this machine because the required Visual C++ 2010 v100 toolchain is not installed
- no two-client in-game session has been run here

## Manual validation requested before ready

- Join places and completes a workbench inside an owned house; Host sees it owned and usable
- repeat Host -> Join
- reconnect / late join
- save and reload
- dismantle the replicated building and verify both peers converge

Draft for maintainer review because the ownership API is engine-sensitive and needs the repository's normal two-client harness before merge.