### PR TITLE
Route join door and lock changes through host-authoritative intents

### DIFF
--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -25,7 +25,10 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 55;
+// v56 / packet 49 are reserved by sibling PR #75 (production intents). This
+// branch is the next independently-reviewable step in that series; after #75
+// lands it rebases without renumbering the door contract below.
+const u16 PROTOCOL_VERSION = 57;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -76,7 +79,9 @@ enum PacketType {
     PKT_INV_XFER_ACK     = 45,// RELIABLE transfer verdict (protocol 50); InvXferAckPacket
     PKT_MONEY_DELTA      = 46,// RELIABLE join money-pool delta (join -> host, protocol 52); MoneyDeltaPacket
     PKT_DEED             = 47,// RELIABLE property-ownership row (protocol 54); DeedPacket
-    PKT_FIXTURE          = 48 // RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    PKT_FIXTURE          = 48,// RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    // 49 = PKT_PROD_INTENT in sibling PR #75 (protocol 56), deliberately reserved.
+    PKT_DOOR_INTENT      = 50 // RELIABLE join -> host open/lock request (protocol 57); DoorIntentPacket
 };
 
 // One-shot transition events carried on the RELIABLE channel. Continuous state
@@ -1052,27 +1057,25 @@ struct TimePacket {
     f64 gameHours; // absolute in-game clock, total hours
 };
 
-// ---- Protocol 26: baked-door open/lock state ----------------------------------
+// ---- Protocol 26/57: host-canonical baked-door open/lock state ----------------
 // One door/gate state row, keyed by the door Building's save-stable hand (the
 // furniture/bed identity precedent - door_probe run 160041 confirmed census
-// intersection on the shared save). SYMMETRIC change-gated channel: each
-// client samples doors near its interest centers ~1 Hz, streams rows whose
-// (open, locked) moved vs a seeded per-hand baseline, and applies received
-// rows through the engine's own openDoor/closeDoor/lockDoor/unlockDoor -
-// updating the baseline BEFORE the write, so an applied row is never
-// re-detected as a local change (echo-free). seq is per-sender monotonic so
-// a stale row never overwrites a newer one. open is the collapsed DESTINATION
-// state (OPENING counts as open, CLOSING as closed) so a door mid-swing never
-// publishes a transient. A receiver that cannot resolve the hand skips the
-// row silently (out-of-interest or a runtime-placed door - accepted edge).
+// intersection on the shared save). The HOST is the only state writer. A Join
+// sends DoorIntentPacket when its local UI/engine changes a door, the Host
+// resolves + validates + applies it, then publishes the resulting canonical row
+// with an explicit acknowledgement. seq is Host-monotonic. open is the collapsed
+// DESTINATION state (OPENING counts as open, CLOSING as closed), so a door
+// mid-swing never publishes a transient.
 struct DoorPacket {
     u8  type;      // = PKT_DOOR
-    u32 ownerId;   // network player id of the sender
-    u32 seq;       // per-sender monotonic (stale-row guard)
+    u32 ownerId;   // Host network player id
+    u32 seq;       // Host-monotonic canonical-state sequence
     // door hand [type, container, containerSerial, index, serial]
     u32 hand[5];
     u8  open;      // 1 = open/opening
     u8  locked;    // 1 = DoorLock engaged (only applied when the door has a lock)
+    u32 ackOwnerId;// Join whose latest intent this canonical row answers
+    u32 ackSeq;    // 0 = unsolicited state; otherwise covers <= this intent seq
 };
 
 // ---- Protocol 54: property-deed (building ownership) ------------------------
