### PR TITLE
sync: make bed and cage occupancy host-canonical

### DIFF
--- a/src/netproto/HostIntent.h
+++ b/src/netproto/HostIntent.h
@@ -1,0 +1,26 @@
+// HostIntent.h - reusable sequencing policy for host-canonical interactions.
+// Pure C++03 and dependency-free so prototest can lock the contract.
+
+#ifndef COOP_HOST_INTENT_H
+#define COOP_HOST_INTENT_H
+
+namespace coop {
+
+inline bool hostIntentIsNew(unsigned int lastSeq, unsigned int incomingSeq) {
+    return incomingSeq != 0u && incomingSeq > lastSeq;
+}
+
+inline bool hostIntentAckCovers(unsigned int localOwnerId,
+                                unsigned int pendingSeq,
+                                unsigned int ackOwnerId,
+                                unsigned int ackSeq) {
+    return pendingSeq != 0u && ackOwnerId == localOwnerId && ackSeq >= pendingSeq;
+}
+
+inline bool hostIntentRetryDue(unsigned long nowMs, unsigned long lastSendMs,
+                               unsigned long retryMs) {
+    return lastSendMs == 0ul || (nowMs - lastSendMs) >= retryMs;
+}
+
+} // namespace coop
+#endif

--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -25,7 +25,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 55;
+const u16 PROTOCOL_VERSION = 58;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -76,7 +76,9 @@ enum PacketType {
     PKT_INV_XFER_ACK     = 45,// RELIABLE transfer verdict (protocol 50); InvXferAckPacket
     PKT_MONEY_DELTA      = 46,// RELIABLE join money-pool delta (join -> host, protocol 52); MoneyDeltaPacket
     PKT_DEED             = 47,// RELIABLE property-ownership row (protocol 54); DeedPacket
-    PKT_FIXTURE          = 48 // RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    PKT_FIXTURE          = 48,// RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    // 49 and 50 are reserved by the sibling host-intent PRs (production/doors).
+    PKT_FURNITURE        = 51 // RELIABLE join intent / host-canonical bed+cage row (protocol 58)
 };
 
 // One-shot transition events carried on the RELIABLE channel. Continuous state
@@ -1175,6 +1177,30 @@ struct FixturePacket {
     char sid[48];  // building template GameData stringID - the match guard, so a
                    // wrong-but-nearby building can never be paired
     u8  classType; // BuildingClassType, second match guard
+};
+
+// ---- Protocol 58: host-canonical bed/cage occupancy -------------------------
+// The join sends an INTENT after its local engine performs an enter/exit. The
+// host applies that intent to its canonical copy and broadcasts the resulting
+// STATE with an owner-scoped acknowledgement. Reliable ordered delivery plus
+// monotonic sequences makes retries idempotent. Chained/pole prisoners remain
+// on the protocol-41 path; kind is deliberately restricted to bed(1)/cage(2).
+enum FurnitureWireMode {
+    FURNITURE_INTENT = 0,
+    FURNITURE_STATE  = 1
+};
+
+struct FurniturePacket {
+    u8  type;       // = PKT_FURNITURE
+    u8  mode;       // FurnitureWireMode
+    u8  on;         // desired/actual occupancy (0 exit, 1 enter)
+    u8  kind;       // 1 bed, 2 cage
+    u32 ownerId;    // sender (join for intent, host for canonical state)
+    u32 seq;        // per-sender monotonic sequence
+    u32 occupant[5];// save-stable occupant hand
+    u32 furniture[5];// save-stable bed/cage hand
+    u32 ackOwnerId; // requester whose intent this state acknowledges (0 if none)
+    u32 ackSeq;     // highest folded intent sequence for ackOwnerId
 };
 
 // ---- Protocol 27: placed-building sync --------------------------------------

--- a/src/plugin/KenshiCoop.vcxproj
+++ b/src/plugin/KenshiCoop.vcxproj
@@ -211,6 +211,7 @@
     <ClInclude Include="test\ScenarioTimed.h" />
     <ClInclude Include="test\ScenarioSupport.h" />
     <ClInclude Include="..\netproto\Wire.h" />
+    <ClInclude Include="..\netproto\HostIntent.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -1063,6 +1063,9 @@ void tickReplicatePublish(GameWorld* gw, bool worldLive) {
         // Phase 4a: drain received container-contents snapshots into the per-container
         // cache (reconciled after the engine tick by applyInventories).
         g_repl.ingestInv(g_inbound);
+        // Fold reliable bed/cage intents before the generic event channel. The
+        // Host's canonical decision is therefore visible to publish/drive in this tick.
+        g_repl.applyFurniturePackets(gw, g_inbound, g_net, g_net.localId(), g_cfg.isHost);
         // Both clients latch reliable transition events (KO/death/revive) for the bodies
         // they drive, before apply (a side can emit an event for its own owned body and
         // the peer that drives that body must honour it).

--- a/src/plugin/core/Inbound.h
+++ b/src/plugin/core/Inbound.h
@@ -255,6 +255,12 @@ struct InboundFixture {
     FixturePacket pkt;
 };
 
+// One received bed/cage intent or canonical state row (protocol 58).
+struct InboundFurniture {
+    u32             ownerId;
+    FurniturePacket pkt;
+};
+
 // One received stealth detection-map snapshot (protocol 20): the detection
 // AUTHORITY (the host's world, where the sneaker is a driven copy) streams who
 // notices the sneaker; the sneaker's OWNER replays the entries between its
@@ -430,6 +436,7 @@ public:
         faction_(worldReset_),
         time_(worldReset_),       door_(worldReset_),       prod_(worldReset_),
         research_(worldReset_),   deed_(worldReset_),       fixture_(worldReset_),
+        furniture_(worldReset_),
         buildPlace_(worldReset_), buildState_(worldReset_),
         buildDoor_(worldReset_),  buildRemove_(worldReset_), stealth_(worldReset_, 512),
         spawnReq_(worldReset_),   spawnInfo_(worldReset_),  camHint_(worldReset_, 64),
@@ -605,6 +612,11 @@ public:
         InboundFixture ifx; ifx.ownerId = ownerId; ifx.pkt = pkt;
         EnterCriticalSection(&cs_); fixture_.push_back(ifx); LeaveCriticalSection(&cs_);
     }
