### PR TITLE
Route join recipe changes through host-authoritative intents

### DIFF
--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -25,7 +25,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 55;
+const u16 PROTOCOL_VERSION = 56;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -76,7 +76,8 @@ enum PacketType {
     PKT_INV_XFER_ACK     = 45,// RELIABLE transfer verdict (protocol 50); InvXferAckPacket
     PKT_MONEY_DELTA      = 46,// RELIABLE join money-pool delta (join -> host, protocol 52); MoneyDeltaPacket
     PKT_DEED             = 47,// RELIABLE property-ownership row (protocol 54); DeedPacket
-    PKT_FIXTURE          = 48 // RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    PKT_FIXTURE          = 48,// RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    PKT_PROD_INTENT      = 49 // RELIABLE recipe intent (join -> host, protocol 56); ProdIntentPacket
 };
 
 // One-shot transition events carried on the RELIABLE channel. Continuous state
@@ -1465,7 +1466,7 @@ struct LoadNackPacket {
     char name[48];    // save name ('\0'-padded)
 };
 
-// ---- Protocol 33: production machine sync ------------------------------------
+// ---- Protocol 33/56: production state + host-validated recipe intent ----------
 // One machine state row, HOST-authoritative (world-simulation precedent: the
 // host's engine is the one whose production/power/farming ticks count; the
 // join's copies are quieted by convergence, not suppression - its machines