@@ -1231,18 +1234,35 @@ struct BuildStatePacket {
 // translation identity: the factory mints doors in template order, so
 // (PLACER's building hand, index in Building::doors) names the same physical
 // door on both clients once resolved through the protocol-27 build maps.
-// Symmetric change-gated rows, the protocol-26 door shape on the translated
-// key: both clients sample their placed/minted buildings' doors ~1 Hz and
-// stream rows whose (open, locked) moved vs the seeded baseline; the baseline
-// updates BEFORE the apply write (echo-free); per-sender seq drops stale rows.
+// Host-canonical rows, the protocol-26/57 door shape on the translated key.
+// A Join requests changes with DoorIntentPacket; only the Host publishes state.
 struct BuildDoorPacket {
     u8  type;      // = PKT_BUILD_DOOR
-    u32 ownerId;   // network player id of the sender
-    u32 seq;       // per-sender monotonic (stale-row guard)
+    u32 ownerId;   // Host network player id
+    u32 seq;       // Host-monotonic canonical-state sequence
     u32 bkey[5];   // the PLACER's hand for the owning building (map key)
     u8  doorIndex; // position in the building's ordered doors list
     u8  open;      // 1 = open/opening (collapsed destination state)
     u8  locked;    // 1 = DoorLock engaged (applied only when the door has one)
+    u32 ackOwnerId;// Join whose latest intent this canonical row answers
+    u32 ackSeq;    // 0 = unsolicited state; otherwise covers <= this intent seq
+};
+
+// Protocol 57 Join -> Host request for either door identity. keyKind=0 names a
+// baked door directly by hand; keyKind=1 names a session-placed building plus
+// doorIndex. The request carries a complete desired pair because one local
+// interaction can unlock+open (or close+lock) between 200 ms samples. It is an
+// intent, never a second state writer: the Host validates and replies through
+// DoorPacket/BuildDoorPacket with the actual resulting state and ack fields.
+struct DoorIntentPacket {
+    u8  type;       // = PKT_DOOR_INTENT
+    u32 ownerId;    // requesting Join's network player id
+    u32 seq;        // per-Join monotonic; retries reuse the same seq
+    u8  keyKind;    // 0 = baked door hand, 1 = placed building key + doorIndex
+    u32 key[5];
+    u8  doorIndex;  // ignored for keyKind=0
+    u8  open;       // desired collapsed destination state (0/1)
+    u8  locked;     // desired lock bit (0/1; 1 rejected when no lock exists)
 };
 
 // Placer-authoritative removal of a session-placed building: the dismantle

--- a/src/plugin/KenshiCoop.vcxproj
+++ b/src/plugin/KenshiCoop.vcxproj
@@ -201,6 +201,7 @@
     <ClInclude Include="CoopLog.h" />
     <ClInclude Include="core\Config.h" />
     <ClInclude Include="core\Inbound.h" />
+    <ClInclude Include="core\HostIntent.h" />
     <ClInclude Include="net\NetLink.h" />
     <ClInclude Include="net\SteamP2P.h" />
     <ClInclude Include="game\Engine.h" />

--- a/src/plugin/core/HostIntent.h
+++ b/src/plugin/core/HostIntent.h
@@ -1,0 +1,33 @@
+// HostIntent.h - small reusable policy for host-canonical interaction channels.
+// Pure C++03: no game, Win32 or network dependencies, so prototest can lock the
+// idempotency/ack contract before this pattern is reused for doors, cages, etc.
+
+#ifndef COOP_HOST_INTENT_H
+#define COOP_HOST_INTENT_H
+
+namespace coop {
+
+// Sequence 0 is reserved for "none". Reliable ordering handles transport order;
+// this guard makes duplicate retries harmless at the authority.
+inline bool hostIntentIsNew(unsigned int lastSeq, unsigned int incomingSeq) {
+    return incomingSeq != 0u && incomingSeq > lastSeq;
+}
+
+// A canonical state row settles only the pending intent it explicitly answers.
+inline bool hostIntentAckCovers(unsigned int localOwnerId,
+                                unsigned int pendingSeq,
+                                unsigned int ackOwnerId,
+                                unsigned int ackSeq) {
+    return pendingSeq != 0u && ackOwnerId == localOwnerId && ackSeq >= pendingSeq;
+}
+
+// Wall-clock retry backstop. At rest there is no traffic; while an ack is missing
+// the same idempotent intent may be resent after the interval.
+inline bool hostIntentRetryDue(unsigned long nowMs, unsigned long lastSendMs,
+                               unsigned long retryMs) {
+    return lastSendMs == 0ul || (nowMs - lastSendMs) >= retryMs;
+}
+
+} // namespace coop
+
+#endif // COOP_HOST_INTENT_H

--- a/src/plugin/core/Inbound.h
+++ b/src/plugin/core/Inbound.h
@@ -192,6 +192,13 @@ struct InboundDoor {
     DoorPacket pkt;
 };
 
+// One received Join -> Host door intent (protocol 57). keyKind selects a baked
+// door hand or a placed-building key + door index; only the Host mutates state.
+struct InboundDoorIntent {
+    u32              ownerId;
+    DoorIntentPacket pkt;
+};
+
 // One received placed-building announcement (protocol 27): the sender placed
 // a building; the receiver mints a local construction site and maps the
 // sender's key to its own local hand.
@@ -428,7 +435,8 @@ public:
         speed_(worldReset_),
         stats_(worldReset_),      money_(worldReset_),      moneyDelta_(worldReset_),
         faction_(worldReset_),
-        time_(worldReset_),       door_(worldReset_),       prod_(worldReset_),
+        time_(worldReset_),       door_(worldReset_),       doorIntent_(worldReset_),
+        prod_(worldReset_),
         research_(worldReset_),   deed_(worldReset_),       fixture_(worldReset_),
         buildPlace_(worldReset_), buildState_(worldReset_),
         buildDoor_(worldReset_),  buildRemove_(worldReset_), stealth_(worldReset_, 512),
@@ -584,6 +592,11 @@ public:
     void pushDoor(u32 ownerId, const DoorPacket& pkt) {
         InboundDoor ido; ido.ownerId = ownerId; ido.pkt = pkt;
         EnterCriticalSection(&cs_); door_.push_back(ido); LeaveCriticalSection(&cs_);
+    }
+    // NET thread: one reliable Join -> Host door request (protocol 57).
+    void pushDoorIntent(u32 ownerId, const DoorIntentPacket& pkt) {
+        InboundDoorIntent idi; idi.ownerId = ownerId; idi.pkt = pkt;
+        EnterCriticalSection(&cs_); doorIntent_.push_back(idi); LeaveCriticalSection(&cs_);
     }
     // NET thread: one received machine state row (protocol 33), owner-tagged.
     void pushProd(u32 ownerId, const ProdPacket& pkt) {
@@ -757,6 +770,9 @@ public:
     void drainDoor(std::deque<InboundDoor>& out) {
         EnterCriticalSection(&cs_); out.swap(door_); LeaveCriticalSection(&cs_);
     }
+    void drainDoorIntents(std::deque<InboundDoorIntent>& out) {
+        EnterCriticalSection(&cs_); out.swap(doorIntent_); LeaveCriticalSection(&cs_);
+    }
     void drainProd(std::deque<InboundProd>& out) {
         EnterCriticalSection(&cs_); out.swap(prod_); LeaveCriticalSection(&cs_);
     }
@@ -886,6 +902,7 @@ private:
     WorldQ<InboundFaction>         faction_;
     WorldQ<InboundTime>            time_;
     WorldQ<InboundDoor>            door_;
+    WorldQ<InboundDoorIntent>      doorIntent_;
     WorldQ<InboundProd>            prod_;
     WorldQ<InboundResearch>        research_;
     WorldQ<InboundDeed>            deed_;

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -1744,12 +1744,13 @@ unsigned int enumDoorsNear(GameWorld* gw, float radius, DoorRead* out, unsigned 
 // SEH-guarded single-door read by hand. Returns false when the hand does not
 // resolve locally or is not a door.
 bool readDoorByHand(const unsigned int dHand[5], DoorRead* out);
-// SEH-guarded door write through the engine's own action entries:
-// openDoor/closeDoor (the polite path - animation, navmesh, sound), falling
-// back to _forceDoorOpenUT/_forceDoorClosedUT when the polite call refuses;
-// lockDoor/unlockDoor for the lock bit (skipped when the door has no lock).
-// wantLocked < 0 leaves the lock untouched. Returns false on resolve failure
-// or fault; *outAfter reports the post-write DoorRead when non-null.
+// SEH-guarded door write through the engine's own action entries. Unlock is
+// applied before an open/close request and lock after it, so combined
+// unlock+open / close+lock intents use a coherent order. Polite openDoor/
+// closeDoor runs first (animation, navmesh, sound), with the UT force path only
+// when it refuses. wantLocked < 0 leaves the lock untouched. Returns true only
+// when a post-read proves every requested field converged; *outAfter always
+// reports that post-write state when non-null.
 bool writeDoorByHand(const unsigned int dHand[5], int wantOpen, int wantLocked,
                      DoorRead* outAfter);
 

--- a/src/plugin/game/EngineWorld.cpp
+++ b/src/plugin/game/EngineWorld.cpp
@@ -487,6 +487,15 @@ bool writeDoorByHand(const unsigned int dHand[5], int wantOpen, int wantLocked,
         DoorStuff* d = static_cast<DoorStuff*>(b);
         DoorState st = d->state;
         int curOpen = (st == DOORSTATE_OPEN || st == DOORSTATE_OPENING) ? 1 : 0;
+        int curLocked = (d->doorLock && g_doorIsLockedFn &&
+                         g_doorIsLockedFn(d)) ? 1 : 0;
+        // Combined unlock+open must unlock first; asking a locked door to open
+        // can make the polite path refuse and unnecessarily hit the force path.
+        if (wantLocked == 0 && curLocked && d->doorLock &&
+            g_doorUnlockFn) {
+            g_doorUnlockFn(d);
+            curLocked = 0;
+        }
         if (wantOpen != curOpen) {
             // Polite path first (animation + navmesh + sound - what a local
             // click does); the blunt UT force paths only when it refuses.
@@ -497,13 +506,18 @@ bool writeDoorByHand(const unsigned int dHand[5], int wantOpen, int wantLocked,
             }
         }
         if (wantLocked >= 0 && d->doorLock && g_doorLockFn && g_doorUnlockFn) {
-            int curLocked = (g_doorIsLockedFn && g_doorIsLockedFn(d)) ? 1 : 0;
+            curLocked = (g_doorIsLockedFn && g_doorIsLockedFn(d)) ? 1 : 0;
             if (wantLocked != curLocked) {
                 if (wantLocked) g_doorLockFn(d); else g_doorUnlockFn(d);
             }
         }
-        if (outAfter) fillDoorRead(d, outAfter);
-        return true;
+        DoorRead after;
+        fillDoorRead(d, &after);
+        if (outAfter) *outAfter = after;
+        bool openOk = wantOpen < 0 || after.open == wantOpen;
+        bool lockOk = wantLocked < 0 ||
+                      (after.hasLock && after.locked == wantLocked);
+        return openOk && lockOk;
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         coop::logLine("[door] write SEH-except");
         return false;

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -217,6 +217,9 @@ void NetLink::queueFaction(const FactionPacket& pkt) { pushLocked(outCs_, outFac
 void NetLink::queueTime(const TimePacket& pkt) { pushLocked(outCs_, outTime_, pkt); }
 
 void NetLink::queueDoor(const DoorPacket& pkt) { pushLocked(outCs_, outDoor_, pkt); }
+void NetLink::queueDoorIntent(const DoorIntentPacket& pkt) {
+    pushLocked(outCs_, outDoorIntent_, pkt);
+}
 
 void NetLink::queueProd(const ProdPacket& pkt) { pushLocked(outCs_, outProd_, pkt); }
 
@@ -749,12 +752,20 @@ void NetLink::threadLoop() {
                             inbound_->pushTime(ti.ownerId, ti);
                         }
                     } else if (type == PKT_DOOR) {
-                        // Reliable baked-door state row (protocol 26):
-                        // symmetric change-gated, disambiguated on apply.
+                        // Reliable Host-canonical baked-door state row
+                        // (protocol 26/57).
                         DoorPacket dp;
                         if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &dp)
                             && inbound_) {
                             inbound_->pushDoor(dp.ownerId, dp);
+                        }
+                    } else if (type == PKT_DOOR_INTENT) {
+                        // Reliable idempotent door request (protocol 57,
+                        // Join -> Host). The game thread validates and mutates.
+                        DoorIntentPacket di;
+                        if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &di)
+                            && inbound_) {
+                            inbound_->pushDoorIntent(di.ownerId, di);
                         }
                     } else if (type == PKT_PROD) {
                         // Reliable host-authoritative machine state row
@@ -1434,8 +1445,8 @@ void NetLink::threadLoop() {
             }
         }
 
-        // Drain + send any queued baked-door state rows on CH_RELIABLE
-        // (protocol 26). Change-gated by the Replicator; a settled town is
+        // Drain + send any queued Host-canonical baked-door state rows on
+        // CH_RELIABLE (protocol 26/57). Change-gated by the Replicator; a settled town is
         // silent. A lost row would leave a door diverged until the safety
         // resend, so reliable is the right channel.
         std::vector<DoorPacket> doorPkts;
@@ -1448,6 +1459,24 @@ void NetLink::threadLoop() {
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);
             } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