+    // NET thread: one received host-canonical furniture row (protocol 58).
+    void pushFurniture(u32 ownerId, const FurniturePacket& pkt) {
+        InboundFurniture ifn; ifn.ownerId = ownerId; ifn.pkt = pkt;
+        EnterCriticalSection(&cs_); furniture_.push_back(ifn); LeaveCriticalSection(&cs_);
+    }
     // NET thread: one received placed-building announcement (protocol 27), owner-tagged.
     void pushBuildPlace(u32 ownerId, const BuildPlacePacket& pkt) {
         InboundBuildPlace ibp; ibp.ownerId = ownerId; ibp.pkt = pkt;
@@ -769,6 +781,9 @@ public:
     void drainFixture(std::deque<InboundFixture>& out) {
         EnterCriticalSection(&cs_); out.swap(fixture_); LeaveCriticalSection(&cs_);
     }
+    void drainFurniture(std::deque<InboundFurniture>& out) {
+        EnterCriticalSection(&cs_); out.swap(furniture_); LeaveCriticalSection(&cs_);
+    }
     void drainBuildPlace(std::deque<InboundBuildPlace>& out) {
         EnterCriticalSection(&cs_); out.swap(buildPlace_); LeaveCriticalSection(&cs_);
     }
@@ -890,6 +905,7 @@ private:
     WorldQ<InboundResearch>        research_;
     WorldQ<InboundDeed>            deed_;
     WorldQ<InboundFixture>         fixture_;
+    WorldQ<InboundFurniture>       furniture_;
     WorldQ<InboundBuildPlace>      buildPlace_;
     WorldQ<InboundBuildState>      buildState_;
     WorldQ<InboundBuildDoor>       buildDoor_;

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -226,6 +226,8 @@ void NetLink::queueDeed(const DeedPacket& pkt) { pushLocked(outCs_, outDeed_, pk
 
 void NetLink::queueFixture(const FixturePacket& pkt) { pushLocked(outCs_, outFixture_, pkt); }
 
+void NetLink::queueFurniture(const FurniturePacket& pkt) { pushLocked(outCs_, outFurniture_, pkt); }
+
 void NetLink::queueBuildPlace(const BuildPlacePacket& pkt) { pushLocked(outCs_, outBuildPlace_, pkt); }
 
 void NetLink::queueBuildState(const BuildStatePacket& pkt) { pushLocked(outCs_, outBuildState_, pkt); }
@@ -787,6 +789,18 @@ void NetLink::threadLoop() {
                         if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &fxp)
                             && inbound_) {
                             inbound_->pushFixture(fxp.ownerId, fxp);
+                        }
+                    } else if (type == PKT_FURNITURE) {
+                        // Reliable join intent / host-canonical bed+cage row (v58).
+                        FurniturePacket fp;
+                        if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &fp)
+                            && inbound_) {
+                            // Unlike legacy owner-tagged rows, intents need the
+                            // transport identity so a payload cannot impersonate
+                            // another owner. The server is always owner 0.
+                            u32 senderId = isHost_
+                                ? (u32)(size_t)ev.peer->data : (u32)0;
+                            inbound_->pushFurniture(senderId, fp);
                         }
                     } else if (type == PKT_BUILD_PLACE) {
                         // Reliable placed-building announcement (protocol 27):
@@ -1523,6 +1537,25 @@ void NetLink::threadLoop() {
         LeaveCriticalSection(&outCs_);
         for (size_t i = 0; i < fixPkts.size(); ++i) {
             ENetPacket* out = enet_packet_create(&fixPkts[i], sizeof(FixturePacket),
+                                                 ENET_PACKET_FLAG_RELIABLE);
+            if (isHost_) {
+                enet_host_broadcast(enetHost_, CH_RELIABLE, out);
+            } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
+                enet_peer_send(serverPeer_, CH_RELIABLE, out);
+            } else {
+                enet_packet_destroy(out);
+            }
+        }
+
+        // Bed/cage intent and canonical state share one reliable ordered shape
+        // (protocol 58). The join sends intents to the server; the host only
+        // queues canonical rows and therefore broadcasts them.
+        std::vector<FurniturePacket> furniturePkts;
+        EnterCriticalSection(&outCs_);
+        furniturePkts.swap(outFurniture_);
+        LeaveCriticalSection(&outCs_);
+        for (size_t i = 0; i < furniturePkts.size(); ++i) {
+            ENetPacket* out = enet_packet_create(&furniturePkts[i], sizeof(FurniturePacket),
                                                  ENET_PACKET_FLAG_RELIABLE);
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -142,6 +142,8 @@ public:
     // Symmetric and static (a fixture's position/template never change), so this
     // is first-sight plus a slow safety resend and idles at zero traffic.
     void queueFixture(const FixturePacket& pkt);
+    // MAIN thread: queue a reliable bed/cage intent or canonical state (v58).
+    void queueFurniture(const FurniturePacket& pkt);
     void queueBuildPlace(const BuildPlacePacket& pkt);
     void queueBuildState(const BuildStatePacket& pkt);
     void queueBuildDoor(const BuildDoorPacket& pkt);
@@ -306,6 +308,7 @@ private:
     std::vector<DeedPacket>      outDeed_;
     // Reliable runtime-fixture identity rows (protocol 55). Guarded by outCs_.
     std::vector<FixturePacket>   outFixture_;
+    std::vector<FurniturePacket> outFurniture_;
     std::vector<BuildPlacePacket> outBuildPlace_;
     std::vector<BuildStatePacket> outBuildState_;
     std::vector<BuildDoorPacket>  outBuildDoor_;

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -147,9 +147,9 @@ public:
     // carried body is released back to the ordinary KO/down channels.
     void sweepCarries(GameWorld* gw);
 
-    // Furniture occupancy sync (protocol 19, default ON): reliable enter/exit
-    // edges + self-healing BODY_IN_BED/BODY_IN_CAGE state, executed engine-
-    // native (setBedMode/setPrisonMode) on each machine's local pair.
+    // Furniture occupancy sync (protocol 58, default ON): Join intent -> Host
+    // canonical state + owner-scoped ack, with BODY_IN_BED/BODY_IN_CAGE as a
+    // self-healing view. Applied engine-native (setBedMode/setPrisonMode).
     // KENSHICOOP_FURN_SYNC=0 disables.
     void setFurnSync(bool v) { furnSync_ = v; }
 
@@ -207,6 +207,12 @@ public:
     // onto the matching tracked body (death = held down permanently; revive clears).
     // gw is needed by the EVT_RECRUIT re-key (restoring a suppressed local body).
     void applyEvents(GameWorld* gw, Inbound& in);
+
+    // BEFORE engine: fold reliable Join bed/cage intents on the Host, or apply
+    // Host-canonical state on the Join. Also records the real role for the
+    // continuous furniture self-heal (streamNpcs_ is not host-only under cells).
+    void applyFurniturePackets(GameWorld* gw, Inbound& in, NetLink& net,
+                               u32 localId, bool isHost);
 
     // BEFORE engine: capture the locally-owned squad and publish it (host side).
     // Also detects per-entity bodyState transitions (KO/death/revive) and queues the
@@ -877,9 +883,6 @@ private:
         unsigned long furnNoSeeTick;  // first tick a locally-occupying copy's stream
                                       //   stopped reporting the occupancy bit (the
                                       //   debounced owner-side-exit detector)
-        // Third-party placement (protocol 36): last time the host authored a
-        // PEER-ENTER for this peer-owned driven body (re-author throttle).
-        unsigned long furnPeerTick;
         // Chained/pole prisoner (protocol 41): the OWNER hand last seen for this
         // body while it was locally chained, so a lost/late reliable ENTER (or
         // an AI break-out) can be self-healed by re-applying setChainedMode -
@@ -956,7 +959,7 @@ private:
                    goalsCleared(false),
                    trusted(false), agreeStreak(0),
                    carryHealTick(0), carryNoSeeTick(0),
-                   furnHealTick(0), furnNoSeeTick(0), furnPeerTick(0),
+                   furnHealTick(0), furnNoSeeTick(0),
                    haveChainOwner(false), chainHealTick(0),
                    sneakTick(0), proneTick(0), crawlDrive(false),
                    velPeak(0.0f), moveSeenMs(0), wasMoving(false),
@@ -1002,7 +1005,8 @@ private:
         // edge exactly once per transition. carried = the carried body's hand
         // (readObjectHand layout), meaningful only while carrying.
         bool carrying; unsigned int carried[5];
-        // Furniture occupancy (protocol 19): last published occupancy of this
+        // Furniture occupancy (protocol 58 for bed/cage; protocol 41 for chain):
+        // last published occupancy of this
         // entity (0 none / 1 bed / 2 cage) + the furniture's hand (captured
         // from the local Character on the ENTER edge), so publishOwned can
         // emit the reliable enter/exit edge exactly once per transition and
@@ -1342,17 +1346,48 @@ private:
     struct JailObs { int kind; float x, y, z; unsigned long ms;
                      JailObs() : kind(0), x(0), y(0), z(0), ms(0) {} };
     std::map<Key, JailObs>    jailObs_;
-    // Third-party furniture placement (protocol 36): ENTER edges detected on
-    // peer-owned driven bodies in applyTargets (a guard jailing an arrested
-    // player runs purely on the host sim, so the occupant's owner can never
-    // author the designed occupant-owner edge). Buffered here because
-    // applyTargets has no NetLink; publishOwned drains them onto the wire.
-    struct PendFurnEnter { Key occ; unsigned int furn[5]; int kind; };
-    std::vector<PendFurnEnter> furnPeerPend_;
-    // When WE last authored an owner-side EXIT for an own hand: an in-flight
-    // (5 s re-author window) PEER-ENTER must not re-jail a body its owner
-    // just freed - the exit-vs-reauthor race guard.
-    std::map<Key, unsigned long> ownFurnExit_;
+    // Host-canonical bed/cage occupancy (protocol 58). One row per occupant is
+    // both the Host's authority ledger and the Join's last accepted Host row.
+    // `pending*` is the Join's optimistic local intent held until an owner-
+    // scoped ack; `apply*` retains a canonical row until the world object loads.
+    struct FurnitureRow {
+        bool seeded, on;
+        int kind;
+        unsigned int furn[5];
+        u32 stateSeqSeen;
+        bool applyPending, applyOn;
+        int applyKind;
+        unsigned int applyFurn[5];
+        u32 pendingSeq;
+        bool pendingOn;
+        int pendingKind;
+        unsigned int pendingFurn[5];
+        unsigned long pendingSendMs;
+        std::map<u32, u32> intentSeen;
+        FurnitureRow()
+            : seeded(false), on(false), kind(0), stateSeqSeen(0),
+              applyPending(false), applyOn(false), applyKind(0),
+              pendingSeq(0), pendingOn(false), pendingKind(0), pendingSendMs(0) {
+            for (int i = 0; i < 5; ++i)
+                furn[i] = applyFurn[i] = pendingFurn[i] = 0;
+        }
+    };
+    std::map<Key, FurnitureRow> furnitureRows_;
+    // applyTargets has no NetLink. Host-only third-party changes (a guard puts
+    // a peer PC in a cage) are queued here and published before the next engine
+    // tick. `on=false` is also supported so removals converge through one path.
+    struct PendFurnState { Key occ; unsigned int furn[5]; int kind; bool on; };
+    std::vector<PendFurnState> furnitureHostPend_;
+    u32 furnitureIntentSeqOut_;
+    u32 furnitureStateSeqOut_;
+    bool hostRole_;
+    void queueFurnitureIntent(NetLink& net, u32 ownerId, const Key& occ,
+                              bool on, int kind, const unsigned int furn[5],
+                              unsigned long now);
+    void queueFurnitureState(NetLink& net, u32 ownerId, const Key& occ,
+                             bool on, int kind, const unsigned int furn[5],
+                             u32 ackOwnerId, u32 ackSeq);
+    Character* characterForFurnitureKey(const Key& occ) const;
     InterpConfig          cfg_;
     float                 catchupK_;  // walk-drive gap-proportional speed gain
     float                 snapDist_;  // moving-body hard-snap distance floor (u)

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -66,6 +66,7 @@ Replicator::Replicator()
       attnFlips_(0), attnWinMs_(0), attnBaseSupp_(0), attnBaseCull_(0),
       attnBaseProxy_(0), attnVetoMs_(0), attnVetoRawN_(0), attnVetoMask_(0),
       auditRows_(false), jailProbe_(false), jailObserve_(false),
+      furnitureIntentSeqOut_(1), furnitureStateSeqOut_(1), hostRole_(false),
       speedLastApplied_(-1.0f), speedMyReq_(-1.0f), speedPeerReq_(-1.0f),
       speedCombatCap_(true),
       speedMyCombat_(false), speedPeerCombat_(false), speedLastSet_(-1.0f),
@@ -236,8 +237,10 @@ void Replicator::resetSession() {
     attnVetoMs_ = 0;
     attnVetoRawN_ = 0;
     attnVetoMask_ = 0;
-    furnPeerPend_.clear();
-    ownFurnExit_.clear();
+    furnitureRows_.clear();
+    furnitureHostPend_.clear();
+    furnitureIntentSeqOut_ = 1;
+    furnitureStateSeqOut_ = 1;
     // Session maps + change-gate baselines (they describe the OLD world; the
     // reloaded save re-seeds them on first sample).
     ownBuilds_.clear();

--- a/src/plugin/sync/ReplicatorDrive.cpp
+++ b/src/plugin/sync/ReplicatorDrive.cpp
@@ -487,7 +487,7 @@ void Replicator::applyTargets(GameWorld* gw) {
                 continue;
             }
         }
-        // ---- Furniture carve-out + self-heal (protocol 19) ----------------------
+        // ---- Furniture carve-out + self-heal (protocols 58 / 41) ----------------
         // A body in a bed/cage (streamed BODY_IN_BED/BODY_IN_CAGE, or LOCALLY
         // occupying - the local placement may lead/trail the stream by a beat) is
         // transform-owned by its furniture attach: the down override and any
@@ -541,19 +541,65 @@ void Replicator::applyTargets(GameWorld* gw) {
             }
         }
         if (furnSync_ && !engine::taskIsBedPose((int)out.task)) {
-            // Chained/pole prisoner (protocol 41) rides this carve-out as
-            // kind=3 (Character::isChained). Gated by chainSync_ so it can be
-            // turned off without disabling bed/cage occupancy.
-            int streamKind = (out.bodyState & BODY_IN_BED) ? 1
-                           : ((out.bodyState & BODY_IN_CAGE) ? 2
-                           : ((chainSync_ && (out.bodyState & BODY_CHAINED)) ? 3 : 0));
             engine::FurnitureRead lfr;
             bool haveFr = engine::readFurniture(c, &lfr);
             int localKind = (haveFr && lfr.valid) ? lfr.kind : 0;
             if (localKind == 3 && !chainSync_) localKind = 0;
+
+            // Protocol 58: on the Host, the continuous owner stream is evidence,
+            // never authority, for bed/cage bits. First fold any real Host-engine
+            // change (including a guard placing/removing a captive), then rebuild
+            // those two bits from the canonical row. This closes the bypass where
+            // a fast Join body packet could undo a reliable Host verdict.
+            u16 furnitureState = out.bodyState;
+            Key furnitureKey = keyOf(out);
+            if (hostRole_) {
+                FurnitureRow& row = furnitureRows_[furnitureKey];
+                int localSeatKind = (localKind == 1 || localKind == 2) ? localKind : 0;
+                if (!row.seeded) {
+                    row.seeded = true; row.on = localSeatKind != 0;
+                    row.kind = localSeatKind;
+                    for (int fi = 0; fi < 5; ++fi)
+                        row.furn[fi] = localSeatKind ? lfr.furn[fi] : 0;
+                } else {
+                    bool changed = (row.on ? row.kind : 0) != localSeatKind;
+                    for (int fi = 0; !changed && localSeatKind && fi < 5; ++fi)
+                        changed = row.furn[fi] != lfr.furn[fi];
+                    if (changed) {
+                        // Host simulation changed the actual attachment. Queue an
+                        // EXIT for the old anchor before an ENTER for a new one so
+                        // even the rare direct cage->bed switch remains applicable.
+                        if (row.on) {
+                            PendFurnState pe;
+                            pe.occ = furnitureKey; pe.on = false; pe.kind = row.kind;
+                            for (int fi = 0; fi < 5; ++fi) pe.furn[fi] = row.furn[fi];
+                            furnitureHostPend_.push_back(pe);
+                        }
+                        if (localSeatKind) {
+                            PendFurnState pe;
+                            pe.occ = furnitureKey; pe.on = true; pe.kind = localSeatKind;
+                            for (int fi = 0; fi < 5; ++fi) pe.furn[fi] = lfr.furn[fi];
+                            furnitureHostPend_.push_back(pe);
+                        }
+                        row.on = localSeatKind != 0; row.kind = localSeatKind;
+                        for (int fi = 0; fi < 5; ++fi)
+                            row.furn[fi] = localSeatKind ? lfr.furn[fi] : 0;
+                    }
+                }
+                furnitureState &= (u16)~(BODY_IN_BED | BODY_IN_CAGE);
+                if (row.on && row.kind == 1) furnitureState |= BODY_IN_BED;
+                if (row.on && row.kind == 2) furnitureState |= BODY_IN_CAGE;
+            }
+            // Chained/pole prisoner (protocol 41) rides this carve-out as
+            // kind=3 (Character::isChained). Gated by chainSync_ so it can be
+            // turned off without disabling bed/cage occupancy.
+            int streamKind = (furnitureState & BODY_IN_BED) ? 1
+                           : ((furnitureState & BODY_IN_CAGE) ? 2
+                           : ((chainSync_ && (furnitureState & BODY_CHAINED)) ? 3 : 0));
             // Jail put-to-work desync spike (KENSHICOOP_JAIL_PROBE, read-only):
             // the DRIVEN view of a peer-owned captive (the host's copy of the
-            // join's jailed PC). streamKind is what the owner reports;
+            // join's jailed PC). On the Join streamKind is what the Host reports;
+            // on the Host it is the canonical row rebuilt above.
             // localKind is where our copy actually sits. A streamKind=2/3 with
             // localKind=0 (or vice-versa) is the twitch. Pairs with side=own.
             if (jailProbe_ && (streamKind != 0 || localKind != 0)) {
@@ -596,7 +642,7 @@ void Replicator::applyTargets(GameWorld* gw) {
             // unified drive owns transform AND task for chained bodies (it
             // AI-suspends driven bodies itself; applyRest reproduces the
             // host's work pose at rest). Cage/bed (kinds 1-2) remain true
-            // transform anchors below - BUT only when the OWNER streams them.
+            // transform anchors below, driven by protocol 58's Host row.
             if (streamKind == 3) {
                 // Unvouched local bed/cage while the owner streams chained-
                 // not-caged (world_parity camp, Flashbox): the host's guards
@@ -739,44 +785,9 @@ void Replicator::applyTargets(GameWorld* gw) {
                     out.hIndex, out.hSerial, ok ? 1 : 0);
                 bfe[sizeof(bfe) - 1] = '\0'; coop::logLine(bfe);
             } else if (localKind != 0) {
-                // Third-party placement authority (protocol 36): a HOST-sim
-                // actor (a guard jailing an arrested player) put this PEER-
-                // OWNED squad body into furniture. The occupant's owner never
-                // sees the action, so the occupant-owner ENTER can't fire -
-                // the owner's stream keeps reporting no bit and the debounced
-                // HEAL EXIT below ejected the body every 3 s ("the host kept
-                // taking it out of the cage", 2026-07-09). The host is the
-                // world authority for NPC actions: author the ENTER for the
-                // owner (buffered; publishOwned sends), HOLD the self-heal
-                // exit while it crosses, and re-author every FURN_PEER_MS
-                // until the owner's stream carries the bit. KO'd/down bodies
-                // only - a conscious voluntary use stays owner-authored, which
-                // (protocol 53) is why the crawlers are excluded by name: a
-                // crippled body reads Character::isDown() while conscious, so
-                // plain bodyIsDown would have us author bed-enters for someone
-                // who crawled past a bed under their own control.
-                bool downish = coop::bodyDownNotCrawling(out.bodyState) ||
-                               d.koLatched || d.deathLatched ||
-                               coop::bodyDownNotCrawling(engine::readBodyState(c));
-                if (streamNpcs_ && isSquad && downish) {
-                    if (d.furnPeerTick == 0 || (now - d.furnPeerTick) >= FURN_PEER_MS) {
-                        d.furnPeerTick = now;
-                        PendFurnEnter pe;
-                        pe.occ = keyOf(out);
-                        for (int fi = 0; fi < 5; ++fi) pe.furn[fi] = lfr.furn[fi];
-                        pe.kind = localKind;
-                        furnPeerPend_.push_back(pe);
-                        char b[160]; _snprintf(b, sizeof(b) - 1,
-                            "[furn] PEER-ENTER author occ=%u,%u furn=%u,%u kind=%d",
-                            out.hIndex, out.hSerial, lfr.furn[3], lfr.furn[4],
-                            localKind);
-                        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
-                    }
-                    d.furnNoSeeTick = 0; // never self-heal-eject a host placement
-                    d.parked = false; d.haveDest = false;
-                    if (haveActual) { d.haveActual = true; d.lx = ax; d.ly = ay; d.lz = az; }
-                    continue;
-                }
+                // Join-only local attachment without a Host row: debounce before
+                // ejecting it. On the Host, real local changes were folded into
+                // the canonical row above and never reach this branch.
                 if (d.furnNoSeeTick == 0) {
                     d.furnNoSeeTick = now;
                 } else if ((now - d.furnNoSeeTick) > FURN_EXIT_MS) {

--- a/src/plugin/sync/ReplicatorPublish.cpp
+++ b/src/plugin/sync/ReplicatorPublish.cpp
@@ -628,8 +628,8 @@ void Replicator::publishOwned(GameWorld* gw, NetLink& net, u32 ownerId) {
                 hb.carried[3] = e.sIndex; hb.carried[4] = e.sSerial;
             }
         }
-        // Furniture occupancy (protocol 19): emit reliable enter/exit edges on
-        // BODY_IN_BED/BODY_IN_CAGE transitions, same authorship scope as carry
+        // Furniture occupancy: protocol 58 sends Join intent / Host canonical
+        // state on BODY_IN_BED/BODY_IN_CAGE transitions, same scope as carry
         // (owned members + host-streamed world NPCs). The furniture HAND is not
         // in the stream (an unconscious occupant has no task subject), so it is
         // read off the LOCAL character (inWhat) at the ENTER edge and remembered
@@ -637,7 +637,14 @@ void Replicator::publishOwned(GameWorld* gw, NetLink& net, u32 ownerId) {
         // poses (USE_BED / USE_BED_ORDER / SLEEP_ON_FLOOR): those stream their
         // TASK and the peer's copy walks in via the validated L3 fixture-pose
         // path (bed_pose) - an ENTER event would teleport it in and fight that.
-        if (furnSync_ && carryAuthor && !engine::taskIsBedPose((int)e.task)) {
+        const Key furnitureOccKey = keyOf(e);
+        std::map<Key, FurnitureRow>::iterator furnitureRowIt =
+            furnitureRows_.find(furnitureOccKey);
+        bool furnitureCorrectionPending = !hostRole_ &&
+            furnitureRowIt != furnitureRows_.end() &&
+            furnitureRowIt->second.applyPending;
+        if (furnSync_ && carryAuthor && !furnitureCorrectionPending &&
+            !engine::taskIsBedPose((int)e.task)) {
             // Chained/pole prisoner (protocol 41) rides this pipeline as kind=3
             // (readFurniture puts the OWNER hand in fr.furn). Gated by chainSync_
             // so it can be disabled without losing bed/cage sync.
@@ -645,29 +652,38 @@ void Replicator::publishOwned(GameWorld* gw, NetLink& net, u32 ownerId) {
                           ((cur & BODY_IN_CAGE) ? 2 :
                           ((chainSync_ && (cur & BODY_CHAINED)) ? 3 : 0));
             if (curKind != hb.furnKind) {
+                const Key& occKey = furnitureOccKey;
                 if (hb.furnKind != 0) {
-                    // Exit edge: subject = occupant, actor = the remembered furniture.
-                    EventPacket ev; memset(&ev, 0, sizeof(ev));
-                    ev.type = (u8)PKT_EVENT; ev.event = (u8)EVT_EXIT_FURNITURE;
-                    ev.ownerId = ownerId;    ev.eventId = nextEventId_++;
-                    ev.sType = e.hType; ev.sContainer = e.hContainer;
-                    ev.sContainerSerial = e.hContainerSerial;
-                    ev.sIndex = e.hIndex; ev.sSerial = e.hSerial;
-                    ev.aType = hb.furn[0]; ev.aContainer = hb.furn[1];
-                    ev.aContainerSerial = hb.furn[2];
-                    ev.aIndex = hb.furn[3]; ev.aSerial = hb.furn[4];
-                    ev.arg = (f32)hb.furnKind;
-                    net.queueEvent(ev);
-                    char b[176]; _snprintf(b, sizeof(b) - 1,
-                        "[furn] SEND EXIT id=%u occ=%u,%u furn=%u,%u kind=%d",
-                        ev.eventId, e.hIndex, e.hSerial, hb.furn[3], hb.furn[4],
-                        hb.furnKind);
-                    b[sizeof(b) - 1] = '\0'; coop::logLine(b);
-                    // Protocol 36 race guard: a stale in-flight PEER-ENTER
-                    // must not re-jail this body right after we freed it.
-                    ownFurnExit_[keyOf(e)] = nowPub;
+                    if (hb.furnKind == 1 || hb.furnKind == 2) {
+                        // Protocol 58: the Host publishes fact; the Join asks.
+                        if (hostRole_)
+                            queueFurnitureState(net, ownerId, occKey, false,
+                                                hb.furnKind, hb.furn, 0, 0);
+                        else
+                            queueFurnitureIntent(net, ownerId, occKey, false,
+                                                 hb.furnKind, hb.furn, nowPub);
+                    } else {
+                        // Chained/pole prisoners remain on protocol 41's reliable
+                        // event path, independent of the bed/cage authority change.
+                        EventPacket ev; memset(&ev, 0, sizeof(ev));
+                        ev.type = (u8)PKT_EVENT; ev.event = (u8)EVT_EXIT_FURNITURE;
+                        ev.ownerId = ownerId; ev.eventId = nextEventId_++;
+                        ev.sType = e.hType; ev.sContainer = e.hContainer;
+                        ev.sContainerSerial = e.hContainerSerial;
+                        ev.sIndex = e.hIndex; ev.sSerial = e.hSerial;
+                        ev.aType = hb.furn[0]; ev.aContainer = hb.furn[1];
+                        ev.aContainerSerial = hb.furn[2];
+                        ev.aIndex = hb.furn[3]; ev.aSerial = hb.furn[4];
+                        ev.arg = (f32)hb.furnKind;
+                        net.queueEvent(ev);
+                        char b[176]; _snprintf(b, sizeof(b) - 1,
+                            "[furn] SEND EXIT id=%u occ=%u,%u furn=%u,%u kind=%d",
+                            ev.eventId, e.hIndex, e.hSerial, hb.furn[3], hb.furn[4],
+                            hb.furnKind);
+                        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+                    }
                     hb.furnKind = 0;
-                    hb.furn[0] = hb.furn[1] = hb.furn[2] = hb.furn[3] = hb.furn[4] = 0;
+                    for (int fi = 0; fi < 5; ++fi) hb.furn[fi] = 0;
                 }
                 if (curKind != 0) {
                     // Enter edge: the local occupant knows WHICH furniture (inWhat).
@@ -677,24 +693,33 @@ void Replicator::publishOwned(GameWorld* gw, NetLink& net, u32 ownerId) {
                     Character* oc = engine::resolve(e);
                     if (oc && engine::readFurniture(oc, &fr) && fr.valid &&
                         fr.kind == curKind) {
-                        EventPacket ev; memset(&ev, 0, sizeof(ev));
-                        ev.type = (u8)PKT_EVENT; ev.event = (u8)EVT_ENTER_FURNITURE;
-                        ev.ownerId = ownerId;    ev.eventId = nextEventId_++;
-                        ev.sType = e.hType; ev.sContainer = e.hContainer;
-                        ev.sContainerSerial = e.hContainerSerial;
-                        ev.sIndex = e.hIndex; ev.sSerial = e.hSerial;
-                        ev.aType = fr.furn[0]; ev.aContainer = fr.furn[1];
-                        ev.aContainerSerial = fr.furn[2];
-                        ev.aIndex = fr.furn[3]; ev.aSerial = fr.furn[4];
-                        ev.arg = (f32)curKind;
-                        net.queueEvent(ev);
+                        if (curKind == 1 || curKind == 2) {
+                            if (hostRole_)
+                                queueFurnitureState(net, ownerId, occKey, true,
+                                                    curKind, fr.furn, 0, 0);
+                            else
+                                queueFurnitureIntent(net, ownerId, occKey, true,
+                                                     curKind, fr.furn, nowPub);
+                        } else {
+                            EventPacket ev; memset(&ev, 0, sizeof(ev));
+                            ev.type = (u8)PKT_EVENT; ev.event = (u8)EVT_ENTER_FURNITURE;
+                            ev.ownerId = ownerId; ev.eventId = nextEventId_++;
+                            ev.sType = e.hType; ev.sContainer = e.hContainer;
+                            ev.sContainerSerial = e.hContainerSerial;
+                            ev.sIndex = e.hIndex; ev.sSerial = e.hSerial;
+                            ev.aType = fr.furn[0]; ev.aContainer = fr.furn[1];
+                            ev.aContainerSerial = fr.furn[2];
+                            ev.aIndex = fr.furn[3]; ev.aSerial = fr.furn[4];
+                            ev.arg = (f32)curKind;
+                            net.queueEvent(ev);
+                            char b[176]; _snprintf(b, sizeof(b) - 1,
+                                "[furn] SEND ENTER id=%u occ=%u,%u furn=%u,%u kind=%d",
+                                ev.eventId, e.hIndex, e.hSerial, fr.furn[3], fr.furn[4],
+                                curKind);
+                            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+                        }
                         hb.furnKind = curKind;
                         for (int fi = 0; fi < 5; ++fi) hb.furn[fi] = fr.furn[fi];
-                        char b[176]; _snprintf(b, sizeof(b) - 1,
-                            "[furn] SEND ENTER id=%u occ=%u,%u furn=%u,%u kind=%d",
-                            ev.eventId, e.hIndex, e.hSerial, fr.furn[3], fr.furn[4],
-                            curKind);
-                        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
                     }
                 }
             }
@@ -754,48 +779,57 @@ void Replicator::publishOwned(GameWorld* gw, NetLink& net, u32 ownerId) {
             if (bufKeys2.find(hit->first) != bufKeys2.end()) continue;
             if (nowPub - hb.seenMs < FURN_GONE_MS) continue;
             const Key& ok = hit->first;
-            EventPacket ev; memset(&ev, 0, sizeof(ev));
-            ev.type = (u8)PKT_EVENT; ev.event = (u8)EVT_EXIT_FURNITURE;
-            ev.ownerId = ownerId;    ev.eventId = nextEventId_++;
-            ev.sType = ok.t; ev.sContainer = ok.c; ev.sContainerSerial = ok.cs;
-            ev.sIndex = ok.i; ev.sSerial = ok.s;
-            ev.aType = hb.furn[0]; ev.aContainer = hb.furn[1];
-            ev.aContainerSerial = hb.furn[2];
-            ev.aIndex = hb.furn[3]; ev.aSerial = hb.furn[4];
-            ev.arg = (f32)hb.furnKind;
-            net.queueEvent(ev);
-            char b[176]; _snprintf(b, sizeof(b) - 1,
-                "[furn] SEND EXIT id=%u occ=%u,%u furn=%u,%u kind=%d (occupant left stream)",
-                ev.eventId, ok.i, ok.s, hb.furn[3], hb.furn[4], hb.furnKind);
-            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            if (hb.furnKind == 1 || hb.furnKind == 2) {
+                if (hostRole_)
+                    queueFurnitureState(net, ownerId, ok, false, hb.furnKind,
+                                        hb.furn, 0, 0);
+                else
+                    queueFurnitureIntent(net, ownerId, ok, false, hb.furnKind,
+                                         hb.furn, nowPub);
+            } else {
+                EventPacket ev; memset(&ev, 0, sizeof(ev));
+                ev.type = (u8)PKT_EVENT; ev.event = (u8)EVT_EXIT_FURNITURE;
+                ev.ownerId = ownerId; ev.eventId = nextEventId_++;
+                ev.sType = ok.t; ev.sContainer = ok.c; ev.sContainerSerial = ok.cs;
+                ev.sIndex = ok.i; ev.sSerial = ok.s;
+                ev.aType = hb.furn[0]; ev.aContainer = hb.furn[1];
+                ev.aContainerSerial = hb.furn[2];
+                ev.aIndex = hb.furn[3]; ev.aSerial = hb.furn[4];
+                ev.arg = (f32)hb.furnKind;
+                net.queueEvent(ev);
+                char b[176]; _snprintf(b, sizeof(b) - 1,
+                    "[furn] SEND EXIT id=%u occ=%u,%u furn=%u,%u kind=%d (occupant left stream)",
+                    ev.eventId, ok.i, ok.s, hb.furn[3], hb.furn[4], hb.furnKind);
+                b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            }
             hb.furnKind = 0;
             hb.furn[0] = hb.furn[1] = hb.furn[2] = hb.furn[3] = hb.furn[4] = 0;
         }
     }
 
-    // Third-party placement edges (protocol 36): drain the PEER-ENTER events
-    // applyTargets detected on peer-owned driven bodies (host = world
-    // authority; the occupant's owner applies them to its own KO'd body).
-    if (furnSync_ && !furnPeerPend_.empty()) {
-        for (unsigned int pi = 0; pi < furnPeerPend_.size(); ++pi) {
-            const PendFurnEnter& pe = furnPeerPend_[pi];
-            EventPacket ev; memset(&ev, 0, sizeof(ev));
-            ev.type = (u8)PKT_EVENT; ev.event = (u8)EVT_ENTER_FURNITURE;
-            ev.ownerId = ownerId;    ev.eventId = nextEventId_++;
-            ev.sType = pe.occ.t; ev.sContainer = pe.occ.c;
-            ev.sContainerSerial = pe.occ.cs;
-            ev.sIndex = pe.occ.i; ev.sSerial = pe.occ.s;
-            ev.aType = pe.furn[0]; ev.aContainer = pe.furn[1];
-            ev.aContainerSerial = pe.furn[2];
-            ev.aIndex = pe.furn[3]; ev.aSerial = pe.furn[4];
-            ev.arg = (f32)pe.kind;
-            net.queueEvent(ev);
-            char b[176]; _snprintf(b, sizeof(b) - 1,
-                "[furn] SEND PEER-ENTER id=%u occ=%u,%u furn=%u,%u kind=%d",
-                ev.eventId, pe.occ.i, pe.occ.s, pe.furn[3], pe.furn[4], pe.kind);
-            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    // Host-only engine changes on a peer-owned captive (for example a guard
+    // jailing it) join the same canonical state stream as accepted intents.
+    if (furnSync_ && hostRole_ && !furnitureHostPend_.empty()) {
+        for (unsigned int pi = 0; pi < furnitureHostPend_.size(); ++pi) {
+            const PendFurnState& pe = furnitureHostPend_[pi];
+            queueFurnitureState(net, ownerId, pe.occ, pe.on, pe.kind,
+                                pe.furn, 0, 0);
         }
-        furnPeerPend_.clear();
+        furnitureHostPend_.clear();
+    }
+
+    // A Join retries the SAME sequence until an owner-scoped Host ack covers
+    // it. At rest this loop sends nothing; packet loss costs at most two seconds.
+    if (furnSync_ && !hostRole_) {
+        const unsigned long FURN_INTENT_RETRY_MS = 2000;
+        for (std::map<Key, FurnitureRow>::iterator fi = furnitureRows_.begin();
+             fi != furnitureRows_.end(); ++fi) {
+            FurnitureRow& row = fi->second;
+            if (row.pendingSeq == 0 || !hostIntentRetryDue(
+                    nowPub, row.pendingSendMs, FURN_INTENT_RETRY_MS)) continue;
+            queueFurnitureIntent(net, ownerId, fi->first, row.pendingOn,
+                                 row.pendingKind, row.pendingFurn, nowPub);
+        }
     }
     // Age out entities that left the interest set long ago (step 6): an unbounded
     // hostBody_ leaks a session's worth of passers-by. 60 s is far beyond any

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -820,6 +820,9 @@ void Replicator::applyFurniturePackets(GameWorld* gw, Inbound& in, NetLink& net,
     localId_ = localId;
     std::deque<InboundFurniture> got;
     in.drainFurniture(got);
+    // Preserve the existing A/B escape hatch: disabled means discard the
+    // channel, not merely stop publishing while received rows still mutate.
+    if (!furnSync_) return;
     for (std::deque<InboundFurniture>::iterator it = got.begin(); it != got.end(); ++it) {
         const FurniturePacket& fp = it->pkt;
         if (fp.ownerId != it->ownerId || fp.on > 1 ||

--- a/src/plugin/sync/ReplicatorSpawn.cpp
+++ b/src/plugin/sync/ReplicatorSpawn.cpp
@@ -743,6 +743,192 @@ bool Replicator::pickMintedProxyNear(GameWorld* gw, const unsigned int refHand[5
     return true;
 }
 
+Character* Replicator::characterForFurnitureKey(const Key& occ) const {
+    Character* c = engine::resolveCharByHand(occ.i, occ.s, occ.t, occ.c, occ.cs);
+    if (c) return c;
+    std::map<Key, Character*>::const_iterator pi = proxyByKey_.find(occ);
+    if (pi != proxyByKey_.end()) return pi->second;
+    // A driven save-native body can be re-keyed by the engine after recruitment
+    // or combat. canonicalOf_ is the authoritative wire-key -> local-body bridge.
+    for (std::map<Character*, Key>::const_iterator ci = canonicalOf_.begin();
+         ci != canonicalOf_.end(); ++ci) {
+        if (!(ci->second < occ) && !(occ < ci->second)) return ci->first;
+    }
+    return 0;
+}
+
+void Replicator::queueFurnitureIntent(NetLink& net, u32 ownerId, const Key& occ,
+                                      bool on, int kind,
+                                      const unsigned int furn[5],
+                                      unsigned long now) {
+    if (kind != 1 && kind != 2) return;
+    FurnitureRow& row = furnitureRows_[occ];
+    bool same = row.pendingSeq != 0 && row.pendingOn == on &&
+                row.pendingKind == kind;
+    for (int i = 0; same && i < 5; ++i) same = row.pendingFurn[i] == furn[i];
+    if (!same) {
+        row.pendingSeq = furnitureIntentSeqOut_++;
+        if (row.pendingSeq == 0) row.pendingSeq = furnitureIntentSeqOut_++;
+        row.pendingOn = on;
+        row.pendingKind = kind;
+        for (int i = 0; i < 5; ++i) row.pendingFurn[i] = furn[i];
+    }
+
+    FurniturePacket fp; memset(&fp, 0, sizeof(fp));
+    fp.type = (u8)PKT_FURNITURE; fp.mode = (u8)FURNITURE_INTENT;
+    fp.on = on ? 1 : 0; fp.kind = (u8)kind;
+    fp.ownerId = ownerId; fp.seq = row.pendingSeq;
+    fp.occupant[0] = occ.t; fp.occupant[1] = occ.c; fp.occupant[2] = occ.cs;
+    fp.occupant[3] = occ.i; fp.occupant[4] = occ.s;
+    for (int i = 0; i < 5; ++i) fp.furniture[i] = furn[i];
+    net.queueFurniture(fp);
+    row.pendingSendMs = now;
+    char b[176]; _snprintf(b, sizeof(b) - 1,
+        "[furn58] INTENT seq=%u occ=%u,%u on=%d kind=%d furn=%u,%u",
+        fp.seq, occ.i, occ.s, on ? 1 : 0, kind, furn[3], furn[4]);
+    b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+}
+
+void Replicator::queueFurnitureState(NetLink& net, u32 ownerId, const Key& occ,
+                                     bool on, int kind,
+                                     const unsigned int furn[5],
+                                     u32 ackOwnerId, u32 ackSeq) {
+    if (kind != 1 && kind != 2) return;
+    FurnitureRow& row = furnitureRows_[occ];
+    row.seeded = true; row.on = on; row.kind = on ? kind : 0;
+    for (int i = 0; i < 5; ++i) row.furn[i] = on ? furn[i] : 0;
+
+    FurniturePacket fp; memset(&fp, 0, sizeof(fp));
+    fp.type = (u8)PKT_FURNITURE; fp.mode = (u8)FURNITURE_STATE;
+    fp.on = on ? 1 : 0; fp.kind = (u8)kind;
+    fp.ownerId = ownerId; fp.seq = furnitureStateSeqOut_++;
+    if (fp.seq == 0) fp.seq = furnitureStateSeqOut_++;
+    fp.occupant[0] = occ.t; fp.occupant[1] = occ.c; fp.occupant[2] = occ.cs;
+    fp.occupant[3] = occ.i; fp.occupant[4] = occ.s;
+    for (int i = 0; i < 5; ++i) fp.furniture[i] = furn[i];
+    fp.ackOwnerId = ackOwnerId; fp.ackSeq = ackSeq;
+    net.queueFurniture(fp);
+    char b[192]; _snprintf(b, sizeof(b) - 1,
+        "[furn58] STATE seq=%u occ=%u,%u on=%d kind=%d ack=%u:%u",
+        fp.seq, occ.i, occ.s, on ? 1 : 0, kind, ackOwnerId, ackSeq);
+    b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+}
+
+void Replicator::applyFurniturePackets(GameWorld* gw, Inbound& in, NetLink& net,
+                                       u32 localId, bool isHost) {
+    hostRole_ = isHost;
+    localId_ = localId;
+    std::deque<InboundFurniture> got;
+    in.drainFurniture(got);
+    for (std::deque<InboundFurniture>::iterator it = got.begin(); it != got.end(); ++it) {
+        const FurniturePacket& fp = it->pkt;
+        if (fp.ownerId != it->ownerId || fp.on > 1 ||
+            (fp.kind != 1 && fp.kind != 2) || fp.seq == 0) continue;
+        Key k; k.t = fp.occupant[0]; k.c = fp.occupant[1]; k.cs = fp.occupant[2];
+        k.i = fp.occupant[3]; k.s = fp.occupant[4];
+        FurnitureRow& row = furnitureRows_[k];
+
+        if (isHost) {
+            if (fp.mode != FURNITURE_INTENT || fp.ownerId == localId) continue;
+            // Only a body already being driven from this peer may be commanded
+            // by its intent. This prevents a forged packet from moving a Host-
+            // owned squad member or arbitrary world NPC.
+            if (ownHands_.find(k) != ownHands_.end() ||
+                targets_.find(k) == targets_.end()) continue;
+            u32 seen = row.intentSeen[fp.ownerId];
+            Character* occ = characterForFurnitureKey(k);
+            if (!occ) continue; // unresolved world object: leave unacked; retry is same-seq
+
+            engine::FurnitureRead before;
+            bool haveBefore = engine::readFurniture(occ, &before) && before.valid;
+            int beforeKind = haveBefore && (before.kind == 1 || before.kind == 2)
+                           ? before.kind : 0;
+            bool isNew = hostIntentIsNew(seen, fp.seq);
+            if (isNew) {
+                if (fp.on) {
+                    bool same = beforeKind == (int)fp.kind;
+                    for (int i = 0; same && i < 5; ++i)
+                        same = before.furn[i] == fp.furniture[i];
+                    if (!same && beforeKind == 0)
+                        engine::applyFurniture(gw, occ, fp.furniture, (int)fp.kind, true);
+                } else if (beforeKind == (int)fp.kind) {
+                    engine::applyFurniture(gw, occ, before.furn, beforeKind, false);
+                }
+                row.intentSeen[fp.ownerId] = fp.seq;
+                seen = fp.seq;
+            }
+
+            // Always answer duplicates too: this is the idempotent retry/ack path.
+            engine::FurnitureRead after;
+            bool haveAfter = engine::readFurniture(occ, &after) && after.valid;
+            int actualKind = haveAfter && (after.kind == 1 || after.kind == 2)
+                           ? after.kind : 0;
+            unsigned int stateFurn[5];
+            for (int i = 0; i < 5; ++i)
+                stateFurn[i] = actualKind ? after.furn[i] : fp.furniture[i];
+            int wireKind = actualKind ? actualKind : (int)fp.kind;
+            queueFurnitureState(net, localId, k, actualKind != 0, wireKind,
+                                stateFurn, fp.ownerId, seen);
+        } else {
+            if (fp.mode != FURNITURE_STATE || fp.seq <= row.stateSeqSeen) continue;
+            row.stateSeqSeen = fp.seq;
+            row.seeded = true; row.on = fp.on != 0; row.kind = fp.on ? fp.kind : 0;
+            for (int i = 0; i < 5; ++i) row.furn[i] = fp.on ? fp.furniture[i] : 0;
+            row.applyPending = true; row.applyOn = fp.on != 0;
+            row.applyKind = fp.kind;
+            for (int i = 0; i < 5; ++i) row.applyFurn[i] = fp.furniture[i];
+            if (hostIntentAckCovers(localId, row.pendingSeq,
+                                    fp.ackOwnerId, fp.ackSeq)) {
+                row.pendingSeq = 0; row.pendingSendMs = 0;
+            }
+            // A Host correction is a new baseline, not another local intent.
+            HostBody& hb = hostBody_[k];
+            hb.furnKind = fp.on ? fp.kind : 0;
+            for (int i = 0; i < 5; ++i) hb.furn[i] = fp.on ? fp.furniture[i] : 0;
+        }
+    }
+
+    if (!isHost) {
+        // Retain canonical rows across zone-load gaps. Reliable delivery proves
+        // the decision arrived; application simply waits for the local object.
+        for (std::map<Key, FurnitureRow>::iterator it = furnitureRows_.begin();
+             it != furnitureRows_.end(); ++it) {
+            FurnitureRow& row = it->second;
+            if (!row.applyPending) continue;
+            Character* occ = characterForFurnitureKey(it->first);
+            if (!occ) continue;
+            engine::FurnitureRead cur;
+            bool have = engine::readFurniture(occ, &cur) && cur.valid;
+            int curKind = have && (cur.kind == 1 || cur.kind == 2) ? cur.kind : 0;
+            bool ok = false;
+            if (row.applyOn) {
+                bool same = curKind == row.applyKind;
+                for (int i = 0; same && i < 5; ++i)
+                    same = cur.furn[i] == row.applyFurn[i];
+                if (same) {
+                    ok = true;
+                } else {
+                    // Canonical switches (or a wrong same-kind anchor) are an
+                    // ordered exit+enter locally; applyFurniture intentionally
+                    // refuses an enter while another attachment is active.
+                    bool released = curKind == 0 || engine::applyFurniture(
+                        gw, occ, cur.furn, curKind, false);
+                    ok = released && engine::applyFurniture(
+                        gw, occ, row.applyFurn, row.applyKind, true);
+                }
+            } else {
+                ok = curKind == 0 || engine::applyFurniture(
+                    gw, occ, have ? cur.furn : row.applyFurn,
+                    curKind ? curKind : row.applyKind, false);
+            }
+            if (ok) {
+                engine::endAction(occ);
+                row.applyPending = false;
+            }
+        }
+    }
+}
+
 void Replicator::applyEvents(GameWorld* gw, Inbound& in) {
     std::deque<InboundEvent> got;
     in.drainEvents(got);
@@ -817,43 +1003,14 @@ void Replicator::applyEvents(GameWorld* gw, Inbound& in) {
                 break;
             }
             case EVT_ENTER_FURNITURE: {
-                // Furniture occupancy (protocol 19): subject = the OCCUPANT,
-                // actor = the FURNITURE's save-stable hand (both clients loaded
-                // the same save, so it resolves locally). Run the engine's own
-                // setBedMode/setPrisonMode between the LOCAL pair - the in-bed/
-                // in-cage pose and transform are engine-native here. On a body
-                // we OWN, only a THIRD-PARTY placement is honoured (protocol
-                // 36): the world authority jailed our KO'd body (a guard
-                // action that runs purely on the host sim - our engine never
-                // executed it). Conscious voluntary use stays owner-authored:
-                // for those our engine did the real placement and this event
-                // is just the echo of our own edge.
+                // Protocol 58 owns beds/cages. Keep the legacy reliable event
+                // solely for protocol 41's chained/pole kind.
                 if (!furnSync_) break;
-                if (ownHands_.find(k) != ownHands_.end()) {
-                    Character* own = engine::resolveCharByHand(k.i, k.s, k.t, k.c, k.cs);
-                    bool down = own && coop::bodyIsDown(engine::readBodyState(own));
-                    engine::FurnitureRead ofr;
-                    bool already = own && engine::readFurniture(own, &ofr) &&
-                                   ofr.valid && ofr.kind == (int)ev.arg;
-                    // Race guard: the host re-authors PEER-ENTER on a 5 s
-                    // cadence, so one can be in flight when we free our own
-                    // body - a recent owner-side exit vetoes the stale enter.
-                    std::map<Key, unsigned long>::iterator ox = ownFurnExit_.find(k);
-                    bool justExited = ox != ownFurnExit_.end() &&
-                                      (nowMs() - ox->second) < 10000;
-                    if (!down || already || justExited) {
-                        char sb[160]; _snprintf(sb, sizeof(sb) - 1,
-                            "[furn] RECV PEER-ENTER own occ=%u,%u SKIP (down=%d already=%d exited=%d)",
-                            k.i, k.s, down ? 1 : 0, already ? 1 : 0,
-                            justExited ? 1 : 0);
-                        sb[sizeof(sb) - 1] = '\0'; coop::logLine(sb);
-                        break;
-                    }
-                }
+                int kind = (int)ev.arg;
+                if (kind != 3 || ownHands_.find(k) != ownHands_.end()) break;
                 Character* occ = engine::resolveCharByHand(k.i, k.s, k.t, k.c, k.cs);
                 unsigned int fh[5] = { ev.aType, ev.aContainer, ev.aContainerSerial,
                                        ev.aIndex, ev.aSerial };
-                int kind = (int)ev.arg;
                 bool ok = occ && engine::applyFurniture(0, occ, fh, kind, true);
                 char fb[160]; _snprintf(fb, sizeof(fb) - 1,
                     "[furn] RECV ENTER id=%u occ=%u,%u furn=%u,%u kind=%d ok=%d",
@@ -866,6 +1023,7 @@ void Replicator::applyEvents(GameWorld* gw, Inbound& in) {
                 // The inverse: release the local occupant. Idempotent - a copy
                 // that never entered locally (lost/late enter) is a no-op success.
                 if (!furnSync_) break;
+                if ((int)ev.arg != 3) break;
                 if (ownHands_.find(k) != ownHands_.end()) break;
                 Character* occ = engine::resolveCharByHand(k.i, k.s, k.t, k.c, k.cs);
                 unsigned int fh[5] = { ev.aType, ev.aContainer, ev.aContainerSerial,

--- a/src/plugin/sync/ReplicatorUtil.h
+++ b/src/plugin/sync/ReplicatorUtil.h
@@ -33,6 +33,7 @@
 #include "../core/DeathLatch.h" // rekeyCarryLatch (down/death latch carry on re-key)
 #include "ChangeGate.h" // Phase 6: shared change-gated send/accept policy
 #include "SyncContext.h" // Phase 6: per-tick channel call environment
+#include "../../netproto/HostIntent.h" // monotonic intent/ack/retry policy
 #include "../CoopLog.h"
 
 #include <windows.h> // GetTickCount
@@ -183,12 +184,10 @@ const unsigned long ATTR_WINDOW_MS = 3000; // remember a combatant's victim this
 const unsigned long CARRY_HEAL_MS = 1500; // min gap between self-heal pickups
 const unsigned long CARRY_DROP_MS = 3000; // stream must stop reporting the carry
                                           // this long before the local copy drops
-// Furniture occupancy sync (protocol 19): same shape as the carry self-heal.
+// Furniture occupancy sync (protocol 58): same shape as the carry self-heal.
 const unsigned long FURN_HEAL_MS = 1500;  // min gap between self-heal enters
 const unsigned long FURN_EXIT_MS = 3000;  // stream must stop reporting occupancy
                                           // this long before the local copy exits
-const unsigned long FURN_PEER_MS = 5000;  // third-party PEER-ENTER re-author gap
-                                          // (protocol 36: guard jails a peer PC)
 const float FURN_MATCH_DIST = 6.0f;       // self-heal fixture search radius around
                                           // the streamed occupant position
 // Stealth sync (protocol 20). The posture is CONTINUOUS state (a pure bool in

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -25,6 +25,7 @@
 
 #include "../netproto/Wire.h"
 #include "../netproto/ContentHash.h"
+#include "../netproto/HostIntent.h"
 #include "../plugin/sync/Interp.h"
 #include "../plugin/core/OwnRanks.h"
 #include "../plugin/core/SteamId.h"
@@ -118,6 +119,7 @@ static void testSizes() {
     CHECK_EQ("sizeof(ResearchPacket)",          sizeof(ResearchPacket),          57); // v37: research
     CHECK_EQ("sizeof(DeedPacket)",              sizeof(DeedPacket),              78); // v54: deeds
     CHECK_EQ("sizeof(FixturePacket)",           sizeof(FixturePacket),           90); // v55: fixture identity
+    CHECK_EQ("sizeof(FurniturePacket)",         sizeof(FurniturePacket),         60); // v58: bed/cage intent+state
     CHECK_EQ("sizeof(CamHintPacket)",           sizeof(CamHintPacket),           17); // v43: camera hint
     CHECK_EQ("sizeof(CellClaimPacket)",         sizeof(CellClaimPacket),         21); // v49: cell claim
     CHECK_EQ("sizeof(InvXferAckPacket)",        sizeof(InvXferAckPacket),        18); // v50: transfer verdict
@@ -310,8 +312,10 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v55: runtime-fixture identity)",
-             (int)PROTOCOL_VERSION, 55);
+    CHECK_EQ("PROTOCOL_VERSION (v58: host-canonical furniture)",
+             (int)PROTOCOL_VERSION, 58);
+    CHECK_EQ("PKT_FURNITURE reserved id", (int)PKT_FURNITURE, 51);
+    CHECK("furniture modes distinct", FURNITURE_INTENT != FURNITURE_STATE);
 
     // Protocol 52: the shared money pool. The two players spend from ONE wallet,
     // so the join reports CHANGES and the host the authoritative TOTAL - swap
@@ -495,6 +499,7 @@ static void testRoundTrips() {
     roundTrip<ResearchPacket>("ResearchPacket", (u8)PKT_RESEARCH);
     roundTrip<DeedPacket>("DeedPacket", (u8)PKT_DEED);
     roundTrip<FixturePacket>("FixturePacket", (u8)PKT_FIXTURE);
+    roundTrip<FurniturePacket>("FurniturePacket", (u8)PKT_FURNITURE);
     roundTrip<CellClaimPacket>("CellClaimPacket", (u8)PKT_CELL_CLAIM);
     roundTrip<InvXferAckPacket>("InvXferAckPacket", (u8)PKT_INV_XFER_ACK);
 
@@ -1382,6 +1387,7 @@ static void testFlushWorldStateContract() {
     ResearchPacket  rp;  std::memset(&rp,  0, sizeof(rp));
     DeedPacket      de;  std::memset(&de,  0, sizeof(de));
     FixturePacket   fx;  std::memset(&fx,  0, sizeof(fx));
+    FurniturePacket fn;  std::memset(&fn,  0, sizeof(fn));
     BuildPlacePacket  bp; std::memset(&bp,  0, sizeof(bp));
     BuildStatePacket  bs; std::memset(&bs,  0, sizeof(bs));
     BuildDoorPacket   bd; std::memset(&bd,  0, sizeof(bd));
@@ -1402,7 +1408,7 @@ static void testFlushWorldStateContract() {
     LoadReqPacket   lrq; std::memset(&lrq, 0, sizeof(lrq));
     LoadNackPacket  lnk; std::memset(&lnk, 0, sizeof(lnk));
 
-    // --- Push one sentinel into every WORLD-STATE queue (34).
+    // --- Push one sentinel into every WORLD-STATE queue (35).
     in.pushEntity(1, 0, e);
     in.pushEvent(1, ev);
     in.pushInv(1, 0, cKey, 0, 0);
@@ -1427,6 +1433,7 @@ static void testFlushWorldStateContract() {
     in.pushResearch(1, rp);
     in.pushDeed(1, de);
     in.pushFixture(1, fx);
+    in.pushFurniture(1, fn);
     in.pushBuildPlace(1, bp);
     in.pushBuildState(1, bs);
     in.pushBuildDoor(1, bd);
@@ -1480,6 +1487,7 @@ static void testFlushWorldStateContract() {
     WS_EMPTY("research",    InboundResearch,    drainResearch);
     WS_EMPTY("deed",        InboundDeed,        drainDeed);
     WS_EMPTY("fixture",     InboundFixture,     drainFixture);
+    WS_EMPTY("furniture",   InboundFurniture,   drainFurniture);
     WS_EMPTY("buildPlace",  InboundBuildPlace,  drainBuildPlace);
     WS_EMPTY("buildState",  InboundBuildState,  drainBuildState);
     WS_EMPTY("buildDoor",   InboundBuildDoor,   drainBuildDoor);
@@ -1766,6 +1774,30 @@ static void testChangeGate() {
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
 
+static void testHostIntentPolicy() {
+    std::printf("== host-canonical intent sequencing ==\n");
+    CHECK("intent seq zero rejected", !hostIntentIsNew(0, 0));
+    CHECK("first intent accepted", hostIntentIsNew(0, 1));
+    CHECK("newer intent accepted", hostIntentIsNew(7, 8));
+    CHECK("duplicate intent folded once", !hostIntentIsNew(7, 7));
+    CHECK("older intent rejected", !hostIntentIsNew(7, 6));
+
+    CHECK("owner-scoped ack covers pending",
+          hostIntentAckCovers(2, 9, 2, 9));
+    CHECK("newer owner-scoped ack covers pending",
+          hostIntentAckCovers(2, 9, 2, 10));
+    CHECK("other owner's ack cannot clear pending",
+          !hostIntentAckCovers(2, 9, 3, 10));
+    CHECK("older ack cannot clear pending",
+          !hostIntentAckCovers(2, 9, 2, 8));
+    CHECK("no pending intent cannot be acked",
+          !hostIntentAckCovers(2, 0, 2, 10));
+
+    CHECK("unsent intent is due", hostIntentRetryDue(1000, 0, 2000));
+    CHECK("intent holds before retry", !hostIntentRetryDue(2999, 1000, 2000));
+    CHECK("intent retries on boundary", hostIntentRetryDue(3000, 1000, 2000));
+}
+
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
                 (unsigned)PROTOCOL_VERSION);
@@ -1774,6 +1806,7 @@ int main() {
     testEngineFaults();
     testEngineCaps();
     testChangeGate();
+    testHostIntentPolicy();
     testRoundTrips();
     testFraming();
     testSaveCrc();


### PR DESCRIPTION
## Problem

Bed/cage occupancy is currently owner-authored: a Join body can publish an occupancy bit before the Host has accepted the interaction, while Host-only NPC actions (for example a guard jailing that body) have to be re-authored periodically. Those two paths can fight and produce the enter/exit teleport loop.

## Approach

- add a reliable `FurniturePacket` with two modes: Join **intent** and Host **canonical state**
- authenticate intents against the transport peer id, fold each sequence once, and reply with an owner-scoped acknowledgement
- retry the same unacknowledged sequence after 2 seconds; stable state sends no traffic
- on the Host, rebuild only `BODY_IN_BED` / `BODY_IN_CAGE` from the canonical row so the fast body stream cannot bypass the verdict
- publish Host-simulation changes (such as a guard placing/removing a captive) through the same canonical state path
- retain canonical state until an unloaded local object resolves, then apply it idempotently
- bump the wire protocol to 58 and reserve packet id 51 (49/50 belong to the sibling production/door intent PRs)

## Deliberate scope / non-overlap

- bed and cage kinds only (1/2)
- conscious `USE_BED` task/pose flow remains unchanged
- chained/pole prisoners remain on protocol 41 and the existing reliable event path

This is complementary to #6: that PR fixes re-seat teleport/owner-hand propagation for a body that is both chained and caged; this PR arbitrates bed/cage occupancy itself.

It follows the same Host-canonical intent/state/ack pattern proposed in #75 and #76 so the interaction channels can converge on one policy.

## Verification

- packet ids checked unique; protocol 58 / packet 51 locked
- exact packed `FurniturePacket` size (60 bytes), round-trip/truncation tests, intent sequencing/ack/retry tests added
- inbound world-state reset coverage extended
- legacy periodic peer-enter bookkeeping removed
- final diff covers 14 intended files only and passes `git diff --check`

Not run here: the repository's Windows C++ build and a real Host/Join session (this environment has no compatible Visual C++ toolchain). The PR is therefore a draft.

Suggested runtime matrix:

1. Join enters/exits cage and unconscious bed.
2. Host guard places/removes a down Join-owned body.
3. Lost/delayed acknowledgement: same sequence retries without double-applying.
4. Wrong/late local attachment is corrected to the Host row.
5. Chained/pole and conscious bed-pose regressions, including #6 when available.