@@ -1488,6 +1489,7 @@ struct ProdPacket {
     i8  powerOn;   // 0/1; -1 = unreadable (not applied)
     i8  prodState; // ProductionBuilding::ProductionState; -1 = not carried
     f32 outAmount; // output buffer amount; -1 = not carried
+    u32 outType;     // output GameData::type (0 when outSid is not carried)
     char outSid[48]; // output item template sid ("" = not carried) - lets the
                    // receiver MATERIALIZE a still-null buffer with the same
                    // item via the native setProductionItem lever
@@ -1496,6 +1498,25 @@ struct ProdPacket {
     f32 died;
     f32 growStart;
     f32 harvested; // int on the engine side; carried as f32 (-1 = not a farm)
+    u32 ackOwnerId; // sender whose latest recipe intent this state answers
+    u32 ackSeq;     // 0 = no intent answered; otherwise covers <= this seq
+};
+
+// Join -> host: request a recipe change on one canonical production machine.
+// This is an INTENT, never a second state writer: the host resolves the key,
+// validates the exact GameData identity and that changing recipes cannot discard
+// a non-empty output buffer, applies through setProductionItem, then answers by
+// publishing ProdPacket with ackOwnerId/ackSeq and the resulting canonical state.
+// Reliable ordered delivery plus monotonic seq makes retries idempotent; the join
+// may resend the same seq while waiting for an acknowledgement.
+struct ProdIntentPacket {
+    u8  type;       // = PKT_PROD_INTENT
+    u32 ownerId;    // network player id of the requesting join
+    u32 seq;        // monotonic per-session intent sequence (starts at 1)
+    u8  keyKind;    // same identity scheme as ProdPacket
+    u32 key[5];
+    u32 recipeType; // exact GameData::type of recipeSid
+    char recipeSid[48];
 };
 
 // ---- Protocol 38: research tech-tree sync -------------------------------------

--- a/src/plugin/KenshiCoop.vcxproj
+++ b/src/plugin/KenshiCoop.vcxproj
@@ -201,6 +201,7 @@
     <ClInclude Include="CoopLog.h" />
     <ClInclude Include="core\Config.h" />
     <ClInclude Include="core\Inbound.h" />
+    <ClInclude Include="core\HostIntent.h" />
     <ClInclude Include="net\NetLink.h" />
     <ClInclude Include="net\SteamP2P.h" />
     <ClInclude Include="game\Engine.h" />

--- a/src/plugin/core/HostIntent.h
+++ b/src/plugin/core/HostIntent.h
@@ -1,0 +1,33 @@
+// HostIntent.h - small reusable policy for host-canonical interaction channels.
+// Pure C++03: no game, Win32 or network dependencies, so prototest can lock the
+// idempotency/ack contract before this pattern is reused for doors, cages, etc.
+
+#ifndef COOP_HOST_INTENT_H
+#define COOP_HOST_INTENT_H
+
+namespace coop {
+
+// Sequence 0 is reserved for "none". Reliable ordering handles transport order;
+// this guard makes duplicate retries harmless at the authority.
+inline bool hostIntentIsNew(unsigned int lastSeq, unsigned int incomingSeq) {
+    return incomingSeq != 0u && incomingSeq > lastSeq;
+}
+
+// A canonical state row settles only the pending intent it explicitly answers.
+inline bool hostIntentAckCovers(unsigned int localOwnerId,
+                                unsigned int pendingSeq,
+                                unsigned int ackOwnerId,
+                                unsigned int ackSeq) {
+    return pendingSeq != 0u && ackOwnerId == localOwnerId && ackSeq >= pendingSeq;
+}
+
+// Wall-clock retry backstop. At rest there is no traffic; while an ack is missing
+// the same idempotent intent may be resent after the interval.
+inline bool hostIntentRetryDue(unsigned long nowMs, unsigned long lastSendMs,
+                               unsigned long retryMs) {
+    return lastSendMs == 0ul || (nowMs - lastSendMs) >= retryMs;
+}
+
+} // namespace coop
+
+#endif // COOP_HOST_INTENT_H

--- a/src/plugin/core/Inbound.h
+++ b/src/plugin/core/Inbound.h
@@ -231,6 +231,13 @@ struct InboundProd {
     ProdPacket pkt;
 };
 
+// One received recipe intent (protocol 56): the join asks, the host remains the
+// only machine-state writer and answers through the ordinary ProdPacket stream.
+struct InboundProdIntent {
+    u32              ownerId;
+    ProdIntentPacket pkt;
+};
+
 // One received known-research row (protocol 38): the HOST reports a RESEARCH
 // stringID as known; the join applies via Research::startResearch (idempotent
 // against already-known sids).
@@ -429,6 +436,7 @@ public:
         stats_(worldReset_),      money_(worldReset_),      moneyDelta_(worldReset_),
         faction_(worldReset_),
         time_(worldReset_),       door_(worldReset_),       prod_(worldReset_),
+        prodIntent_(worldReset_),
         research_(worldReset_),   deed_(worldReset_),       fixture_(worldReset_),
         buildPlace_(worldReset_), buildState_(worldReset_),
         buildDoor_(worldReset_),  buildRemove_(worldReset_), stealth_(worldReset_, 512),
@@ -589,6 +597,11 @@ public:
     void pushProd(u32 ownerId, const ProdPacket& pkt) {
         InboundProd ip; ip.ownerId = ownerId; ip.pkt = pkt;
         EnterCriticalSection(&cs_); prod_.push_back(ip); LeaveCriticalSection(&cs_);
+    }
+    // NET thread: one join -> host recipe intent (protocol 56), owner-tagged.
+    void pushProdIntent(u32 ownerId, const ProdIntentPacket& pkt) {
+        InboundProdIntent ip; ip.ownerId = ownerId; ip.pkt = pkt;
+        EnterCriticalSection(&cs_); prodIntent_.push_back(ip); LeaveCriticalSection(&cs_);
     }
     // NET thread: one received known-research row (protocol 38), owner-tagged.
     void pushResearch(u32 ownerId, const ResearchPacket& pkt) {
@@ -760,6 +773,9 @@ public:
     void drainProd(std::deque<InboundProd>& out) {
         EnterCriticalSection(&cs_); out.swap(prod_); LeaveCriticalSection(&cs_);
     }
+    void drainProdIntents(std::deque<InboundProdIntent>& out) {
+        EnterCriticalSection(&cs_); out.swap(prodIntent_); LeaveCriticalSection(&cs_);
+    }
     void drainResearch(std::deque<InboundResearch>& out) {
         EnterCriticalSection(&cs_); out.swap(research_); LeaveCriticalSection(&cs_);
     }
@@ -887,6 +903,7 @@ private:
     WorldQ<InboundTime>            time_;
     WorldQ<InboundDoor>            door_;
     WorldQ<InboundProd>            prod_;
+    WorldQ<InboundProdIntent>      prodIntent_;
     WorldQ<InboundResearch>        research_;
     WorldQ<InboundDeed>            deed_;
     WorldQ<InboundFixture>         fixture_;

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -1954,6 +1954,7 @@ struct ProdRead {
     float miningLevel;    // _resourceMiningLevel (ore drills / mines)
     // output buffer (StorageBuilding::productionItem; sid "" / -1 = no buffer)
     char  outSid[48];     // output item template GameData stringID
+    unsigned int outType; // output item template GameData::type
     float outAmount;      // productionItem->amount (stack + progress toward next)
     int   outCap;         // productionItem->maxCapacity
     // input buffers (ProductionBuilding::consumptionItems, first 2; -1 = absent)
@@ -1978,6 +1979,15 @@ unsigned int enumMachinesNear(GameWorld* gw, float radius, ProdRead* out,
 // SEH-guarded single-machine read by local hand. Returns false when the hand
 // does not resolve locally or is not a machine-class building.
 bool readMachineByHand(const unsigned int mHand[5], ProdRead* out);
+// Apply an exact recipe identity through ProductionBuilding::setProductionItem.
+// requireEmpty=true is the host-validation mode: a different recipe is refused
+// while the canonical output buffer holds any amount, so accepting a remote
+// click can never destroy produced items. amount is stack+progress (negative ->
+// zero). Returns true only when a post-read proves the requested sid+type landed.
+bool writeMachineRecipeByHand(GameWorld* gw, const unsigned int mHand[5],
+                              const char* recipeSid, unsigned int recipeType,
+                              float amount, bool requireEmpty,
+                              ProdRead* outAfter);
 // SEH-guarded machine write through the engine's own levers. All fields are
 // optional (sentinel = leave untouched):
 //   wantPower  - -1 leave, 0/1 switchPowerOn (vtable, the engine's own toggle)

--- a/src/plugin/game/EngineWorld.cpp
+++ b/src/plugin/game/EngineWorld.cpp
@@ -1170,6 +1170,7 @@ static void fillProdRead(Building* b, ProdRead* r) {
             r->outAmount = outBuf->amount;
             r->outCap    = outBuf->maxCapacity;
             if (outBuf->item) {
+                r->outType = (unsigned int)outBuf->item->type;
                 strncpy(r->outSid, outBuf->item->stringID.c_str(),
                         sizeof(r->outSid) - 1);
                 r->outSid[sizeof(r->outSid) - 1] = '\0';
@@ -1184,6 +1185,7 @@ static void fillProdRead(Building* b, ProdRead* r) {
                 ? g_machProdDataCraftFn : g_machProdDataBaseFn;
             GameData* pd = pf ? pf(b) : 0;
             if (pd) {
+                r->outType = (unsigned int)pd->type;
                 strncpy(r->outSid, pd->stringID.c_str(), sizeof(r->outSid) - 1);
                 r->outSid[sizeof(r->outSid) - 1] = '\0';
             }
@@ -1260,6 +1262,47 @@ bool readMachineByHand(const unsigned int mHand[5], ProdRead* out) {
         fillProdRead(b, out);
         return true;
     } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+}
+
+bool writeMachineRecipeByHand(GameWorld* gw, const unsigned int mHand[5],
+                              const char* recipeSid, unsigned int recipeType,
+                              float amount, bool requireEmpty,
+                              ProdRead* outAfter) {
+    if (outAfter) memset(outAfter, 0, sizeof(*outAfter));
+    if (!gw || !mHand || !recipeSid || !recipeSid[0] || !g_machSetProdItemFn)
+        return false;
+    GameData* recipe = findItemTemplateImpl(gw, recipeSid, recipeType);
+    if (!recipe || recipe->stringID != recipeSid ||
+        (unsigned int)recipe->type != recipeType)
+        return false; // exact stable identity only; never fall back by display name
+    RootObject* ro = resolveObjectByHand(mHand);
+    if (!ro) return false;
+    __try {
+        Building* b = static_cast<Building*>(ro);
+        int ct = (int)b->classType;
+        if (!isProductionClassType(ct) || !b->_buildState.isComplete) return false;
+        ProductionBuilding* pb = static_cast<ProductionBuilding*>(b);
+        StorageBuilding::ConsumptionItem* cur = pb->productionItem;
+        bool same = cur && cur->item &&
+                    cur->item->stringID == recipeSid &&
+                    (unsigned int)cur->item->type == recipeType;
+        // Host validation: never replace a different, non-empty canonical
+        // buffer. That would turn a remote UI click into item destruction.
+        if (requireEmpty && !same && cur && cur->amount > 0.005f)
+            return false;
+        float useAmount = amount >= 0.0f ? amount : 0.0f;
+        int stack = (int)useAmount;
+        float progress = useAmount - (float)stack;
+        g_machSetProdItemFn(pb, recipe, stack, progress);
+        ProdRead verify;
+        fillProdRead(b, &verify);
+        if (outAfter) *outAfter = verify;
+        return verify.outType == recipeType &&
+               strcmp(verify.outSid, recipeSid) == 0;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        coop::logLine("[prod] recipe-write SEH-except");
+        return false;
+    }
 }
 
 bool writeMachineByHand(const unsigned int mHand[5], int wantPower,

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -219,6 +219,9 @@ void NetLink::queueTime(const TimePacket& pkt) { pushLocked(outCs_, outTime_, pk
 void NetLink::queueDoor(const DoorPacket& pkt) { pushLocked(outCs_, outDoor_, pkt); }
 
 void NetLink::queueProd(const ProdPacket& pkt) { pushLocked(outCs_, outProd_, pkt); }
+void NetLink::queueProdIntent(const ProdIntentPacket& pkt) {
+    pushLocked(outCs_, outProdIntent_, pkt);
+}
 
 void NetLink::queueResearch(const ResearchPacket& pkt) { pushLocked(outCs_, outResearch_, pkt); }
 
@@ -763,6 +766,15 @@ void NetLink::threadLoop() {
                         if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &pp)
                             && inbound_) {
                             inbound_->pushProd(pp.ownerId, pp);
+                        }
+                    } else if (type == PKT_PROD_INTENT) {
+                        // Reliable idempotent recipe request (protocol 56,
+                        // join -> host). The host validates; this packet never
+                        // writes machine state directly on the receiver thread.
+                        ProdIntentPacket pi;
+                        if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &pi)
+                            && inbound_) {
+                            inbound_->pushProdIntent(pi.ownerId, pi);
                         }
                     } else if (type == PKT_RESEARCH) {
                         // Reliable host-authoritative known-research row
@@ -1468,6 +1480,24 @@ void NetLink::threadLoop() {
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);
             } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
+                enet_peer_send(serverPeer_, CH_RELIABLE, out);
+            } else {
+                enet_packet_destroy(out);
+            }
+        }
+
+        // Drain + send join recipe intents. At rest this vector is empty; while
+        // an acknowledgement is missing the same seq may be retried safely.
+        std::vector<ProdIntentPacket> prodIntentPkts;
+        EnterCriticalSection(&outCs_);
+        prodIntentPkts.swap(outProdIntent_);
+        LeaveCriticalSection(&outCs_);
+        for (size_t i = 0; i < prodIntentPkts.size(); ++i) {
+            ENetPacket* out = enet_packet_create(&prodIntentPkts[i],
+                                                 sizeof(ProdIntentPacket),
+                                                 ENET_PACKET_FLAG_RELIABLE);
+            if (!isHost_ && serverPeer_ &&
+                serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
                 enet_peer_send(serverPeer_, CH_RELIABLE, out);
             } else {
                 enet_packet_destroy(out);

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -131,6 +131,8 @@ public:
     // MAIN thread: queue a reliable host-authoritative machine state row
     // (protocol 33). Change-gated + safety-resent by the caller.
     void queueProd(const ProdPacket& pkt);
+    // MAIN thread: queue a reliable recipe intent (protocol 56, join -> host).
+    void queueProdIntent(const ProdIntentPacket& pkt);
     // MAIN thread: queue a reliable host-authoritative known-research row
     // (protocol 38). First-sight sent + safety-resent by the caller.
     void queueResearch(const ResearchPacket& pkt);
@@ -300,6 +302,7 @@ private:
     std::vector<DoorPacket>      outDoor_;
     // Reliable machine state rows (protocol 33). Guarded by outCs_.
     std::vector<ProdPacket>      outProd_;
+    std::vector<ProdIntentPacket> outProdIntent_;
     // Reliable known-research rows (protocol 38). Guarded by outCs_.
     std::vector<ResearchPacket>  outResearch_;
     // Reliable property-deed ownership rows (protocol 54). Guarded by outCs_.

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -25,6 +25,7 @@
 #include "Interp.h"
 #include "../../netproto/Wire.h"
 #include "../core/Inbound.h"
+#include "../core/HostIntent.h"
 #include "../net/NetLink.h"
 #include "SyncContext.h" // Phase 6: per-tick channel call environment
 #include "SyncTuning.h"  // Phase 6d: owned per-channel send-cadence tunables
@@ -499,6 +500,13 @@ public:
     // drops stale rows; unresolvable keys skip silently (out-of-interest).
     void applyProd(const SyncContext& ctx);
 
+    // Protocol 56 recipe command path. The join detects only a recipe identity
+    // that differs from its last canonical host row and sends an idempotent
+    // intent; the host drains/validates those intents before publishing state.
+    // This keeps one writer while allowing the join to use the crafting UI.
+    void publishProdIntents(const SyncContext& ctx);
+    void applyProdIntents(const SyncContext& ctx);
+
     // Production machine sync master enable (KENSHICOOP_PROD_SYNC).
     void setProdSync(bool v) { prodSync_ = v; }
 
@@ -653,6 +661,7 @@ public:
     // launched state while PRESERVING: the config gates (set* levers), the
     // ownership partition (ownRanks_), and every OUTBOUND sequence counter
     // (facSeqOut_, doorSeqOut_, buildSeqOut_, bdoorSeqOut_, prodSeqOut_,
+    // prodIntentSeqOut_,
     // speedSeqOut_, timeSeqOut_, nextEventId_/netId/dropId/pickupId/treatId)
     // - a peer that
     // did NOT reload keeps its per-sender stale-row guards, so restarting a
@@ -2041,7 +2050,7 @@ private:
     bool          bdoorSync_;
     // Protocol 29: hunger fold-in enable (rides the medical snapshot).
     bool          hungerSync_;
-    // Protocol 33 machine rows, keyed by the WIRE identity (keyKind, key) so
+    // Protocol 33/56 machine rows, keyed by the WIRE identity (keyKind, key) so
     // a baked hand can never collide with a placer key. HOST: lastSend* =
     // the change gate + safety resend (sent = the row went out at least
     // once - first sight sends, see publishProd). JOIN: seqSeen = stale-row
@@ -2050,16 +2059,35 @@ private:
         int knownPower; int knownState;
         int qOut; int qIn0; int qIn1;          // quantized amounts (x100)
         int qGrown; int qDied; int qGrowStart; int qHarv;
+        std::string knownSid; u32 knownType; // last canonical recipe identity
         unsigned long lastSendMs;
-        u32 seqSeen; bool sent;
+        u32 seqSeen; bool sent; bool haveCanonical; bool canonicalRecipeApplied;
+        // Host: latest processed intent answer echoed in ProdPacket. Join:
+        // optimistic request held until that explicit answer covers pendingSeq.
+        u32 ackOwnerId; u32 ackSeq;
+        u32 sentAckOwnerId; u32 sentAckSeq;
+        u32 pendingSeq; u32 pendingType; std::string pendingSid;
+        unsigned long pendingSendMs;
         ProdRow() : knownPower(-2), knownState(-2), qOut(-200), qIn0(-200),
                     qIn1(-200), qGrown(-200), qDied(-200), qGrowStart(-200),
-                    qHarv(-200), lastSendMs(0), seqSeen(0), sent(false) {}
+                    qHarv(-200), knownType(0), lastSendMs(0), seqSeen(0),
+                    sent(false), haveCanonical(false), canonicalRecipeApplied(false),
+                    ackOwnerId(0), ackSeq(0), sentAckOwnerId(0), sentAckSeq(0),
+                    pendingSeq(0), pendingType(0), pendingSendMs(0) {}
     };
     std::map<std::pair<int, Key>, ProdRow> prodRows_;
     u32           prodSeqOut_;
     unsigned long prodSampleMs_;
+    u32           prodIntentSeqOut_;
+    unsigned long prodIntentSampleMs_;
     bool          prodSync_;
+    // Translate between a local machine hand and protocol 33's canonical wire
+    // key. The reverse fixture scan is needed for join-authored intents on mines,
+    // whose runtime hands differ even though they are not player-placed builds.
+    void prodWireKeyForLocal(const Key& local, bool reverseFixture,
+                             int& keyKind, Key& wire) const;
+    bool localHandForProdKey(int keyKind, const Key& wire,
+                             unsigned int out[5]) const;
     // Protocol 38 known-research rows, keyed by the RESEARCH stringID (the
     // cross-client-stable wire identity, spike 401). HOST: sent/lastSendMs =
     // first-sight send + safety resend. JOIN: seqSeen = stale-row guard,

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -892,6 +892,57 @@ inline int qProd(float v) {
 }
 } // namespace
 
+void Replicator::prodWireKeyForLocal(const Key& local, bool reverseFixture,
+                                     int& keyKind, Key& wire) const {
+    keyKind = 0; wire = local;
+    if (ownBuilds_.find(local) != ownBuilds_.end()) {
+        keyKind = 1;
+        return;
+    }
+    std::map<Key, Key>::const_iterator mint = mintByLocal_.find(local);
+    if (mint != mintByLocal_.end()) {
+        keyKind = 1; wire = mint->second;
+        return;
+    }
+    if (!reverseFixture) return; // host's raw fixture key is canonical
+    // Runtime terrain fixtures (notably mines) are not protocol-27 builds but
+    // still have different hands. fixtureMap_ is wire(host/peer) -> local, so
+    // reverse it for a join-authored intent.
+    for (std::map<Key, FixtureRow>::const_iterator it = fixtureMap_.begin();
+         it != fixtureMap_.end(); ++it) {
+        if (!it->second.resolved) continue;
+        const unsigned int* h = it->second.hand;
+        if (h[0] == local.t && h[1] == local.c && h[2] == local.cs &&
+            h[3] == local.i && h[4] == local.s) {
+            wire = it->first;
+            return;
+        }
+    }
+}
+
+bool Replicator::localHandForProdKey(int keyKind, const Key& wire,
+                                     unsigned int out[5]) const {
+    if (!out) return false;
+    if (keyKind == 0) {
+        if (localHandForFixtureKey(wire, out)) return true;
+        out[0] = wire.t; out[1] = wire.c; out[2] = wire.cs;
+        out[3] = wire.i; out[4] = wire.s;
+        return true;
+    }
+    if (keyKind != 1) return false;
+    std::map<Key, OwnBuild>::const_iterator ob = ownBuilds_.find(wire);
+    if (ob != ownBuilds_.end()) {
+        if (ob->second.removed) return false;
+        memcpy(out, ob->second.hand, sizeof(unsigned int) * 5);
+        return true;
+    }
+    std::map<Key, PeerBuild>::const_iterator pb = peerBuilds_.find(wire);
+    if (pb == peerBuilds_.end() || pb->second.minted != 1 || pb->second.removed)
+        return false;
+    memcpy(out, pb->second.localHand, sizeof(unsigned int) * 5);
+    return true;
+}
+
 void Replicator::publishProd(const SyncContext& ctx) {
     GameWorld* gw = ctx.gw; NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
     if (!prodSync_) return;
@@ -912,13 +963,8 @@ void Replicator::publishProd(const SyncContext& ctx) {
         // key (our own placement keys by OUR hand; a minted proxy of the
         // join's placement translates through the reverse map). Everything
         // else is a BAKED machine with a save-stable hand.
-        int keyKind = 0; Key wk = lk;
-        if (ownBuilds_.find(lk) != ownBuilds_.end()) {
-            keyKind = 1;
-        } else {
-            std::map<Key, Key>::iterator mit = mintByLocal_.find(lk);
-            if (mit != mintByLocal_.end()) { keyKind = 1; wk = mit->second; }
-        }
+        int keyKind = 0; Key wk;
+        prodWireKeyForLocal(lk, /*reverseFixture*/false, keyKind, wk);
         ProdRow& pr = prodRows_[std::make_pair(keyKind, wk)];
         int qOut = qProd(r.outAmount);
         int qIn0 = qProd(r.nInputs > 0 ? r.inAmount[0] : -1.0f);
@@ -926,6 +972,9 @@ void Replicator::publishProd(const SyncContext& ctx) {
         int qGr  = qProd(r.grown), qDi = qProd(r.died);
         int qGs  = qProd(r.growStart), qHv = qProd((float)r.harvested);
         bool changed = !pr.sent ||
+                       pr.knownType != r.outType || pr.knownSid != r.outSid ||
+                       pr.sentAckOwnerId != pr.ackOwnerId ||
+                       pr.sentAckSeq != pr.ackSeq ||
                        r.powerOn != pr.knownPower ||
                        r.productionState != pr.knownState ||
                        qOut != pr.qOut || qIn0 != pr.qIn0 || qIn1 != pr.qIn1 ||
@@ -939,6 +988,8 @@ void Replicator::publishProd(const SyncContext& ctx) {
         bool first = !pr.sent;
         pr.sent = true; pr.lastSendMs = now;
         pr.knownPower = r.powerOn; pr.knownState = r.productionState;
+        pr.knownType = r.outType; pr.knownSid = r.outSid;
+        pr.haveCanonical = true; pr.canonicalRecipeApplied = true;
         pr.qOut = qOut; pr.qIn0 = qIn0; pr.qIn1 = qIn1;
         pr.qGrown = qGr; pr.qDied = qDi; pr.qGrowStart = qGs; pr.qHarv = qHv;
         ProdPacket pkt;
@@ -953,12 +1004,17 @@ void Replicator::publishProd(const SyncContext& ctx) {
         pkt.powerOn   = (i8)r.powerOn;
         pkt.prodState = (i8)r.productionState;
         pkt.outAmount = r.outAmount;
+        pkt.outType   = r.outType;
         strncpy(pkt.outSid, r.outSid, sizeof(pkt.outSid) - 1);
         pkt.outSid[sizeof(pkt.outSid) - 1] = '\0';
         pkt.inAmount[0] = (r.nInputs > 0) ? r.inAmount[0] : -1.0f;
         pkt.inAmount[1] = (r.nInputs > 1) ? r.inAmount[1] : -1.0f;
         pkt.grown = r.grown; pkt.died = r.died; pkt.growStart = r.growStart;
         pkt.harvested = (float)r.harvested;
+        pkt.ackOwnerId = pr.ackOwnerId;
+        pkt.ackSeq     = pr.ackSeq;
+        pr.sentAckOwnerId = pr.ackOwnerId;
+        pr.sentAckSeq = pr.ackSeq;
         net.queueProd(pkt);
         if (changed) { // resends stay silent; the change is the signal
             char b[256];
@@ -975,6 +1031,116 @@ void Replicator::publishProd(const SyncContext& ctx) {
     }
 }
 
+void Replicator::publishProdIntents(const SyncContext& ctx) {
+    if (!prodSync_ || ctx.isHost) return;
+    const unsigned long SAMPLE_MS = 200; // UI response; change-gated, no idle wire traffic
+    const unsigned long RETRY_MS  = 2000;
+    unsigned long now = nowMs();
+    if (!sync::gateSampleDue(now, prodIntentSampleMs_, SAMPLE_MS)) return;
+    prodIntentSampleMs_ = now;
+
+    const unsigned int MAX_MACH = 48;
+    static engine::ProdRead rows[MAX_MACH];
+    unsigned int n = engine::enumMachinesNear(ctx.gw, 100.0f, rows, MAX_MACH);
+    for (unsigned int i = 0; i < n; ++i) {
+        const engine::ProdRead& r = rows[i];
+        if (!r.outSid[0]) continue; // no exact recipe identity to request
+        Key local; local.t = r.hand[0]; local.c = r.hand[1]; local.cs = r.hand[2];
+        local.i = r.hand[3]; local.s = r.hand[4];
+        int keyKind = 0; Key wire;
+        prodWireKeyForLocal(local, /*reverseFixture*/true, keyKind, wire);
+        ProdRow& pr = prodRows_[std::make_pair(keyKind, wire)];
+        if (!pr.haveCanonical) continue; // never turn first sight into a command
+        if (!pr.canonicalRecipeApplied && pr.pendingSeq == 0)
+            continue; // a failed host-state apply is not a local UI click
+
+        bool sameCanonical = pr.knownType == r.outType && pr.knownSid == r.outSid;
+        bool samePending = pr.pendingSeq != 0 &&
+                           pr.pendingType == r.outType && pr.pendingSid == r.outSid;
+        bool isNewChoice = pr.pendingSeq == 0 ? !sameCanonical : !samePending;
+        if (!isNewChoice && pr.pendingSeq == 0) continue;
+        if (!isNewChoice &&
+            !hostIntentRetryDue(now, pr.pendingSendMs, RETRY_MS))
+            continue;
+
+        if (isNewChoice) {
+            pr.pendingSeq = prodIntentSeqOut_++;
+            pr.pendingType = r.outType;
+            pr.pendingSid = r.outSid;
+        }
+        ProdIntentPacket pkt;
+        memset(&pkt, 0, sizeof(pkt));
+        pkt.type = (u8)PKT_PROD_INTENT;
+        pkt.ownerId = ctx.localId;
+        pkt.seq = pr.pendingSeq;
+        pkt.keyKind = (u8)keyKind;
+        pkt.key[0] = wire.t; pkt.key[1] = wire.c; pkt.key[2] = wire.cs;
+        pkt.key[3] = wire.i; pkt.key[4] = wire.s;
+        pkt.recipeType = pr.pendingType;
+        strncpy(pkt.recipeSid, pr.pendingSid.c_str(), sizeof(pkt.recipeSid) - 1);
+        pr.pendingSendMs = now;
+        ctx.net->queueProdIntent(pkt);
+        char b[224];
+        _snprintf(b, sizeof(b) - 1,
+                  "[prod] INTENT SEND key=%u.%u.%u.%u.%u kind=%d recipe='%s' "
+                  "type=%u seq=%u retry=%d",
+                  wire.t, wire.c, wire.cs, wire.i, wire.s, keyKind,
+                  pkt.recipeSid, pkt.recipeType, pkt.seq, isNewChoice ? 0 : 1);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
+}
+
+void Replicator::applyProdIntents(const SyncContext& ctx) {
+    std::deque<InboundProdIntent> got;
+    ctx.in->drainProdIntents(got);
+    if (got.empty() || !prodSync_ || !ctx.isHost) return;
+    for (std::deque<InboundProdIntent>::iterator it = got.begin();
+         it != got.end(); ++it) {
+        const ProdIntentPacket& p = it->pkt;
+        char sid[sizeof(p.recipeSid)];
+        memcpy(sid, p.recipeSid, sizeof(sid)); sid[sizeof(sid) - 1] = '\0';
+        if (p.keyKind > 1 || p.seq == 0 || !sid[0]) continue;
+        Key wire; wire.t = p.key[0]; wire.c = p.key[1]; wire.cs = p.key[2];
+        wire.i = p.key[3]; wire.s = p.key[4];
+        ProdRow& pr = prodRows_[std::make_pair((int)p.keyKind, wire)];
+
+        // A repeated reliable request is a request for the ACK, not a second
+        // mutation. Force the canonical row out again and do nothing else.
+        if (pr.ackOwnerId == p.ownerId &&
+            !hostIntentIsNew(pr.ackSeq, p.seq)) {
+            pr.sentAckOwnerId = 0; pr.sentAckSeq = 0; prodSampleMs_ = 0;
+            continue;
+        }
+        unsigned int hand[5];
+        if (!localHandForProdKey((int)p.keyKind, wire, hand))
+            continue; // defer: the join retries if/when the machine is loaded
+        engine::ProdRead cur;
+        if (!engine::readMachineByHand(hand, &cur) || !cur.complete)
+            continue;
+        bool same = cur.outType == p.recipeType && strcmp(cur.outSid, sid) == 0;
+        bool ok = same;
+        engine::ProdRead after;
+        if (!same)
+            ok = engine::writeMachineRecipeByHand(ctx.gw, hand, sid, p.recipeType,
+                                                   0.0f, /*requireEmpty*/true,
+                                                   &after);
+
+        // Accept and reject are both final verdicts. Echoing the ack beside the
+        // actual state lets the join distinguish "not processed yet" from a
+        // validated rejection and roll back through the normal state path.
+        pr.ackOwnerId = p.ownerId; pr.ackSeq = p.seq;
+        prodSampleMs_ = 0; // ack fields make the verdict publish this tick
+        char b[224];
+        _snprintf(b, sizeof(b) - 1,
+                  "[prod] INTENT %s key=%u.%u.%u.%u.%u kind=%u recipe='%s' "
+                  "type=%u old='%s' amount=%.3f seq=%u",
+                  ok ? "ACCEPT" : "REJECT", wire.t, wire.c, wire.cs, wire.i,
+                  wire.s, (unsigned)p.keyKind, sid, p.recipeType, cur.outSid,
+                  cur.outAmount, p.seq);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
+}
+
 void Replicator::applyProd(const SyncContext& ctx) {
     Inbound& in = *ctx.in;
     std::deque<InboundProd> got;
@@ -988,31 +1154,23 @@ void Replicator::applyProd(const SyncContext& ctx) {
         ProdRow& pr = prodRows_[std::make_pair((int)p.keyKind, wk)];
         if (!sync::gateSeqAccept(pr.seqSeen, p.seq)) continue; // stale/dup row
         pr.seqSeen = p.seq;
+        char canonicalSid[sizeof(p.outSid)];
+        memcpy(canonicalSid, p.outSid, sizeof(canonicalSid));
+        canonicalSid[sizeof(canonicalSid) - 1] = '\0';
+        bool settled = hostIntentAckCovers(ctx.localId, pr.pendingSeq,
+                                           p.ackOwnerId, p.ackSeq);
+        if (settled) {
+            pr.pendingSeq = 0; pr.pendingType = 0; pr.pendingSid.clear();
+            pr.pendingSendMs = 0;
+        }
+        bool holdRecipe = pr.pendingSeq != 0; // do not bounce an unacked UI click
+        pr.knownType = p.outType; pr.knownSid = canonicalSid;
+        pr.haveCanonical = true;
         // Resolve the wire key to OUR machine's hand: baked hands resolve
         // directly; a placer key is either a building WE placed (our own
         // hand) or one we MINTED for the host's placement (translation map).
         unsigned int hand[5];
-        if (p.keyKind == 0) {
-            // A baked hand resolves directly, but a MINE's does not: it is a
-            // per-client instance for a terrain node, so the host's key names
-            // nothing here and every buffer row for it used to be dropped -
-            // the "mine inventory does not sync" half of the report. Prefer the
-            // protocol-55 pairing, fall back to the raw hand.
-            if (!localHandForFixtureKey(wk, hand))
-                for (unsigned int h = 0; h < 5; ++h) hand[h] = p.key[h];
-        } else {
-            std::map<Key, OwnBuild>::iterator ob = ownBuilds_.find(wk);
-            if (ob != ownBuilds_.end()) {
-                if (ob->second.removed) continue;
-                memcpy(hand, ob->second.hand, sizeof(hand));
-            } else {
-                std::map<Key, PeerBuild>::iterator pb = peerBuilds_.find(wk);
-                if (pb == peerBuilds_.end() || pb->second.minted != 1 ||
-                    pb->second.removed)
-                    continue; // unknown / refused / tombstoned key
-                memcpy(hand, pb->second.localHand, sizeof(hand));
-            }
-        }
+        if (!localHandForProdKey((int)p.keyKind, wk, hand)) continue;
         engine::ProdRead cur;
         if (!engine::readMachineByHand(hand, &cur))
             continue; // out-of-interest / not resolvable here - accepted edge
@@ -1022,8 +1180,26 @@ void Replicator::applyProd(const SyncContext& ctx) {
         int wantPower = -1;
         if (p.powerOn >= 0 && cur.powerOn >= 0 && (int)p.powerOn != cur.powerOn)
             wantPower = (int)p.powerOn;
+        // Recipe identity is part of canonical state in v56. Apply it before
+        // the amount write, except while our own request is still unacknowledged.
+        bool recipeDiff = canonicalSid[0] &&
+                          (cur.outType != p.outType || strcmp(cur.outSid, canonicalSid) != 0);
+        bool needMaterialize = canonicalSid[0] && p.outAmount >= 0.0f &&
+                               cur.outAmount < 0.0f;
+        if (!holdRecipe && (recipeDiff || needMaterialize)) {
+            engine::ProdRead recipeAfter;
+            if (engine::writeMachineRecipeByHand(ctx.gw, hand, canonicalSid,
+                                                  p.outType, p.outAmount,
+                                                  /*requireEmpty*/false,
+                                                  &recipeAfter))
+                cur = recipeAfter;
+        }
+        bool recipeConverged = !canonicalSid[0] ||
+                               (cur.outType == p.outType &&
+                                strcmp(cur.outSid, canonicalSid) == 0);
+        pr.canonicalRecipeApplied = recipeConverged;
         float outWant = -1.0f;
-        if (p.outAmount >= 0.0f &&
+        if (!holdRecipe && recipeConverged && p.outAmount >= 0.0f &&
             qProd(p.outAmount) != qProd(cur.outAmount >= 0.0f ? cur.outAmount : 0.0f))
             outWant = p.outAmount;
         float inWant[2] = { -1.0f, -1.0f };
@@ -1050,9 +1226,9 @@ void Replicator::applyProd(const SyncContext& ctx) {
         // proven materializing lever), then land the exact amount directly
         // (setProductionItem splits stack into inventory; the direct write
         // is what makes the buffer byte-match the host's).
-        if (outWant >= 0.0f && cur.outAmount < 0.0f)
-            engine::writeMachineByHand(hand, -1, outWant, /*useSetItem*/true,
-                                       0, 0, 0);
+        if (outWant >= 0.0f && cur.outAmount < 0.0f && canonicalSid[0])
+            engine::writeMachineRecipeByHand(ctx.gw, hand, canonicalSid, p.outType,
+                                              outWant, /*requireEmpty*/false, 0);
         engine::ProdRead after;
         bool ok = engine::writeMachineByHand(hand, wantPower, outWant,
                                              /*useSetItem*/false,
@@ -1757,6 +1933,13 @@ void Replicator::driveSampledChannels(const SyncContext& ctx) {
         { &Replicator::researchSync_, 0,                     &Replicator::publishResearch,   &Replicator::applyResearch,   true  },
         { &Replicator::deedSync_,     0,                     &Replicator::publishDeeds,      &Replicator::applyDeeds,      false }
     };
+    // Protocol 56 command path brackets the ordinary host-authoritative state
+    // row: join observes its UI choice before an older host row can reconcile it;
+    // host validates queued intents before it samples/publishes canonical state.
+    if (prodSync_) {
+        if (ctx.isHost) applyProdIntents(ctx);
+        else            publishProdIntents(ctx);
+    }
     const int n = (int)(sizeof(kCh) / sizeof(kCh[0]));
     for (int i = 0; i < n; ++i) {
         const Desc& d = kCh[i];

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -85,7 +85,8 @@ Replicator::Replicator()
       buildSeqOut_(1), buildSampleMs_(0), buildSync_(true),
       bdoorSeqOut_(1), bdoorSampleMs_(0), bdoorSync_(true),
       hungerSync_(true),
-      prodSeqOut_(1), prodSampleMs_(0), prodSync_(true),
+      prodSeqOut_(1), prodSampleMs_(0), prodIntentSeqOut_(1),
+      prodIntentSampleMs_(0), prodSync_(true),
       researchSeqOut_(1), researchSampleMs_(0), researchSync_(true),
       deedSeqOut_(1), deedSampleMs_(0), deedAuditMs_(0), deedSync_(true),
       fixtureSeqOut_(1), fixtureSampleMs_(0), fixtureSync_(true),
@@ -321,6 +322,7 @@ void Replicator::resetSession() {
     // Sample-cadence clocks restart.
     facSampleMs_ = doorSampleMs_ = buildSampleMs_ = bdoorSampleMs_ = 0;
     prodSampleMs_ = 0;
+    prodIntentSampleMs_ = 0;
     researchSampleMs_ = 0;
     deedSampleMs_ = 0;
     deedAuditMs_ = 0;

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -31,6 +31,7 @@
 #include "../plugin/core/WorkPose.h"
 #include "../plugin/core/DeathLatch.h"
 #include "../plugin/core/Inbound.h" // Phase 0 queue-lifecycle fixes (header-only)
+#include "../plugin/core/HostIntent.h" // protocol 56 reusable intent/ack policy
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
@@ -113,7 +114,8 @@ static void testSizes() {
     CHECK_EQ("sizeof(LoadGoPacket)",            sizeof(LoadGoPacket),            61);
     CHECK_EQ("sizeof(LoadReqPacket)",           sizeof(LoadReqPacket),           57);
     CHECK_EQ("sizeof(LoadNackPacket)",          sizeof(LoadNackPacket),          61);
-    CHECK_EQ("sizeof(ProdPacket)",              sizeof(ProdPacket),              109);
+    CHECK_EQ("sizeof(ProdPacket)",              sizeof(ProdPacket),              121);
+    CHECK_EQ("sizeof(ProdIntentPacket)",        sizeof(ProdIntentPacket),         82);
     CHECK_EQ("sizeof(NpcCensusHeader)",         sizeof(NpcCensusHeader),         7); // v35: census
     CHECK_EQ("sizeof(ResearchPacket)",          sizeof(ResearchPacket),          57); // v37: research
     CHECK_EQ("sizeof(DeedPacket)",              sizeof(DeedPacket),              78); // v54: deeds
@@ -310,8 +312,10 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v55: runtime-fixture identity)",
-             (int)PROTOCOL_VERSION, 55);
+    CHECK_EQ("PROTOCOL_VERSION (v56: host-validated production intents)",
+             (int)PROTOCOL_VERSION, 56);
+    CHECK("PKT_PROD_INTENT distinct", (int)PKT_PROD_INTENT == 49 &&
+          PKT_PROD_INTENT != PKT_PROD && PKT_PROD_INTENT != PKT_FIXTURE);
 
     // Protocol 52: the shared money pool. The two players spend from ONE wallet,
     // so the join reports CHANGES and the host the authoritative TOTAL - swap
@@ -492,6 +496,7 @@ static void testRoundTrips() {
     roundTrip<LoadReqPacket>("LoadReqPacket", (u8)PKT_LOAD_REQ);
     roundTrip<LoadNackPacket>("LoadNackPacket", (u8)PKT_LOAD_NACK);
     roundTrip<ProdPacket>("ProdPacket", (u8)PKT_PROD);
+    roundTrip<ProdIntentPacket>("ProdIntentPacket", (u8)PKT_PROD_INTENT);
     roundTrip<ResearchPacket>("ResearchPacket", (u8)PKT_RESEARCH);
     roundTrip<DeedPacket>("DeedPacket", (u8)PKT_DEED);
     roundTrip<FixturePacket>("FixturePacket", (u8)PKT_FIXTURE);
@@ -1379,6 +1384,7 @@ static void testFlushWorldStateContract() {
     TimePacket      ti;  std::memset(&ti,  0, sizeof(ti));
     DoorPacket      dp;  std::memset(&dp,  0, sizeof(dp));
     ProdPacket      pr;  std::memset(&pr,  0, sizeof(pr));
+    ProdIntentPacket pri; std::memset(&pri, 0, sizeof(pri));
     ResearchPacket  rp;  std::memset(&rp,  0, sizeof(rp));
     DeedPacket      de;  std::memset(&de,  0, sizeof(de));
     FixturePacket   fx;  std::memset(&fx,  0, sizeof(fx));
@@ -1402,7 +1408,7 @@ static void testFlushWorldStateContract() {
     LoadReqPacket   lrq; std::memset(&lrq, 0, sizeof(lrq));
     LoadNackPacket  lnk; std::memset(&lnk, 0, sizeof(lnk));
 
-    // --- Push one sentinel into every WORLD-STATE queue (34).
+    // --- Push one sentinel into every WORLD-STATE queue (35).
     in.pushEntity(1, 0, e);
     in.pushEvent(1, ev);
     in.pushInv(1, 0, cKey, 0, 0);
@@ -1424,6 +1430,7 @@ static void testFlushWorldStateContract() {
     in.pushTime(1, ti);
     in.pushDoor(1, dp);
     in.pushProd(1, pr);
+    in.pushProdIntent(1, pri);
     in.pushResearch(1, rp);
     in.pushDeed(1, de);
     in.pushFixture(1, fx);
@@ -1477,6 +1484,7 @@ static void testFlushWorldStateContract() {
     WS_EMPTY("time",        InboundTime,        drainTime);
     WS_EMPTY("door",        InboundDoor,        drainDoor);
     WS_EMPTY("prod",        InboundProd,        drainProd);
+    WS_EMPTY("prodIntent",  InboundProdIntent,  drainProdIntents);
     WS_EMPTY("research",    InboundResearch,    drainResearch);
     WS_EMPTY("deed",        InboundDeed,        drainDeed);
     WS_EMPTY("fixture",     InboundFixture,     drainFixture);
@@ -1766,6 +1774,33 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- 15. Reusable host-intent contract (protocol 56) ---------------------------
+static void testHostIntentPolicy() {
+    std::printf("== host-canonical intent policy ==\n");
+    CHECK("intent sequence starts at one", hostIntentIsNew(0u, 1u));
+    CHECK("intent duplicate is idempotent", !hostIntentIsNew(7u, 7u));
+    CHECK("intent older row is stale", !hostIntentIsNew(7u, 6u));
+    CHECK("intent newer row accepted", hostIntentIsNew(7u, 8u));
+    CHECK("intent zero is reserved", !hostIntentIsNew(0u, 0u));
+
+    CHECK("ack settles matching owner+seq",
+          hostIntentAckCovers(22u, 5u, 22u, 5u));
+    CHECK("later ack covers pending",
+          hostIntentAckCovers(22u, 5u, 22u, 6u));
+    CHECK("other owner's ack cannot settle",
+          !hostIntentAckCovers(22u, 5u, 23u, 99u));
+    CHECK("older ack cannot settle",
+          !hostIntentAckCovers(22u, 5u, 22u, 4u));
+    CHECK("no pending intent cannot settle",
+          !hostIntentAckCovers(22u, 0u, 22u, 9u));
+
+    CHECK("intent first send due", hostIntentRetryDue(1000ul, 0ul, 2000ul));
+    CHECK("intent retry held before deadline",
+          !hostIntentRetryDue(2999ul, 1000ul, 2000ul));
+    CHECK("intent retry due at deadline",
+          hostIntentRetryDue(3000ul, 1000ul, 2000ul));
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1774,6 +1809,7 @@ int main() {
     testEngineFaults();
     testEngineCaps();
     testChangeGate();
+    testHostIntentPolicy();
     testRoundTrips();
     testFraming();
     testSaveCrc();


### PR DESCRIPTION
## Summary

This keeps the Host as the single production authority while allowing the Join to select a crafting recipe:

Join changes recipe locally -> reliable idempotent intent -> Host resolves and validates -> Host applies through `setProductionItem` -> Host publishes canonical state plus acknowledgement.

Unlike #21, this does not transfer full machine authority to the player who placed it. It is intentionally the first application of a reusable host-intent pattern for other shared-world interactions.

## What changes

- make the exact recipe identity (`outSid` + `outType`) part of production change detection and application
- add `PKT_PROD_INTENT` (protocol 56) with per-session sequence IDs
- add explicit acknowledgement fields to the canonical `ProdPacket`
- hold an unacknowledged Join choice so an older Host row does not visibly bounce it
- retry only while acknowledgement is missing; duplicate requests are idempotent
- reject recipe changes that would replace a different non-empty canonical output buffer
- reuse placed-building and runtime-fixture key translation
- add pure host-intent policy tests and wire/queue coverage

At rest this adds no network traffic. The Join samples at 200 ms and sends one 82-byte reliable intent only on a choice, with a 2 s same-sequence retry while awaiting acknowledgement.

## Relation to existing work

Issue #13 reports inconsistent workstation state and points to #21. PR #21 makes session-placed machines placer-authoritative and also changes research authority. This draft proposes the other architecture: the Host remains the only machine-state writer and the Join submits commands. It can be reviewed as an alternative to the production portion of #21, while research remains separate.

## Validation

- `git diff --check` passes
- exact remote/local blob identity verified for all 12 changed files
- packed layout verified: `ProdPacket=121`, `ProdIntentPacket=82`
- prototest updated for protocol 56, packet roundtrip/size, queue-reset coverage, and sequence/ack/retry policy
- not run: `prototest.exe` / plugin build (Visual C++ 2010 v100 `cl.exe` is unavailable here)
- not run: two-client Kenshi scenario

## Review focus

1. Is the Host-canonical intent direction preferred over #21's placer-authority model?
2. Is exact `GameData` identity plus the native setter and non-empty-output rejection the right validation boundary?
3. Should this generic sequence/ack/retry policy become the common pattern for doors, cages, construction, containers, purchases, and research?

Refs #13. Alternative to the production portion of #21.