+                enet_peer_send(serverPeer_, CH_RELIABLE, out);
+            } else {
+                enet_packet_destroy(out);
+            }
+        }
+
+        // Drain + send Join door intents on CH_RELIABLE. This vector is empty
+        // at rest; while an acknowledgement is missing the same seq may retry.
+        std::vector<DoorIntentPacket> doorIntentPkts;
+        EnterCriticalSection(&outCs_);
+        doorIntentPkts.swap(outDoorIntent_);
+        LeaveCriticalSection(&outCs_);
+        for (size_t i = 0; i < doorIntentPkts.size(); ++i) {
+            ENetPacket* out = enet_packet_create(&doorIntentPkts[i],
+                                                 sizeof(DoorIntentPacket),
+                                                 ENET_PACKET_FLAG_RELIABLE);
+            if (!isHost_ && serverPeer_ &&
+                serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
                 enet_peer_send(serverPeer_, CH_RELIABLE, out);
             } else {
                 enet_packet_destroy(out);

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -127,7 +127,10 @@ public:
     void queueMoneyDelta(const MoneyDeltaPacket& pkt);
     void queueFaction(const FactionPacket& pkt);
     void queueTime(const TimePacket& pkt);
+    // MAIN thread: queue a reliable Host-canonical baked-door state row.
     void queueDoor(const DoorPacket& pkt);
+    // MAIN thread: queue a reliable door request (protocol 57, Join -> Host).
+    void queueDoorIntent(const DoorIntentPacket& pkt);
     // MAIN thread: queue a reliable host-authoritative machine state row
     // (protocol 33). Change-gated + safety-resent by the caller.
     void queueProd(const ProdPacket& pkt);
@@ -298,6 +301,7 @@ private:
     std::vector<FactionPacket>   outFaction_;
     std::vector<TimePacket>      outTime_;
     std::vector<DoorPacket>      outDoor_;
+    std::vector<DoorIntentPacket> outDoorIntent_;
     // Reliable machine state rows (protocol 33). Guarded by outCs_.
     std::vector<ProdPacket>      outProd_;
     // Reliable known-research rows (protocol 38). Guarded by outCs_.

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -418,21 +418,21 @@ public:
     // Faction-relation sync master enable (KENSHICOOP_FACTION_SYNC).
     void setFactionSync(bool v) { factionSync_ = v; }
 
-    // BEFORE engine (protocol 26, both clients): sample baked doors near the
-    // interest centers (~1 Hz) and stream every row whose (open, locked)
-    // moved since the seeded per-hand baseline (change-gated reliable,
-    // per-hand safety resend for rows ever sent). Both clients run the same
-    // detector, so a door change replicates from whichever engine it
-    // happened on (a local click, an NPC, or the write applyDoors made).
+    // BEFORE engine (protocol 26/57): Host samples baked doors and publishes
+    // canonical state. Join samples at 200 ms only to detect a local choice and
+    // send an idempotent intent; settled doors produce no wire traffic.
     void publishDoors(const SyncContext& ctx);
 
-    // BEFORE engine (protocol 26): drain received door rows; each one that
-    // resolves locally is applied through the engine's own door actions
-    // (openDoor/closeDoor + lockDoor/unlockDoor). The baseline updates
-    // BEFORE the write (echo-free); stale rows (per-hand seq guard) and
-    // already-converged rows are skipped; unresolvable hands are skipped
-    // silently (out-of-interest or runtime door - accepted edge).
+    // BEFORE engine (Join, protocol 26/57): apply Host-canonical baked-door
+    // rows. While an intent is pending, older Host rows update the canonical
+    // baseline but do not bounce the optimistic local interaction; the explicit
+    // ack settles it and the actual state then wins.
     void applyDoors(const SyncContext& ctx);
+
+    // BEFORE sampled state (Host, protocol 57): validate baked/placed door
+    // intents, apply through native door actions, and immediately publish an
+    // accept/reject acknowledgement beside the actual canonical state.
+    void applyDoorIntents(const SyncContext& ctx);
 
     // Door-state sync master enable (KENSHICOOP_DOOR_SYNC).
     void setDoorSync(bool v) { doorSync_ = v; }
@@ -457,19 +457,16 @@ public:
     // Placed-building sync master enable (KENSHICOOP_BUILD_SYNC).
     void setBuildSync(bool v) { buildSync_ = v; }
 
-    // BEFORE engine (protocol 28, both clients): sample the doors of every
-    // building in the session build maps (~1 Hz) and stream change-gated
-    // PKT_BUILD_DOOR rows on the TRANSLATED identity (placer's building hand
-    // + door index; own placements key by our hand, minted proxies through
-    // the reverse map) - the protocol-26 symmetric door shape, so a placed
-    // door replicates from whichever engine moved it.
+    // BEFORE engine (protocol 28/57): the Host publishes canonical placed-door
+    // rows on the translated identity. The Join uses the same scan only to send
+    // a local open/lock choice as DoorIntentPacket.
     void publishBuildDoors(const SyncContext& ctx);
 
-    // BEFORE engine (protocol 28): drain received placed-door rows; resolve
+    // BEFORE engine (Join, protocol 28/57): drain canonical placed-door rows; resolve
     // the key through the build maps (own hand or minted local hand), read
     // door #index of that building, and apply through the engine's own door
-    // actions. Baseline updates BEFORE the write (echo-free); per-key seq
-    // guard; unknown/tombstoned keys skip silently.
+    // actions. Pending local intents are held until their explicit ack;
+    // unknown/tombstoned keys skip silently.
     void applyBuildDoors(const SyncContext& ctx);
 
     // Placed-building door + removal sync master enable (KENSHICOOP_BDOOR_SYNC).
@@ -1960,15 +1957,19 @@ private:
     u32           facSeqOut_;
     unsigned long facSampleMs_;
     bool          factionSync_;
-    // Protocol 26 door-state sync, per door hand (the faction shape: known =
-    // baseline, updated on every local change sent AND every received row
-    // applied - the echo guard; lastSendMs = change gate + safety resend;
-    // seqSeen = stale-row guard).
+    // Protocol 26/57 baked-door state + intent tracking. known* is the latest
+    // Host-canonical pair. Host uses lastSendMs/intentSeen for state publication
+    // and idempotent request handling; Join uses seqSeen/pending* for canonical
+    // row ordering and one outstanding optimistic request per door.
     struct DoorRow {
         int knownOpen; int knownLocked; unsigned long lastSendMs;
         u32 seqSeen; bool seeded;
+        std::map<u32, u32> intentSeen; // Host: newest request seq per Join
+        u32 pendingSeq; int pendingOpen; int pendingLocked;
+        unsigned long pendingSendMs;
         DoorRow() : knownOpen(-1), knownLocked(-1), lastSendMs(0),
-                    seqSeen(0), seeded(false) {}
+                    seqSeen(0), seeded(false), pendingSeq(0),
+                    pendingOpen(-1), pendingLocked(-1), pendingSendMs(0) {}
     };
     std::map<Key, DoorRow> doorRows_;
     u32           doorSeqOut_;
@@ -2027,13 +2028,17 @@ private:
     u32           buildSeqOut_;
     unsigned long buildSampleMs_;
     bool          buildSync_;
-    // Protocol 28 placed-door rows, keyed by (placer building key, door
-    // index) - the protocol-26 DoorRow shape on the translated identity.
+    // Protocol 28/57 placed-door rows on the translated (building key,index)
+    // identity, with the same canonical/pending contract as DoorRow.
     struct BdoorRow {
         int knownOpen; int knownLocked; unsigned long lastSendMs;
         u32 seqSeen; bool seeded;
+        std::map<u32, u32> intentSeen;
+        u32 pendingSeq; int pendingOpen; int pendingLocked;
+        unsigned long pendingSendMs;
         BdoorRow() : knownOpen(-1), knownLocked(-1), lastSendMs(0),
-                     seqSeen(0), seeded(false) {}
+                     seqSeen(0), seeded(false), pendingSeq(0),
+                     pendingOpen(-1), pendingLocked(-1), pendingSendMs(0) {}
     };
     std::map<std::pair<Key, int>, BdoorRow> bdoorRows_;
     u32           bdoorSeqOut_;

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -11,6 +11,7 @@
 // PowerShell oracles (see resources/CODE_MAP.md, log-tag index).
 
 #include "ReplicatorUtil.h"
+#include "../core/HostIntent.h"
 
 namespace coop {
 
@@ -790,8 +791,11 @@ void Replicator::applyFactions(const SyncContext& ctx) {
 void Replicator::publishDoors(const SyncContext& ctx) {
     GameWorld* gw = ctx.gw; NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
     if (!doorSync_) return;
-    const unsigned long SAMPLE_MS = tuning_.doorSampleMs;  // doors move in clicks; 1 Hz is plenty
+    // The Join samples UI intent quickly; the Host keeps the historical state
+    // census cadence. Both paths remain change-gated and idle at zero packets.
+    const unsigned long SAMPLE_MS = ctx.isHost ? tuning_.doorSampleMs : 200;
     const unsigned long RESEND_MS = tuning_.doorResendMs;  // safety resend for rows we ever sent
+    const unsigned long RETRY_MS  = 2000;
     unsigned long now = nowMs();
     if (!sync::gateSampleDue(now, doorSampleMs_, SAMPLE_MS)) return;
     doorSampleMs_ = now;
@@ -821,6 +825,41 @@ void Replicator::publishDoors(const SyncContext& ctx) {
             continue;
         }
         bool changed = (r.open != dr.knownOpen) || (r.locked != dr.knownLocked);
+        if (!ctx.isHost) {
+            bool samePending = dr.pendingSeq != 0 &&
+                               dr.pendingOpen == r.open &&
+                               dr.pendingLocked == r.locked;
+            bool newChoice = dr.pendingSeq == 0 ? changed : !samePending;
+            if (!newChoice && dr.pendingSeq == 0) continue;
+            if (!newChoice &&
+                !hostIntentRetryDue(now, dr.pendingSendMs, RETRY_MS))
+                continue;
+            if (newChoice) {
+                dr.pendingSeq = doorSeqOut_++;
+                dr.pendingOpen = r.open;
+                dr.pendingLocked = r.locked;
+            }
+            DoorIntentPacket intent;
+            memset(&intent, 0, sizeof(intent));
+            intent.type = (u8)PKT_DOOR_INTENT;
+            intent.ownerId = ownerId;
+            intent.seq = dr.pendingSeq;
+            intent.keyKind = 0;
+            for (unsigned int h = 0; h < 5; ++h) intent.key[h] = r.hand[h];
+            intent.open = (u8)(dr.pendingOpen ? 1 : 0);
+            intent.locked = (u8)(dr.pendingLocked ? 1 : 0);
+            dr.pendingSendMs = now;
+            net.queueDoorIntent(intent);
+            char b[184];
+            _snprintf(b, sizeof(b) - 1,
+                      "[door] INTENT SEND hand=%u.%u.%u.%u.%u open=%u "
+                      "locked=%u seq=%u retry=%d",
+                      intent.key[0], intent.key[1], intent.key[2], intent.key[3],
+                      intent.key[4], intent.open, intent.locked, intent.seq,
+                      newChoice ? 0 : 1);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            continue;
+        }
         // Doors seed their baseline silently above, so a never-sent row holds
         // (resendUnsent = false); only a real change or a post-send safety
         // resend crosses. No burst throttle - the 1 Hz sample gate paces it.
@@ -836,6 +875,8 @@ void Replicator::publishDoors(const SyncContext& ctx) {
         for (unsigned int h = 0; h < 5; ++h) pkt.hand[h] = r.hand[h];
         pkt.open    = (u8)(r.open ? 1 : 0);
         pkt.locked  = (u8)(r.locked ? 1 : 0);
+        pkt.ackOwnerId = 0;
+        pkt.ackSeq = 0;
         net.queueDoor(pkt);
         if (changed) { // resends stay silent; the change is the signal
             char b[160];
@@ -861,10 +902,19 @@ void Replicator::applyDoors(const SyncContext& ctx) {
         DoorRow& dr = doorRows_[k];
         if (!sync::gateSeqAccept(dr.seqSeen, p.seq)) continue; // stale/dup row
         dr.seqSeen = p.seq;
-        // Updating the baseline FIRST is the echo guard: the local change this
-        // write causes must not be re-detected as ours next sample.
+        bool settled = hostIntentAckCovers(ctx.localId, dr.pendingSeq,
+                                           p.ackOwnerId, p.ackSeq);
+        if (settled) {
+            dr.pendingSeq = 0; dr.pendingOpen = dr.pendingLocked = -1;
+            dr.pendingSendMs = 0;
+        }
+        bool hold = dr.pendingSeq != 0;
+        // Always learn the canonical baseline. Until our explicit ack arrives,
+        // keep the optimistic local interaction visible instead of bouncing it
+        // through an older Host row.
         dr.knownOpen = (int)p.open; dr.knownLocked = (int)p.locked;
         dr.seeded = true;
+        if (hold) continue;
         engine::DoorRead cur;
         if (!engine::readDoorByHand(p.hand, &cur))
             continue; // out-of-interest or runtime door - accepted edge
@@ -878,6 +928,105 @@ void Replicator::applyDoors(const SyncContext& ctx) {
                   "[door] RECV hand=%u.%u.%u.%u.%u open=%u locked=%u was=%d/%d ok=%d seq=%u",
                   p.hand[0], p.hand[1], p.hand[2], p.hand[3], p.hand[4],
                   p.open, p.locked, cur.open, cur.locked, ok ? 1 : 0, p.seq);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
+}
+
+void Replicator::applyDoorIntents(const SyncContext& ctx) {
+    std::deque<InboundDoorIntent> got;
+    ctx.in->drainDoorIntents(got);
+    if (got.empty() || !ctx.isHost) return;
+    const unsigned long now = nowMs();
+    for (std::deque<InboundDoorIntent>::iterator it = got.begin();
+         it != got.end(); ++it) {
+        const DoorIntentPacket& p = it->pkt;
+        if (p.seq == 0 || p.ownerId == 0 || p.ownerId == ctx.localId ||
+            p.keyKind > 1)
+            continue;
+        Key k; k.t = p.key[0]; k.c = p.key[1]; k.cs = p.key[2];
+        k.i = p.key[3]; k.s = p.key[4];
+        engine::DoorRead cur;
+        bool resolved = false;
+        if (p.keyKind == 0) {
+            if (!doorSync_) continue;
+            resolved = engine::readDoorByHand(p.key, &cur);
+        } else {
+            if (!buildSync_ || !bdoorSync_ || p.doorIndex >= 4) continue;
+            unsigned int buildHand[5];
+            if (localHandForBuildKey(k, buildHand))
+                resolved = engine::readDoorOfBuilding(buildHand, p.doorIndex, &cur);
+        }
+        if (!resolved) continue; // retry may succeed when the target loads
+
+        bool fresh = false;
+        bool ok = false;
+        engine::DoorRead actual = cur;
+        if (p.keyKind == 0) {
+            DoorRow& row = doorRows_[k];
+            u32& seen = row.intentSeen[p.ownerId];
+            fresh = hostIntentIsNew(seen, p.seq);
+            if (fresh) {
+                seen = p.seq;
+                bool valid = p.open <= 1 && p.locked <= 1 &&
+                             (!p.locked || cur.hasLock);
+                if (valid) {
+                    ok = engine::writeDoorByHand(cur.hand, (int)p.open,
+                                                 cur.hasLock ? (int)p.locked : -1,
+                                                 &actual);
+                    if (!ok && !engine::readDoorByHand(cur.hand, &actual))
+                        actual = cur;
+                }
+            }
+            row.knownOpen = actual.open; row.knownLocked = actual.locked;
+            row.seeded = true; row.lastSendMs = now;
+            DoorPacket state;
+            memset(&state, 0, sizeof(state));
+            state.type = (u8)PKT_DOOR; state.ownerId = ctx.localId;
+            state.seq = doorSeqOut_++;
+            for (unsigned int h = 0; h < 5; ++h) state.hand[h] = actual.hand[h];
+            state.open = (u8)(actual.open ? 1 : 0);
+            state.locked = (u8)(actual.locked ? 1 : 0);
+            state.ackOwnerId = p.ownerId; state.ackSeq = p.seq;
+            ctx.net->queueDoor(state);
+        } else {
+            BdoorRow& row = bdoorRows_[std::make_pair(k, (int)p.doorIndex)];
+            u32& seen = row.intentSeen[p.ownerId];
+            fresh = hostIntentIsNew(seen, p.seq);
+            if (fresh) {
+                seen = p.seq;
+                bool valid = p.open <= 1 && p.locked <= 1 &&
+                             (!p.locked || cur.hasLock);
+                if (valid) {
+                    ok = engine::writeDoorByHand(cur.hand, (int)p.open,
+                                                 cur.hasLock ? (int)p.locked : -1,
+                                                 &actual);
+                    if (!ok && !engine::readDoorByHand(cur.hand, &actual))
+                        actual = cur;
+                }
+            }
+            row.knownOpen = actual.open; row.knownLocked = actual.locked;
+            row.seeded = true; row.lastSendMs = now;
+            BuildDoorPacket state;
+            memset(&state, 0, sizeof(state));
+            state.type = (u8)PKT_BUILD_DOOR; state.ownerId = ctx.localId;
+            state.seq = bdoorSeqOut_++;
+            state.bkey[0] = k.t; state.bkey[1] = k.c; state.bkey[2] = k.cs;
+            state.bkey[3] = k.i; state.bkey[4] = k.s;
+            state.doorIndex = p.doorIndex;
+            state.open = (u8)(actual.open ? 1 : 0);
+            state.locked = (u8)(actual.locked ? 1 : 0);
+            state.ackOwnerId = p.ownerId; state.ackSeq = p.seq;
+            ctx.net->queueBuildDoor(state);
+        }
+        char b[208];
+        _snprintf(b, sizeof(b) - 1,
+                  "[door] INTENT %s kind=%u key=%u.%u.%u.%u.%u idx=%u "
+                  "want=%u/%u actual=%d/%d seq=%u duplicate=%d",
+                  !fresh ? "DUP-ACK" : (ok ? "ACCEPT" : "REJECT"),
+                  (unsigned)p.keyKind,
+                  k.t, k.c, k.cs, k.i, k.s, (unsigned)p.doorIndex,
+                  (unsigned)p.open, (unsigned)p.locked, actual.open,
+                  actual.locked, p.seq, fresh ? 0 : 1);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 }
@@ -1745,11 +1894,21 @@ void Replicator::driveSampledChannels(const SyncContext& ctx) {
         ChFn               apply;
         bool               hostAuth; // true = host publishes / join applies
     };
+    // Protocol 57 command path runs before canonical state sampling: the Join
+    // captures its local interaction promptly, while the Host validates queued
+    // intents before it samples/publishes the resulting door state.
+    if (ctx.isHost) {
+        if (doorSync_ || (buildSync_ && bdoorSync_))
+            applyDoorIntents(ctx);
+    } else {
+        if (doorSync_) publishDoors(ctx);
+        if (buildSync_ && bdoorSync_) publishBuildDoors(ctx);
+    }
     static const Desc kCh[] = {
         { &Replicator::factionSync_,  0,                     &Replicator::publishFactions,   &Replicator::applyFactions,   false },
-        { &Replicator::doorSync_,     0,                     &Replicator::publishDoors,      &Replicator::applyDoors,      false },
+        { &Replicator::doorSync_,     0,                     &Replicator::publishDoors,      &Replicator::applyDoors,      true  },
         { &Replicator::buildSync_,    0,                     &Replicator::publishBuilds,     &Replicator::applyBuilds,     false },
-        { &Replicator::buildSync_,    &Replicator::bdoorSync_, &Replicator::publishBuildDoors, &Replicator::applyBuildDoors, false },
+        { &Replicator::buildSync_,    &Replicator::bdoorSync_, &Replicator::publishBuildDoors, &Replicator::applyBuildDoors, true },
         // Ahead of prod deliberately: prod rows resolve THROUGH the fixture map,
         // so a pairing that arrives this tick is usable by the very next row.
         { &Replicator::fixtureSync_,  0,                     &Replicator::publishFixtures,   &Replicator::applyFixtures,   false },
@@ -1864,8 +2023,9 @@ void Replicator::onPeerConnected(NetLink& net, u32 ownerId) {
 void Replicator::publishBuildDoors(const SyncContext& ctx) {
     NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
     if (!bdoorSync_) return;
-    const unsigned long SAMPLE_MS = tuning_.bdoorSampleMs; // the protocol-26 door cadence
+    const unsigned long SAMPLE_MS = ctx.isHost ? tuning_.bdoorSampleMs : 200;
     const unsigned long RESEND_MS = tuning_.bdoorResendMs; // safety resend for rows ever sent
+    const unsigned long RETRY_MS  = 2000;
     unsigned long now = nowMs();
     if (!sync::gateSampleDue(now, bdoorSampleMs_, SAMPLE_MS)) return;
     bdoorSampleMs_ = now;
@@ -1901,6 +2061,45 @@ void Replicator::publishBuildDoors(const SyncContext& ctx) {
                 }
                 bool changed = (dr.open != row.knownOpen) ||
                                (dr.locked != row.knownLocked);
+                if (!ctx.isHost) {
+                    bool samePending = row.pendingSeq != 0 &&
+                                       row.pendingOpen == dr.open &&
+                                       row.pendingLocked == dr.locked;
+                    bool newChoice = row.pendingSeq == 0 ? changed : !samePending;
+                    if (!newChoice && row.pendingSeq == 0) continue;
+                    if (!newChoice &&
+                        !hostIntentRetryDue(now, row.pendingSendMs, RETRY_MS))
+                        continue;
+                    if (newChoice) {
+                        row.pendingSeq = bdoorSeqOut_++;
+                        row.pendingOpen = dr.open;
+                        row.pendingLocked = dr.locked;
+                    }
+                    DoorIntentPacket intent;
+                    memset(&intent, 0, sizeof(intent));
+                    intent.type = (u8)PKT_DOOR_INTENT;
+                    intent.ownerId = ownerId;
+                    intent.seq = row.pendingSeq;
+                    intent.keyKind = 1;
+                    intent.key[0] = wireKey->t; intent.key[1] = wireKey->c;
+                    intent.key[2] = wireKey->cs; intent.key[3] = wireKey->i;
+                    intent.key[4] = wireKey->s;
+                    intent.doorIndex = (u8)di;
+                    intent.open = (u8)(row.pendingOpen ? 1 : 0);
+                    intent.locked = (u8)(row.pendingLocked ? 1 : 0);
+                    row.pendingSendMs = now;
+                    net.queueDoorIntent(intent);
+                    char b[192];
+                    _snprintf(b, sizeof(b) - 1,
+                              "[bdoor] INTENT SEND key=%u.%u.%u.%u.%u idx=%u "
+                              "open=%u locked=%u seq=%u retry=%d",
+                              intent.key[0], intent.key[1], intent.key[2],
+                              intent.key[3], intent.key[4], intent.doorIndex,
+                              intent.open, intent.locked, intent.seq,
+                              newChoice ? 0 : 1);
+                    b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+                    continue;
+                }
                 // Seeded silently above (resendUnsent=false); like protocol-26
                 // doors, only a real toggle or a post-send resend crosses.
                 if (!sync::gateShouldSend(changed, now, row.lastSendMs,
@@ -1920,6 +2119,8 @@ void Replicator::publishBuildDoors(const SyncContext& ctx) {
                 pkt.doorIndex = (u8)di;
                 pkt.open    = (u8)(dr.open ? 1 : 0);
                 pkt.locked  = (u8)(dr.locked ? 1 : 0);
+                pkt.ackOwnerId = 0;
+                pkt.ackSeq = 0;
                 net.queueBuildDoor(pkt);
                 if (changed) { // resends stay silent; the change is the signal
                     char b[176];
@@ -1958,10 +2159,16 @@ void Replicator::applyBuildDoors(const SyncContext& ctx) {
         BdoorRow& row = bdoorRows_[std::make_pair(k, (int)p.doorIndex)];
         if (!sync::gateSeqAccept(row.seqSeen, p.seq)) continue; // stale/dup row
         row.seqSeen = p.seq;
-        // Updating the baseline FIRST is the echo guard: the local change this
-        // write causes must not be re-detected as ours next sample.
+        bool settled = hostIntentAckCovers(ctx.localId, row.pendingSeq,
+                                           p.ackOwnerId, p.ackSeq);
+        if (settled) {
+            row.pendingSeq = 0; row.pendingOpen = row.pendingLocked = -1;
+            row.pendingSendMs = 0;
+        }
+        bool hold = row.pendingSeq != 0;
         row.knownOpen = (int)p.open; row.knownLocked = (int)p.locked;
         row.seeded = true;
+        if (hold) continue;
         if (!localHand) continue; // unknown/tombstoned key - skip silently
         engine::DoorRead cur;
         if (!engine::readDoorOfBuilding(localHand, p.doorIndex, &cur))

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -31,6 +31,7 @@
 #include "../plugin/core/WorkPose.h"
 #include "../plugin/core/DeathLatch.h"
 #include "../plugin/core/Inbound.h" // Phase 0 queue-lifecycle fixes (header-only)
+#include "../plugin/core/HostIntent.h" // protocol 57 reusable intent/ack policy
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
 #include "../plugin/sync/ChangeGate.h"   // Phase 6: change-gated send/accept policy
@@ -100,10 +101,11 @@ static void testSizes() {
     CHECK_EQ("sizeof(MoneyDeltaPacket)",        sizeof(MoneyDeltaPacket),        13);
     CHECK_EQ("sizeof(FactionPacket)",           sizeof(FactionPacket),           61);
     CHECK_EQ("sizeof(TimePacket)",              sizeof(TimePacket),              17);
-    CHECK_EQ("sizeof(DoorPacket)",              sizeof(DoorPacket),              31);
+    CHECK_EQ("sizeof(DoorPacket)",              sizeof(DoorPacket),              39);
+    CHECK_EQ("sizeof(DoorIntentPacket)",        sizeof(DoorIntentPacket),        33);
     CHECK_EQ("sizeof(BuildPlacePacket)",        sizeof(BuildPlacePacket),        94);
     CHECK_EQ("sizeof(BuildStatePacket)",        sizeof(BuildStatePacket),        34);
-    CHECK_EQ("sizeof(BuildDoorPacket)",         sizeof(BuildDoorPacket),         32);
+    CHECK_EQ("sizeof(BuildDoorPacket)",         sizeof(BuildDoorPacket),         40);
     CHECK_EQ("sizeof(BuildRemovePacket)",       sizeof(BuildRemovePacket),       29);
     CHECK_EQ("sizeof(SaveReqPacket)",           sizeof(SaveReqPacket),           57);
     CHECK_EQ("sizeof(SaveBeginPacket)",         sizeof(SaveBeginPacket),         67);
@@ -310,8 +312,11 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v55: runtime-fixture identity)",
-             (int)PROTOCOL_VERSION, 55);
+    CHECK_EQ("PROTOCOL_VERSION (v57: host-validated door intents)",
+             (int)PROTOCOL_VERSION, 57);
+    CHECK("PKT_DOOR_INTENT reserves series slot 50",
+          (int)PKT_DOOR_INTENT == 50 && PKT_DOOR_INTENT != PKT_DOOR &&
+          PKT_DOOR_INTENT != PKT_BUILD_DOOR && PKT_DOOR_INTENT != PKT_FIXTURE);
 
     // Protocol 52: the shared money pool. The two players spend from ONE wallet,
     // so the join reports CHANGES and the host the authoritative TOTAL - swap
@@ -478,6 +483,7 @@ static void testRoundTrips() {
     roundTrip<FactionPacket>("FactionPacket", (u8)PKT_FACTION);
     roundTrip<TimePacket>("TimePacket", (u8)PKT_TIME);
     roundTrip<DoorPacket>("DoorPacket", (u8)PKT_DOOR);
+    roundTrip<DoorIntentPacket>("DoorIntentPacket", (u8)PKT_DOOR_INTENT);
     roundTrip<BuildPlacePacket>("BuildPlacePacket", (u8)PKT_BUILD_PLACE);
     roundTrip<BuildStatePacket>("BuildStatePacket", (u8)PKT_BUILD_STATE);
     roundTrip<BuildDoorPacket>("BuildDoorPacket", (u8)PKT_BUILD_DOOR);
@@ -1378,6 +1384,7 @@ static void testFlushWorldStateContract() {
     FactionPacket   fa;  std::memset(&fa,  0, sizeof(fa));
     TimePacket      ti;  std::memset(&ti,  0, sizeof(ti));
     DoorPacket      dp;  std::memset(&dp,  0, sizeof(dp));
+    DoorIntentPacket di; std::memset(&di,  0, sizeof(di));
     ProdPacket      pr;  std::memset(&pr,  0, sizeof(pr));
     ResearchPacket  rp;  std::memset(&rp,  0, sizeof(rp));
     DeedPacket      de;  std::memset(&de,  0, sizeof(de));
@@ -1402,7 +1409,7 @@ static void testFlushWorldStateContract() {
     LoadReqPacket   lrq; std::memset(&lrq, 0, sizeof(lrq));
     LoadNackPacket  lnk; std::memset(&lnk, 0, sizeof(lnk));
 
-    // --- Push one sentinel into every WORLD-STATE queue (34).
+    // --- Push one sentinel into every WORLD-STATE queue (35).
     in.pushEntity(1, 0, e);
     in.pushEvent(1, ev);
     in.pushInv(1, 0, cKey, 0, 0);
@@ -1423,6 +1430,7 @@ static void testFlushWorldStateContract() {
     in.pushFaction(1, fa);
     in.pushTime(1, ti);
     in.pushDoor(1, dp);
+    in.pushDoorIntent(1, di);
     in.pushProd(1, pr);
     in.pushResearch(1, rp);
     in.pushDeed(1, de);
@@ -1476,6 +1484,7 @@ static void testFlushWorldStateContract() {
     WS_EMPTY("faction",     InboundFaction,     drainFaction);
     WS_EMPTY("time",        InboundTime,        drainTime);
     WS_EMPTY("door",        InboundDoor,        drainDoor);
+    WS_EMPTY("doorIntent",  InboundDoorIntent,  drainDoorIntents);
     WS_EMPTY("prod",        InboundProd,        drainProd);
     WS_EMPTY("research",    InboundResearch,    drainResearch);
     WS_EMPTY("deed",        InboundDeed,        drainDeed);
@@ -1766,6 +1775,33 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+// ---- Reusable Host-canonical intent contract (protocol 57) --------------------
+static void testHostIntentPolicy() {
+    std::printf("== host-canonical intent policy ==\n");
+    CHECK("intent sequence starts at one", hostIntentIsNew(0u, 1u));
+    CHECK("intent duplicate is idempotent", !hostIntentIsNew(7u, 7u));
+    CHECK("intent older row is stale", !hostIntentIsNew(7u, 6u));
+    CHECK("intent newer row accepted", hostIntentIsNew(7u, 8u));
+    CHECK("intent zero is reserved", !hostIntentIsNew(0u, 0u));
+
+    CHECK("ack settles matching owner+seq",
+          hostIntentAckCovers(22u, 5u, 22u, 5u));
+    CHECK("later ack covers pending",
+          hostIntentAckCovers(22u, 5u, 22u, 6u));
+    CHECK("other owner's ack cannot settle",
+          !hostIntentAckCovers(22u, 5u, 23u, 99u));
+    CHECK("older ack cannot settle",
+          !hostIntentAckCovers(22u, 5u, 22u, 4u));
+    CHECK("no pending intent cannot settle",
+          !hostIntentAckCovers(22u, 0u, 22u, 9u));
+
+    CHECK("intent first send due", hostIntentRetryDue(1000ul, 0ul, 2000ul));
+    CHECK("intent retry held before deadline",
+          !hostIntentRetryDue(2999ul, 1000ul, 2000ul));
+    CHECK("intent retry due at deadline",
+          hostIntentRetryDue(3000ul, 1000ul, 2000ul));
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1774,6 +1810,7 @@ int main() {
     testEngineFaults();
     testEngineCaps();
     testChangeGate();
+    testHostIntentPolicy();
     testRoundTrips();
     testFraming();
     testSaveCrc();


### PR DESCRIPTION
## Summary

- make the Host the sole publisher of canonical door state for both baked doors and session-placed building doors
- have the Join sample local open/close/lock choices at 200 ms and send an idempotent `DoorIntentPacket`; settled doors remain silent
- retry the same request sequence after 2 s until an explicit acknowledgement arrives
- have the Host resolve, validate and apply the request through native door actions, then re-read and broadcast the actual state with an owner-scoped acknowledgement
- keep the Join's optimistic interaction visible until its matching acknowledgement, then let the Host's actual state win

The native write order is deliberately `unlock -> open/close -> lock`, and success is reported only when a post-read proves the requested fields converged.

## Scope

This covers:
- baked doors/gates keyed by their stable door handle
- doors belonging to session-placed buildings, keyed by the existing translated `(placer building key, door index)` identity

It intentionally does not include cages/beds, construction/removal, inventories, recruitment, purchases, or research.

## Protocol and series ordering

This is the second application of the Host-canonical intent pattern introduced in #75.

- #75 reserves protocol 56 / packet 49 for production intents
- this PR uses protocol 57 / packet 50 for door intents
- the numbering is intentionally stable so this branch can be reviewed independently and rebased after #75 without renumbering the door packet; the shared `HostIntent.h` addition should then collapse to the same helper

This is an architectural alternative to the door/build-door portions of #5: once the Host is the only state writer, symmetric per-sender door sequence guards are no longer the arbitration mechanism. The faction-specific fix in #5 remains independent and useful.

Refs #13.

## Transport behavior

- reliable ordered ENet channel
- zero traffic for settled doors
- one complete desired `(open, locked)` pair per local choice
- same-sequence retry after 2 s if no acknowledgement arrives
- per-requester, per-door Host sequence guard makes retries idempotent
- explicit `ackOwnerId` / `ackSeq` fields prevent one Join's acknowledgement from settling another's request

Resolved-but-rejected or non-converging requests return the actual Host state with an acknowledgement. Temporarily unresolved targets remain unacknowledged so the same request can succeed when the target is loaded.

## Validation

Passed:
- `git diff --check`
- packed wire-layout checks: `DoorPacket == 39`, `BuildDoorPacket == 40`, `DoorIntentPacket == 33`
- intent-policy checks for monotonic acceptance, duplicate/older rejection, owner-scoped acknowledgements and the 2 s retry deadline
- packet round-trip/truncation coverage and inbound world-reset coverage added to `prototest`
- patch applies cleanly to the exact upstream base `5a761e19a4184b42315e96ea7e92e3c1403d54db`
- final remote compare is limited to the intended 11 files and every remote blob matches the reviewed upload bytes

Not run in this environment:
- the official Visual C++ 2010 (v100) x64 build, because that compiler/SDK is not installed
- a live Kenshi Host/Join session

## Review focus

- whether `DoorStuff` requires any additional native precondition beyond the chosen unlock/open-or-close/lock ordering
- placed-door key resolution during load/unload edges
- acknowledgement behavior for rejected or temporarily unresolved targets
- protocol/series ordering relative to #75
