### PR TITLE
Route Join building changes through Host-authoritative intents

### DIFF
--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -25,7 +25,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 55;
+const u16 PROTOCOL_VERSION = 59;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -53,10 +53,10 @@ enum PacketType {
     PKT_FACTION          = 22,// RELIABLE player-faction relation row (protocol 24); FactionPacket
     PKT_TIME             = 23,// RELIABLE host-authoritative game clock (protocol 25); TimePacket
     PKT_DOOR             = 24,// RELIABLE baked-door open/lock state row (protocol 26); DoorPacket
-    PKT_BUILD_PLACE      = 25,// RELIABLE placed-building describe/mint (protocol 27); BuildPlacePacket
-    PKT_BUILD_STATE      = 26,// RELIABLE placer-authoritative construction progress (protocol 27); BuildStatePacket
+    PKT_BUILD_PLACE      = 25,// RELIABLE Host-canonical placed-building result; BuildPlacePacket
+    PKT_BUILD_STATE      = 26,// RELIABLE Host-canonical construction progress; BuildStatePacket
     PKT_BUILD_DOOR       = 27,// RELIABLE placed-building door row, translated key (protocol 28); BuildDoorPacket
-    PKT_BUILD_REMOVE     = 28,// RELIABLE placer-authoritative building removal (protocol 28); BuildRemovePacket
+    PKT_BUILD_REMOVE     = 28,// RELIABLE Host-canonical building removal; BuildRemovePacket
     PKT_SAVE_REQ         = 29,// RELIABLE join save request (join -> host, protocol 31); SaveReqPacket
     PKT_SAVE_BEGIN       = 30,// RELIABLE save-transfer announce (host -> join, protocol 31); SaveBeginPacket
     PKT_SAVE_FILE        = 31,// RELIABLE save-file chunk (host -> join, protocol 31); SaveFileHeader + path + payload
@@ -76,7 +76,9 @@ enum PacketType {
     PKT_INV_XFER_ACK     = 45,// RELIABLE transfer verdict (protocol 50); InvXferAckPacket
     PKT_MONEY_DELTA      = 46,// RELIABLE join money-pool delta (join -> host, protocol 52); MoneyDeltaPacket
     PKT_DEED             = 47,// RELIABLE property-ownership row (protocol 54); DeedPacket
-    PKT_FIXTURE          = 48 // RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    PKT_FIXTURE          = 48,// RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    // 49-51 are reserved by the sibling production, door and furniture intent PRs.
+    PKT_BUILD_INTENT     = 52 // RELIABLE join -> host place/remove request (protocol 59); BuildIntentPacket
 };
 
 // One-shot transition events carried on the RELIABLE channel. Continuous state
@@ -1182,9 +1184,9 @@ struct FixturePacket {
 // session (build_probe: minted-site hand intersection across clients is zero),
 // so the wire key is the PLACER's local hand and the receiver keeps a
 // key -> local-hand translation map, exactly the protocol-21 proxy precedent
-// for structures. The PLACER is the authority for its building's construction
-// progress (the describe/mint edge names the authority implicitly - whoever
-// announced the key streams its state).
+// for structures. Protocol 59 keeps that identity but makes the HOST the only
+// authority for existence, construction progress and removal. A Join placement
+// is an optimistic local preview plus an idempotent request, never a state row.
 //
 // PLACE announces one local placement (the UI commit detour on
 // PreviewBuilding::placeFinalPreviewBuilding, or a programmatic scenario
@@ -1196,8 +1198,8 @@ struct FixturePacket {
 // resends) are deduped by the translation map.
 struct BuildPlacePacket {
     u8  type;      // = PKT_BUILD_PLACE
-    u32 ownerId;   // network player id of the sender (the placer = the authority)
-    u32 seq;       // per-sender monotonic (diagnostics/ordering)
+    u32 ownerId;   // network player id of the sender (always the Host in v59)
+    u32 seq;       // Host-monotonic canonical-state sequence
     // the placed building's hand IN THE PLACER'S SESSION (the wire key)
     u32 key[5];
     char sid[48];  // building template GameData stringID
@@ -1206,10 +1208,14 @@ struct BuildPlacePacket {
     f32 z;
     f32 yaw;       // radians
     u8  fromUi;    // 1 = real build-mode commit, 0 = programmatic (diagnostics)
+    u8  accepted;  // 1 = canonical building exists, 0 = Host rejected the intent
+    u32 ackOwnerId;// Join whose latest placement intent this row answers
+    u32 ackSeq;    // 0 = unsolicited state; otherwise covers <= this intent seq
 };
 
-// One construction-progress row for a building the SENDER placed (keyed by
-// the sender's hand = the PLACE key). Change-gated ~1 Hz with a 10 s safety
+// One Host-canonical construction-progress row. The stable session key remains
+// the original placer's hand, but only the Host samples and publishes progress.
+// Change-gated ~1 Hz with a 10 s safety
 // resend while incomplete; complete=1 latches (the engine self-completes at
 // progress >= 1.0 through its own setter - scaffold off, navmesh updated).
 // A receiver whose translation map lacks the key skips the row silently
@@ -1217,8 +1223,8 @@ struct BuildPlacePacket {
 // latter transient).
 struct BuildStatePacket {
     u8  type;      // = PKT_BUILD_STATE
-    u32 ownerId;   // network player id of the sender (the placer)
-    u32 seq;       // per-sender monotonic (stale-row guard)
+    u32 ownerId;   // network player id of the sender (the Host)
+    u32 seq;       // Host-monotonic (stale-row guard)
     u32 key[5];    // the PLACER's hand for the building (translation-map key)
     f32 progress;  // ConstructionState::constructionProgress (0..1 while building)
     u8  complete;  // 1 = ConstructionState::isComplete (latched)
@@ -1245,17 +1251,41 @@ struct BuildDoorPacket {
     u8  locked;    // 1 = DoorLock engaged (applied only when the door has one)
 };
 
-// Placer-authoritative removal of a session-placed building: the dismantle
-// detour (UI path) or a programmatic destroy queues the edge; the receiver
-// destroys its mapped proxy through the engine's own GameWorld::destroy and
-// tombstones the translation entry (later rows for the key skip silently).
-// Only buildings in the session's build maps ever stream removal - baked
-// buildings are untouched by this channel.
+// Host-canonical removal result for a session-placed building. A Join asks with
+// BuildIntentPacket and keeps retrying the same seq until this state acks it.
 struct BuildRemovePacket {
     u8  type;    // = PKT_BUILD_REMOVE
-    u32 ownerId; // network player id of the sender (the placer)
-    u32 seq;     // per-sender monotonic
+    u32 ownerId; // network player id of the sender (the Host)
+    u32 seq;     // Host-monotonic canonical-state sequence
     u32 key[5];  // the PLACER's hand for the removed building
+    u8  accepted;// 1 = Host canonical state is removed, 0 = unknown/rejected key
+    u32 ackOwnerId;
+    u32 ackSeq;
+};
+
+enum BuildIntentOp {
+    BUILD_INTENT_PLACE  = 1,
+    BUILD_INTENT_REMOVE = 2
+};
+
+// Protocol 59 Join -> Host request. Placement is intentionally optimistic: the
+// Join has already committed its local preview, and the stable key is that local
+// hand. The Host validates and mints its canonical copy under the same wire key,
+// then acknowledges with BuildPlacePacket. Removal likewise reports a local UI
+// dismantle, but only the Host publishes the canonical tombstone. Reliable
+// retries reuse seq, making both operations idempotent.
+struct BuildIntentPacket {
+    u8  type;      // = PKT_BUILD_INTENT
+    u32 ownerId;   // requesting Join's network player id
+    u32 seq;       // per-Join monotonic; retries reuse the same seq
+    u8  op;        // BuildIntentOp
+    u32 key[5];    // original placer's stable session key
+    char sid[48];  // PLACE only
+    f32 x;
+    f32 y;
+    f32 z;
+    f32 yaw;
+    u8  fromUi;    // PLACE only
 };
 
 // ---- Protocol 20: stealth detection-map snapshot ---------------------------

--- a/src/plugin/KenshiCoop.vcxproj
+++ b/src/plugin/KenshiCoop.vcxproj
@@ -200,6 +200,7 @@
   <ItemGroup>
     <ClInclude Include="CoopLog.h" />
     <ClInclude Include="core\Config.h" />
+    <ClInclude Include="core\HostIntent.h" />
     <ClInclude Include="core\Inbound.h" />
     <ClInclude Include="net\NetLink.h" />
     <ClInclude Include="net\SteamP2P.h" />

--- a/src/plugin/core/HostIntent.h
+++ b/src/plugin/core/HostIntent.h
@@ -1,0 +1,33 @@
+// HostIntent.h - reusable policy for host-canonical interaction channels.
+// Pure C++03: no game, Win32 or network dependencies, so prototest can lock the
+// idempotency/ack contract before the pattern is reused by another subsystem.
+
+#ifndef COOP_HOST_INTENT_H
+#define COOP_HOST_INTENT_H
+
+namespace coop {
+
+// Sequence 0 is reserved for "none". Reliable ordering handles transport order;
+// this guard makes duplicate retries harmless at the authority.
+inline bool hostIntentIsNew(unsigned int lastSeq, unsigned int incomingSeq) {
+    return incomingSeq != 0u && incomingSeq > lastSeq;
+}
+
+// A canonical state row settles only the pending intent it explicitly answers.
+inline bool hostIntentAckCovers(unsigned int localOwnerId,
+                                unsigned int pendingSeq,
+                                unsigned int ackOwnerId,
+                                unsigned int ackSeq) {
+    return pendingSeq != 0u && ackOwnerId == localOwnerId && ackSeq >= pendingSeq;
+}
+
+// Wall-clock retry backstop. At rest there is no traffic; while an ack is missing
+// the same idempotent intent may be resent after the interval.
+inline bool hostIntentRetryDue(unsigned long nowMs, unsigned long lastSendMs,
+                               unsigned long retryMs) {
+    return lastSendMs == 0ul || (nowMs - lastSendMs) >= retryMs;
+}
+
+} // namespace coop
+
+#endif // COOP_HOST_INTENT_H

--- a/src/plugin/core/Inbound.h
+++ b/src/plugin/core/Inbound.h
@@ -222,6 +222,13 @@ struct InboundBuildRemove {
     BuildRemovePacket pkt;
 };
 
+// One reliable Join -> Host placement/removal request (protocol 59). ownerId is
+// stamped from the actual ENet peer rather than trusted from the packet body.
+struct InboundBuildIntent {
+    u32               ownerId;
+    BuildIntentPacket pkt;
+};
+
 // One received machine state row (protocol 33): the HOST's authoritative
 // power/production/farm state for a machine; the join resolves the key
 // (baked hand or protocol-27 placer key) and applies through the engine's
@@ -431,7 +438,8 @@ public:
         time_(worldReset_),       door_(worldReset_),       prod_(worldReset_),
         research_(worldReset_),   deed_(worldReset_),       fixture_(worldReset_),
         buildPlace_(worldReset_), buildState_(worldReset_),
-        buildDoor_(worldReset_),  buildRemove_(worldReset_), stealth_(worldReset_, 512),
+        buildDoor_(worldReset_),  buildRemove_(worldReset_), buildIntent_(worldReset_),
+        stealth_(worldReset_, 512),
         spawnReq_(worldReset_),   spawnInfo_(worldReset_),  camHint_(worldReset_, 64),
         cellClaim_(worldReset_, 64) {
         InitializeCriticalSection(&cs_);
@@ -625,6 +633,11 @@ public:
         InboundBuildRemove ibr; ibr.ownerId = ownerId; ibr.pkt = pkt;
         EnterCriticalSection(&cs_); buildRemove_.push_back(ibr); LeaveCriticalSection(&cs_);
     }
+    // NET thread: one reliable Join -> Host build request (protocol 59).
+    void pushBuildIntent(u32 ownerId, const BuildIntentPacket& pkt) {
+        InboundBuildIntent ibi; ibi.ownerId = ownerId; ibi.pkt = pkt;
+        EnterCriticalSection(&cs_); buildIntent_.push_back(ibi); LeaveCriticalSection(&cs_);
+    }
     // NET thread: one received stealth detection-map snapshot, owner-tagged.
     void pushStealth(u32 ownerId, const StealthPacket& pkt) {
         InboundStealth isl; isl.ownerId = ownerId; isl.pkt = pkt;
@@ -781,6 +794,9 @@ public:
     void drainBuildRemove(std::deque<InboundBuildRemove>& out) {
         EnterCriticalSection(&cs_); out.swap(buildRemove_); LeaveCriticalSection(&cs_);
     }
+    void drainBuildIntents(std::deque<InboundBuildIntent>& out) {
+        EnterCriticalSection(&cs_); out.swap(buildIntent_); LeaveCriticalSection(&cs_);
+    }
     void drainMoney(std::deque<InboundMoney>& out) {
         EnterCriticalSection(&cs_); out.swap(money_); LeaveCriticalSection(&cs_);
     }
@@ -894,6 +910,7 @@ private:
     WorldQ<InboundBuildState>      buildState_;
     WorldQ<InboundBuildDoor>       buildDoor_;
     WorldQ<InboundBuildRemove>     buildRemove_;
+    WorldQ<InboundBuildIntent>     buildIntent_;
     WorldQ<InboundStealth>         stealth_;
     WorldQ<InboundSpawnReq>        spawnReq_;
     WorldQ<InboundSpawnInfo>       spawnInfo_;

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -234,6 +234,8 @@ void NetLink::queueBuildDoor(const BuildDoorPacket& pkt) { pushLocked(outCs_, ou
 
 void NetLink::queueBuildRemove(const BuildRemovePacket& pkt) { pushLocked(outCs_, outBuildRemove_, pkt); }
 
+void NetLink::queueBuildIntent(const BuildIntentPacket& pkt) { pushLocked(outCs_, outBuildIntent_, pkt); }
+
 void NetLink::queueStealth(const StealthPacket& pkt) { pushLocked(outCs_, outStealth_, pkt); }
 
 void NetLink::queueCamHint(const CamHintPacket& pkt) { pushLocked(outCs_, outCamHint_, pkt); }
@@ -813,12 +815,22 @@ void NetLink::threadLoop() {
                             inbound_->pushBuildDoor(bd.ownerId, bd);
                         }
                     } else if (type == PKT_BUILD_REMOVE) {
-                        // Reliable placer-authoritative building removal
-                        // (protocol 28).
+                        // Reliable Host-canonical building removal (protocol 59).
                         BuildRemovePacket br;
                         if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &br)
                             && inbound_) {
                             inbound_->pushBuildRemove(br.ownerId, br);
+                        }
+                    } else if (type == PKT_BUILD_INTENT) {
+                        // Reliable idempotent placement/removal request
+                        // (protocol 59, Join -> Host). Stamp the actual peer id;
+                        // the game thread rejects a forged packet owner.
+                        BuildIntentPacket bi;
+                        if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &bi)
+                            && inbound_) {
+                            u32 senderId = isHost_
+                                ? (u32)(size_t)ev.peer->data : (u32)0;
+                            inbound_->pushBuildIntent(senderId, bi);
                         }
                     } else if (type == PKT_STEALTH) {
                         // Unreliable stealth detection-map snapshot (protocol 20).
@@ -1533,13 +1545,8 @@ void NetLink::threadLoop() {
             }
         }
 
-        // Drain + send any queued placed-building announcements + progress
-        // rows on CH_RELIABLE (protocol 27). PLACE is a one-shot describe/mint
-        // edge (a lost one strands an invisible building on the peer - the
-        // protocol-21 lesson); STATE rows are change-gated by the Replicator
-        // (~1 Hz sample, 10 s safety resend while incomplete), so the channel
-        // is silent once every site completes. Same-channel ordered-reliable
-        // guarantees a STATE row never arrives before its PLACE.
+        // Drain + send Host-canonical placed-building announcements + progress
+        // rows on CH_RELIABLE (protocol 59). The Join never publishes state.
         std::vector<BuildPlacePacket> buildPlacePkts;
         std::vector<BuildStatePacket> buildStatePkts;
         EnterCriticalSection(&outCs_);
@@ -1551,8 +1558,6 @@ void NetLink::threadLoop() {
                                                  ENET_PACKET_FLAG_RELIABLE);
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);
-            } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
-                enet_peer_send(serverPeer_, CH_RELIABLE, out);
             } else {
                 enet_packet_destroy(out);
             }
@@ -1562,8 +1567,6 @@ void NetLink::threadLoop() {
                                                  ENET_PACKET_FLAG_RELIABLE);
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);
-            } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
-                enet_peer_send(serverPeer_, CH_RELIABLE, out);
             } else {
                 enet_packet_destroy(out);
             }
@@ -1591,13 +1594,29 @@ void NetLink::threadLoop() {
                 enet_packet_destroy(out);
             }
         }
+
+        // Join build intents are silent at rest; a pending request retries the
+        // same idempotent sequence after two seconds until canonical state acks.
+        std::vector<BuildIntentPacket> buildIntentPkts;
+        EnterCriticalSection(&outCs_);
+        buildIntentPkts.swap(outBuildIntent_);
+        LeaveCriticalSection(&outCs_);
+        for (size_t i = 0; i < buildIntentPkts.size(); ++i) {
+            ENetPacket* out = enet_packet_create(&buildIntentPkts[i],
+                                                 sizeof(BuildIntentPacket),
+                                                 ENET_PACKET_FLAG_RELIABLE);
+            if (!isHost_ && serverPeer_ &&
+                serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
+                enet_peer_send(serverPeer_, CH_RELIABLE, out);
+            } else {
+                enet_packet_destroy(out);
+            }
+        }
         for (size_t i = 0; i < buildRemovePkts.size(); ++i) {
             ENetPacket* out = enet_packet_create(&buildRemovePkts[i], sizeof(BuildRemovePacket),
                                                  ENET_PACKET_FLAG_RELIABLE);
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);
-            } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
-                enet_peer_send(serverPeer_, CH_RELIABLE, out);
             } else {
                 enet_packet_destroy(out);
             }

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -146,6 +146,8 @@ public:
     void queueBuildState(const BuildStatePacket& pkt);
     void queueBuildDoor(const BuildDoorPacket& pkt);
     void queueBuildRemove(const BuildRemovePacket& pkt);
+    // MAIN thread: reliable idempotent placement/removal request (Join -> Host).
+    void queueBuildIntent(const BuildIntentPacket& pkt);
 
     // MAIN thread: queue an UNRELIABLE stealth detection-map snapshot (protocol
     // 20, host -> the sneaker's owner). Latest wins; change-gated + throttled by
@@ -310,6 +312,7 @@ private:
     std::vector<BuildStatePacket> outBuildState_;
     std::vector<BuildDoorPacket>  outBuildDoor_;
     std::vector<BuildRemovePacket> outBuildRemove_;
+    std::vector<BuildIntentPacket> outBuildIntent_;
     // Unreliable stealth detection-map snapshots (protocol 20). Guarded by outCs_.
     std::vector<StealthPacket>   outStealth_;
     // Unreliable camera hints (protocol 43, ~1 Hz latest-wins). Guarded by outCs_.

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -437,22 +437,20 @@ public:
     // Door-state sync master enable (KENSHICOOP_DOOR_SYNC).
     void setDoorSync(bool v) { doorSync_ = v; }
 
-    // BEFORE engine (protocol 27, both clients): drain local placement edges
-    // (the placeFinalPreviewBuilding detour + programmatic scenario places)
-    // into PKT_BUILD_PLACE announcements keyed by OUR hand, then sample every
-    // building WE placed (~1 Hz) and stream change-gated PKT_BUILD_STATE
-    // progress rows (10 s safety resend while incomplete; the final
-    // complete=1 row latches the channel silent for that site).
+    // BEFORE engine (protocol 27/59): drain local placement/removal edges. The
+    // Host registers them directly as canonical state; the Join sends reliable
+    // idempotent intents and retries until explicitly acknowledged. Only the
+    // Host samples and publishes construction progress.
     void publishBuilds(const SyncContext& ctx);
 
-    // BEFORE engine (protocol 27): drain received announcements - each new
-    // key mints a local construction site through the same createBuilding
-    // factory (town-rule-free, probe-proven) and enters the key -> local-hand
-    // translation map (a refused mint is remembered so resends don't retry) -
-    // then apply received progress rows through the engine's own
-    // setConstructionProgress via that map (per-key seq guard drops stale
-    // rows; unknown keys are skipped silently).
+    // BEFORE engine (Join, protocol 27/59): apply Host-canonical placement,
+    // progress and removal state. A placement ack adopts the Join's optimistic
+    // local site instead of minting a duplicate.
     void applyBuilds(const SyncContext& ctx);
+
+    // BEFORE canonical build state (Host, protocol 59): validate and fold Join
+    // place/remove intents exactly once, then publish the actual result + ack.
+    void applyBuildIntents(const SyncContext& ctx);
 
     // Placed-building sync master enable (KENSHICOOP_BUILD_SYNC).
     void setBuildSync(bool v) { buildSync_ = v; }
@@ -1974,17 +1972,14 @@ private:
     u32           doorSeqOut_;
     unsigned long doorSampleMs_;
     bool          doorSync_;
-    // Protocol 27 placed-building sync. OwnBuild = a building WE placed
-    // (registered from the local placement edge; we are its progress
-    // authority): lastProg/lastComplete = change gate, lastSendMs = safety
-    // resend, doneSent latches the channel silent once the final complete row
-    // went out. PeerBuild = a building the PEER placed (learned from
-    // PKT_BUILD_PLACE): the key -> local-hand translation entry; minted=0
-    // remembers a refused mint so resends don't retry the factory forever;
-    // seqSeen = stale STATE-row guard.
+    // Protocol 27/59 placed-building sync. OwnBuild is a locally existing site
+    // whose wire key originated here OR which the Host adopted as canonical.
+    // PeerBuild is a Host placement minted by the Join. Only the Host uses the
+    // progress send fields; the Join uses pendingPlace* until the Host acks.
     struct OwnBuild {
         unsigned int hand[5];
         float lastProg; int lastComplete; unsigned long lastSendMs;
+        u32 seqSeen;
         bool doneSent;
         bool removed; // dismantled/destroyed + REMOVE announced: silent forever
         // Protocol 30: the PLACE announcement captured at edge-drain time, so
@@ -1992,8 +1987,11 @@ private:
         // (the template sid lives in the edge, not on the Building).
         BuildPlacePacket ann;
         bool haveAnn;
+        u32 pendingPlaceSeq;
+        unsigned long pendingPlaceSendMs;
         OwnBuild() : lastProg(-1.0f), lastComplete(-1), lastSendMs(0),
-                     doneSent(false), removed(false), haveAnn(false) {
+                     seqSeen(0), doneSent(false), removed(false), haveAnn(false),
+                     pendingPlaceSeq(0), pendingPlaceSendMs(0) {
             memset(hand, 0, sizeof(hand));
             memset(&ann, 0, sizeof(ann));
         }
@@ -2006,6 +2004,15 @@ private:
     };
     std::map<Key, OwnBuild>  ownBuilds_;
     std::map<Key, PeerBuild> peerBuilds_;
+    struct BuildRemovePending {
+        u32 seq; unsigned long lastSendMs;
+        BuildRemovePending() : seq(0), lastSendMs(0) {}
+    };
+    std::map<Key, BuildRemovePending> buildRemovePending_;
+    // Host-side per-requester high-water marks: a retry never mints/destroys
+    // twice, but still receives a fresh canonical acknowledgement.
+    std::map<std::pair<u32, Key>, u32> buildPlaceIntentSeen_;
+    std::map<std::pair<u32, Key>, u32> buildRemoveIntentSeen_;
     // Reverse translation (protocol 28): local minted building hand -> the
     // placer's wire key. Lets the door sampler express a MINTED proxy's door
     // in the placer's key space, and the protocol-26 filter recognize placed
@@ -2025,6 +2032,7 @@ private:
     bool buildKeyForLocalHand(const Key& local, Key& outWire) const;
     bool localHandForBuildKey(const Key& wire, unsigned int out[5]) const;
     u32           buildSeqOut_;
+    u32           buildIntentSeqOut_;
     unsigned long buildSampleMs_;
     bool          buildSync_;
     // Protocol 28 placed-door rows, keyed by (placer building key, door

--- a/src/plugin/sync/ReplicatorChannels.cpp
+++ b/src/plugin/sync/ReplicatorChannels.cpp
@@ -11,6 +11,7 @@
 // PowerShell oracles (see resources/CODE_MAP.md, log-tag index).
 
 #include "ReplicatorUtil.h"
+#include "../core/HostIntent.h"
 
 namespace coop {
 
@@ -1510,9 +1511,12 @@ bool Replicator::localHandForBuildKey(const Key& wire, unsigned int out[5]) cons
 void Replicator::publishBuilds(const SyncContext& ctx) {
     NetLink& net = *ctx.net; u32 ownerId = ctx.localId;
     if (!buildSync_) return;
+    const unsigned long now = nowMs();
+    const unsigned long INTENT_RETRY_MS = 2000;
 
-    // 1. Local placement edges -> PLACE announcements (drained every tick so
-    // the edge queue never backs up; the detour caps it at 32 anyway).
+    // Local placement edges are optimistic on the Join: its committed preview
+    // supplies the stable session key, while the Host decides whether that key
+    // becomes canonical. Host-local placements are canonical immediately.
     engine::BuildEdge edges[8];
     unsigned int n = engine::drainBuildEdges(edges, 8);
     for (unsigned int i = 0; i < n; ++i) {
@@ -1525,60 +1529,142 @@ void Replicator::publishBuilds(const SyncContext& ctx) {
         BuildPlacePacket pkt;
         memset(&pkt, 0, sizeof(pkt));
         pkt.type    = (u8)PKT_BUILD_PLACE;
-        pkt.ownerId = ownerId;
-        pkt.seq     = buildSeqOut_++;
+        pkt.ownerId = ctx.isHost ? ownerId : 0;
+        pkt.seq     = ctx.isHost ? buildSeqOut_++ : 0;
         for (unsigned int h = 0; h < 5; ++h) pkt.key[h] = e.hand[h];
         strncpy(pkt.sid, e.sid, sizeof(pkt.sid) - 1);
         pkt.sid[sizeof(pkt.sid) - 1] = '\0';
         pkt.x = e.x; pkt.y = e.y; pkt.z = e.z; pkt.yaw = e.yaw;
         pkt.fromUi = (u8)(e.fromUi ? 1 : 0);
+        pkt.accepted = 1;
+        pkt.ackOwnerId = 0; pkt.ackSeq = 0;
         // Protocol 30: retain the announcement so a connect-edge resync can
         // re-send it to a late joiner (the one-shot edge, made repeatable).
         memcpy(&ob.ann, &pkt, sizeof(pkt));
         ob.haveAnn = true;
-        net.queueBuildPlace(pkt);
+        if (ctx.isHost) {
+            net.queueBuildPlace(pkt);
+        } else if (ob.pendingPlaceSeq == 0) {
+            ob.pendingPlaceSeq = buildIntentSeqOut_++;
+            ob.pendingPlaceSendMs = 0; // retry pass below sends immediately
+        }
         char b[224];
         _snprintf(b, sizeof(b) - 1,
-                  "[build] PLACE-SEND key=%u.%u.%u.%u.%u sid='%s' ui=%u "
-                  "pos=%.1f,%.1f,%.1f seq=%u",
+                  ctx.isHost
+                    ? "[build] PLACE-SEND key=%u.%u.%u.%u.%u sid='%s' ui=%u "
+                      "pos=%.1f,%.1f,%.1f seq=%u"
+                    : "[build] PLACE-PENDING key=%u.%u.%u.%u.%u sid='%s' ui=%u "
+                      "pos=%.1f,%.1f,%.1f seq=%u",
                   pkt.key[0], pkt.key[1], pkt.key[2], pkt.key[3], pkt.key[4],
-                  pkt.sid, pkt.fromUi, pkt.x, pkt.y, pkt.z, pkt.seq);
+                  pkt.sid, pkt.fromUi, pkt.x, pkt.y, pkt.z,
+                  ctx.isHost ? pkt.seq : ob.pendingPlaceSeq);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 
-    // 1b. Removal edges (protocol 28): the dismantle detour (UI path) and the
-    // programmatic destroy both queue hands here. Only buildings WE placed
-    // stream a REMOVE (placer-authoritative); a dismantle of a baked building
-    // or of a peer's proxy logs at the detour but stays local.
+    // A local dismantle may name our original site OR a minted Host placement.
+    // Translate either one into the stable wire key before authoring state or
+    // intent. Baked buildings remain outside this session-build channel.
     unsigned int rmEdges[8][5];
     unsigned int rn = engine::drainRemoveEdges(rmEdges, 8);
     for (unsigned int i = 0; i < rn; ++i) {
-        Key k; k.t = rmEdges[i][0]; k.c = rmEdges[i][1]; k.cs = rmEdges[i][2];
-        k.i = rmEdges[i][3]; k.s = rmEdges[i][4];
-        std::map<Key, OwnBuild>::iterator f = ownBuilds_.find(k);
-        if (f == ownBuilds_.end() || f->second.removed) continue;
-        f->second.removed = true;
+        Key local; local.t = rmEdges[i][0]; local.c = rmEdges[i][1];
+        local.cs = rmEdges[i][2]; local.i = rmEdges[i][3]; local.s = rmEdges[i][4];
+        Key k = local;
+        std::map<Key, OwnBuild>::iterator own = ownBuilds_.find(k);
+        std::map<Key, PeerBuild>::iterator peer = peerBuilds_.end();
+        if (own == ownBuilds_.end()) {
+            std::map<Key, Key>::iterator rev = mintByLocal_.find(local);
+            if (rev == mintByLocal_.end()) continue;
+            k = rev->second;
+            own = ownBuilds_.find(k);
+            peer = peerBuilds_.find(k);
+        }
+        bool alreadyRemoved = false;
+        if (own != ownBuilds_.end()) {
+            alreadyRemoved = own->second.removed;
+            own->second.removed = true;
+        } else if (peer != peerBuilds_.end()) {
+            alreadyRemoved = peer->second.removed;
+            peer->second.removed = true;
+        } else {
+            continue;
+        }
+        if (alreadyRemoved) continue;
         if (!bdoorSync_) continue; // A/B hatch: edge observed, nothing streams
-        BuildRemovePacket pkt;
-        memset(&pkt, 0, sizeof(pkt));
-        pkt.type    = (u8)PKT_BUILD_REMOVE;
-        pkt.ownerId = ownerId;
-        pkt.seq     = buildSeqOut_++;
-        for (unsigned int h = 0; h < 5; ++h) pkt.key[h] = rmEdges[i][h];
-        net.queueBuildRemove(pkt);
-        char b[160];
-        _snprintf(b, sizeof(b) - 1,
-                  "[build] REMOVE-SEND key=%u.%u.%u.%u.%u seq=%u",
-                  pkt.key[0], pkt.key[1], pkt.key[2], pkt.key[3], pkt.key[4],
-                  pkt.seq);
-        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        if (ctx.isHost) {
+            BuildRemovePacket pkt;
+            memset(&pkt, 0, sizeof(pkt));
+            pkt.type = (u8)PKT_BUILD_REMOVE; pkt.ownerId = ownerId;
+            pkt.seq = buildSeqOut_++; pkt.accepted = 1;
+            pkt.key[0] = k.t; pkt.key[1] = k.c; pkt.key[2] = k.cs;
+            pkt.key[3] = k.i; pkt.key[4] = k.s;
+            net.queueBuildRemove(pkt);
+            char b[160];
+            _snprintf(b, sizeof(b) - 1,
+                      "[build] REMOVE-SEND key=%u.%u.%u.%u.%u seq=%u",
+                      k.t, k.c, k.cs, k.i, k.s, pkt.seq);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        } else {
+            BuildRemovePending& pending = buildRemovePending_[k];
+            if (pending.seq == 0) pending.seq = buildIntentSeqOut_++;
+            pending.lastSendMs = 0;
+        }
     }
 
-    // 2. Progress rows for buildings WE placed (~1 Hz, change-gated + 10 s
-    // safety resend while incomplete; the final complete row latches).
+    // Join retries are quiet once acknowledged. PLACE and REMOVE use the same
+    // request packet and monotonically increasing per-Join sequence space.
+    if (!ctx.isHost) {
+        for (std::map<Key, OwnBuild>::iterator it = ownBuilds_.begin();
+             it != ownBuilds_.end(); ++it) {
+            OwnBuild& ob = it->second;
+            if (!ob.haveAnn || ob.pendingPlaceSeq == 0 ||
+                !hostIntentRetryDue(now, ob.pendingPlaceSendMs, INTENT_RETRY_MS))
+                continue;
+            BuildIntentPacket p; memset(&p, 0, sizeof(p));
+            p.type = (u8)PKT_BUILD_INTENT; p.ownerId = ownerId;
+            p.seq = ob.pendingPlaceSeq; p.op = (u8)BUILD_INTENT_PLACE;
+            memcpy(p.key, ob.ann.key, sizeof(p.key));
+            strncpy(p.sid, ob.ann.sid, sizeof(p.sid) - 1);
+            p.x = ob.ann.x; p.y = ob.ann.y; p.z = ob.ann.z; p.yaw = ob.ann.yaw;
+            p.fromUi = ob.ann.fromUi;
+            bool retry = ob.pendingPlaceSendMs != 0;
+            ob.pendingPlaceSendMs = now;
+            net.queueBuildIntent(p);
+            char b[176];
+            _snprintf(b, sizeof(b) - 1,
+                      "[build] PLACE-INTENT key=%u.%u.%u.%u.%u seq=%u retry=%d",
+                      p.key[0], p.key[1], p.key[2], p.key[3], p.key[4],
+                      p.seq, retry ? 1 : 0);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        }
+        for (std::map<Key, BuildRemovePending>::iterator it = buildRemovePending_.begin();
+             it != buildRemovePending_.end(); ++it) {
+            BuildRemovePending& pending = it->second;
+            if (pending.seq == 0 ||
+                !hostIntentRetryDue(now, pending.lastSendMs, INTENT_RETRY_MS))
+                continue;
+            BuildIntentPacket p; memset(&p, 0, sizeof(p));
+            p.type = (u8)PKT_BUILD_INTENT; p.ownerId = ownerId;
+            p.seq = pending.seq; p.op = (u8)BUILD_INTENT_REMOVE;
+            p.key[0] = it->first.t; p.key[1] = it->first.c;
+            p.key[2] = it->first.cs; p.key[3] = it->first.i; p.key[4] = it->first.s;
+            bool retry = pending.lastSendMs != 0;
+            pending.lastSendMs = now;
+            net.queueBuildIntent(p);
+            char b[176];
+            _snprintf(b, sizeof(b) - 1,
+                      "[build] REMOVE-INTENT key=%u.%u.%u.%u.%u seq=%u retry=%d",
+                      p.key[0], p.key[1], p.key[2], p.key[3], p.key[4],
+                      p.seq, retry ? 1 : 0);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        }
+        return; // Join never publishes canonical construction progress
+    }
+
+    // Host progress rows (~1 Hz, change-gated + 10 s safety resend while
+    // incomplete; the final complete row latches).
     const unsigned long SAMPLE_MS = tuning_.buildSampleMs;
     const unsigned long RESEND_MS = tuning_.buildResendMs;
-    unsigned long now = nowMs();
     if (!sync::gateSampleDue(now, buildSampleMs_, SAMPLE_MS)) return;
     buildSampleMs_ = now;
     const float EPS = 0.005f;
@@ -1604,7 +1690,9 @@ void Replicator::publishBuilds(const SyncContext& ctx) {
         pkt.type     = (u8)PKT_BUILD_STATE;
         pkt.ownerId  = ownerId;
         pkt.seq      = buildSeqOut_++;
-        for (unsigned int h = 0; h < 5; ++h) pkt.key[h] = ob.hand[h];
+        pkt.key[0] = it->first.t; pkt.key[1] = it->first.c;
+        pkt.key[2] = it->first.cs; pkt.key[3] = it->first.i;
+        pkt.key[4] = it->first.s;
         pkt.progress = cur.progress;
         pkt.complete = (u8)(cur.complete ? 1 : 0);
         net.queueBuildState(pkt);
@@ -1620,71 +1708,215 @@ void Replicator::publishBuilds(const SyncContext& ctx) {
     }
 }
 
+static bool validBuildPlaceIntent(const BuildIntentPacket& p) {
+    if (!p.sid[0] || !memchr(p.sid, '\0', sizeof(p.sid)) || p.fromUi > 1)
+        return false;
+    bool haveKey = false;
+    for (unsigned int i = 0; i < 5; ++i) if (p.key[i] != 0) haveKey = true;
+    if (!haveKey) return false;
+    const float POS_LIMIT = 1000000.0f;
+    if (!(p.x >= -POS_LIMIT && p.x <= POS_LIMIT) ||
+        !(p.y >= -POS_LIMIT && p.y <= POS_LIMIT) ||
+        !(p.z >= -POS_LIMIT && p.z <= POS_LIMIT) ||
+        !(p.yaw >= -1000.0f && p.yaw <= 1000.0f))
+        return false; // comparisons reject NaN and infinities too
+    return true;
+}
+
+void Replicator::applyBuildIntents(const SyncContext& ctx) {
+    std::deque<InboundBuildIntent> got;
+    ctx.in->drainBuildIntents(got);
+    if (got.empty() || !ctx.isHost || !buildSync_) return;
+    for (std::deque<InboundBuildIntent>::iterator it = got.begin();
+         it != got.end(); ++it) {
+        const BuildIntentPacket& p = it->pkt;
+        if (p.seq == 0 || p.ownerId == 0 || it->ownerId != p.ownerId ||
+            (p.op != BUILD_INTENT_PLACE && p.op != BUILD_INTENT_REMOVE))
+            continue;
+        Key k; k.t = p.key[0]; k.c = p.key[1]; k.cs = p.key[2];
+        k.i = p.key[3]; k.s = p.key[4];
+        std::pair<u32, Key> requestKey = std::make_pair(p.ownerId, k);
+
+        if (p.op == BUILD_INTENT_PLACE) {
+            u32& seen = buildPlaceIntentSeen_[requestKey];
+            std::map<Key, OwnBuild>::iterator found = ownBuilds_.find(k);
+            bool accepted = found != ownBuilds_.end() && !found->second.removed;
+            int rc = accepted ? 1 : 0;
+            if (hostIntentIsNew(seen, p.seq)) {
+                if (found == ownBuilds_.end() && validBuildPlaceIntent(p)) {
+                    unsigned int localHand[5] = { 0, 0, 0, 0, 0 };
+                    rc = engine::placeBuildingAt(ctx.gw, p.sid, p.x, p.y, p.z,
+                                                 p.yaw, false, localHand);
+                    if (rc == 1) {
+                        OwnBuild& ob = ownBuilds_[k];
+                        memcpy(ob.hand, localHand, sizeof(ob.hand));
+                        memset(&ob.ann, 0, sizeof(ob.ann));
+                        ob.ann.type = (u8)PKT_BUILD_PLACE;
+                        ob.ann.ownerId = ctx.localId;
+                        memcpy(ob.ann.key, p.key, sizeof(ob.ann.key));
+                        strncpy(ob.ann.sid, p.sid, sizeof(ob.ann.sid) - 1);
+                        ob.ann.x = p.x; ob.ann.y = p.y; ob.ann.z = p.z;
+                        ob.ann.yaw = p.yaw; ob.ann.fromUi = p.fromUi;
+                        ob.ann.accepted = 1; ob.haveAnn = true;
+                        Key local; local.t = localHand[0]; local.c = localHand[1];
+                        local.cs = localHand[2]; local.i = localHand[3];
+                        local.s = localHand[4];
+                        mintByLocal_[local] = k;
+                        found = ownBuilds_.find(k);
+                        accepted = true;
+                    }
+                }
+                // A placement rejection is final for this exact request. The
+                // Join removes its optimistic copy instead of retrying forever.
+                seen = p.seq;
+            }
+
+            BuildPlacePacket state;
+            memset(&state, 0, sizeof(state));
+            if (accepted && found != ownBuilds_.end() && found->second.haveAnn)
+                memcpy(&state, &found->second.ann, sizeof(state));
+            else {
+                memcpy(state.key, p.key, sizeof(state.key));
+                strncpy(state.sid, p.sid, sizeof(state.sid) - 1);
+                state.x = p.x; state.y = p.y; state.z = p.z;
+                state.yaw = p.yaw; state.fromUi = p.fromUi;
+            }
+            state.type = (u8)PKT_BUILD_PLACE;
+            state.ownerId = ctx.localId; state.seq = buildSeqOut_++;
+            state.accepted = accepted ? 1 : 0;
+            state.ackOwnerId = p.ownerId; state.ackSeq = seen;
+            ctx.net->queueBuildPlace(state);
+            char b[224];
+            _snprintf(b, sizeof(b) - 1,
+                      "[build] PLACE-INTENT-APPLY key=%u.%u.%u.%u.%u owner=%u "
+                      "req=%u accepted=%d rc=%d ack=%u",
+                      k.t, k.c, k.cs, k.i, k.s, p.ownerId, p.seq,
+                      accepted ? 1 : 0, rc, seen);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            continue;
+        }
+
+        u32& seen = buildRemoveIntentSeen_[requestKey];
+        std::map<Key, OwnBuild>::iterator found = ownBuilds_.find(k);
+        bool accepted = found != ownBuilds_.end() && found->second.removed;
+        bool transientFailure = false;
+        if (hostIntentIsNew(seen, p.seq)) {
+            if (!bdoorSync_ || found == ownBuilds_.end()) {
+                seen = p.seq; // permanent unknown/disabled rejection
+            } else if (found->second.removed) {
+                accepted = true; seen = p.seq;
+            } else {
+                bool ok = engine::destroyBuildingByHand(ctx.gw, found->second.hand);
+                if (ok) {
+                    found->second.removed = true;
+                    accepted = true; seen = p.seq;
+                } else {
+                    transientFailure = true; // ack=0 leaves the same seq pending
+                }
+            }
+        }
+        BuildRemovePacket state;
+        memset(&state, 0, sizeof(state));
+        state.type = (u8)PKT_BUILD_REMOVE; state.ownerId = ctx.localId;
+        state.seq = buildSeqOut_++;
+        state.key[0] = k.t; state.key[1] = k.c; state.key[2] = k.cs;
+        state.key[3] = k.i; state.key[4] = k.s;
+        state.accepted = accepted ? 1 : 0;
+        state.ackOwnerId = p.ownerId;
+        state.ackSeq = transientFailure ? 0 : seen;
+        ctx.net->queueBuildRemove(state);
+        char b[192];
+        _snprintf(b, sizeof(b) - 1,
+                  "[build] REMOVE-INTENT-APPLY key=%u.%u.%u.%u.%u owner=%u "
+                  "req=%u accepted=%d ack=%u",
+                  k.t, k.c, k.cs, k.i, k.s, p.ownerId, p.seq,
+                  accepted ? 1 : 0, state.ackSeq);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+    }
+}
+
 void Replicator::applyBuilds(const SyncContext& ctx) {
     GameWorld* gw = ctx.gw; Inbound& in = *ctx.in;
-    // Announcements first (same-channel ordered-reliable means a STATE row
-    // never precedes its PLACE on the wire; keep that property here too).
-    std::deque<InboundBuildPlace> places;
-    in.drainBuildPlace(places);
-    std::deque<InboundBuildState> states;
-    in.drainBuildState(states);
-    if (!buildSync_) return;
+    std::deque<InboundBuildPlace> places; in.drainBuildPlace(places);
+    std::deque<InboundBuildState> states; in.drainBuildState(states);
+    std::deque<InboundBuildRemove> removes; in.drainBuildRemove(removes);
+    if (!buildSync_ || ctx.isHost) return; // Host is the sole state publisher
+
+    // Canonical placement first. If this key is the Join's optimistic local
+    // placement, adopt it in-place; otherwise mint the Host's placement.
     for (std::deque<InboundBuildPlace>::iterator it = places.begin();
          it != places.end(); ++it) {
         const BuildPlacePacket& p = it->pkt;
-        if (p.sid[0] == '\0') continue;
         Key k; k.t = p.key[0]; k.c = p.key[1]; k.cs = p.key[2];
         k.i = p.key[3]; k.s = p.key[4];
-        if (peerBuilds_.find(k) != peerBuilds_.end())
-            continue; // already minted (or mint already refused) - dedupe
+        std::map<Key, OwnBuild>::iterator own = ownBuilds_.find(k);
+        bool settled = own != ownBuilds_.end() &&
+            hostIntentAckCovers(ctx.localId, own->second.pendingPlaceSeq,
+                                p.ackOwnerId, p.ackSeq);
+        if (!p.accepted) {
+            if (!settled) continue;
+            own->second.pendingPlaceSeq = 0;
+            own->second.pendingPlaceSendMs = 0;
+            if (!own->second.removed) {
+                engine::destroyBuildingByHand(gw, own->second.hand);
+                own->second.removed = true;
+            }
+            coop::logLine("[build] PLACE-REJECT optimistic site removed");
+            continue;
+        }
+        if (own != ownBuilds_.end()) {
+            if (settled) {
+                own->second.pendingPlaceSeq = 0;
+                own->second.pendingPlaceSendMs = 0;
+            }
+            continue; // the local committed preview is already this building
+        }
+        if (!p.sid[0] || peerBuilds_.find(k) != peerBuilds_.end()) continue;
         PeerBuild& pb = peerBuilds_[k];
-        // Mint INCOMPLETE always: the placer's STATE rows drive progress from
-        // here (a real UI placement starts at 0 anyway).
         int rc = engine::placeBuildingAt(gw, p.sid, p.x, p.y, p.z, p.yaw,
-                                         /*completed*/false, pb.localHand);
+                                         false, pb.localHand);
         pb.minted = (rc == 1) ? 1 : 0;
         if (pb.minted) {
-            // Reverse translation (protocol 28): the door sampler and the
-            // protocol-26 filter recognize this proxy by its LOCAL hand.
-            Key lk; lk.t = pb.localHand[0]; lk.c = pb.localHand[1];
-            lk.cs = pb.localHand[2]; lk.i = pb.localHand[3]; lk.s = pb.localHand[4];
-            mintByLocal_[lk] = k;
+            Key local; local.t = pb.localHand[0]; local.c = pb.localHand[1];
+            local.cs = pb.localHand[2]; local.i = pb.localHand[3];
+            local.s = pb.localHand[4]; mintByLocal_[local] = k;
         }
         char b[240];
         _snprintf(b, sizeof(b) - 1,
                   "[build] MINT key=%u.%u.%u.%u.%u sid='%s' ui=%u rc=%d "
                   "local=%u.%u.%u.%u.%u",
                   p.key[0], p.key[1], p.key[2], p.key[3], p.key[4],
-                  p.sid, p.fromUi, rc,
-                  pb.localHand[0], pb.localHand[1], pb.localHand[2],
-                  pb.localHand[3], pb.localHand[4]);
+                  p.sid, p.fromUi, rc, pb.localHand[0], pb.localHand[1],
+                  pb.localHand[2], pb.localHand[3], pb.localHand[4]);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
+
     for (std::deque<InboundBuildState>::iterator it = states.begin();
          it != states.end(); ++it) {
         const BuildStatePacket& p = it->pkt;
         Key k; k.t = p.key[0]; k.c = p.key[1]; k.cs = p.key[2];
         k.i = p.key[3]; k.s = p.key[4];
-        std::map<Key, PeerBuild>::iterator f = peerBuilds_.find(k);
-        if (f == peerBuilds_.end() || !f->second.minted)
-            continue; // mint refused or key unknown - skip silently
-        PeerBuild& pb = f->second;
-        if (pb.removed) continue; // tombstoned (REMOVE already applied)
-        if (!sync::gateSeqAccept(pb.seqSeen, p.seq)) continue; // stale/dup row
-        pb.seqSeen = p.seq;
+        const unsigned int* localHand = 0; u32* seqSeen = 0;
+        std::map<Key, OwnBuild>::iterator own = ownBuilds_.find(k);
+        if (own != ownBuilds_.end() && !own->second.removed) {
+            localHand = own->second.hand; seqSeen = &own->second.seqSeen;
+        } else {
+            std::map<Key, PeerBuild>::iterator peer = peerBuilds_.find(k);
+            if (peer != peerBuilds_.end() && peer->second.minted && !peer->second.removed) {
+                localHand = peer->second.localHand; seqSeen = &peer->second.seqSeen;
+            }
+        }
+        if (!localHand || !seqSeen || !sync::gateSeqAccept(*seqSeen, p.seq)) continue;
+        *seqSeen = p.seq;
         engine::BuildRead cur;
-        if (engine::readBuildingByHand(pb.localHand, &cur)) {
+        if (engine::readBuildingByHand(localHand, &cur)) {
             float d = cur.progress - p.progress;
-            bool progClose = (d < 0.005f && d > -0.005f);
-            if (progClose && cur.complete == (int)p.complete)
-                continue; // already converged (resend)
-            if (cur.complete) continue; // completion is latched locally
+            if (d < 0.005f && d > -0.005f && cur.complete == (int)p.complete)
+                continue;
+            if (cur.complete) continue;
         }
         engine::BuildRead post;
-        // The placer's own isComplete drives completion here - see the note on
-        // writeBuildProgressByHand. Inferring it from progress crossing 1.0
-        // finished the peer's copy long before the placer's.
-        bool ok = engine::writeBuildProgressByHand(pb.localHand, p.progress,
+        bool ok = engine::writeBuildProgressByHand(localHand, p.progress,
                                                    p.complete != 0, &post);
         char b[208];
         _snprintf(b, sizeof(b) - 1,
@@ -1696,31 +1928,41 @@ void Replicator::applyBuilds(const SyncContext& ctx) {
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 
-    // Removals (protocol 28, placer-authoritative): destroy the mapped proxy
-    // through the engine's own GameWorld::destroy and tombstone the entry so
-    // any late STATE/DOOR rows for the key skip silently. Gated on bdoorSync
-    // (the removal channel ships with the placed-door slice).
-    std::deque<InboundBuildRemove> removes;
-    in.drainBuildRemove(removes);
     if (!bdoorSync_) return;
     for (std::deque<InboundBuildRemove>::iterator it = removes.begin();
          it != removes.end(); ++it) {
         const BuildRemovePacket& p = it->pkt;
         Key k; k.t = p.key[0]; k.c = p.key[1]; k.cs = p.key[2];
         k.i = p.key[3]; k.s = p.key[4];
-        std::map<Key, PeerBuild>::iterator f = peerBuilds_.find(k);
-        if (f == peerBuilds_.end() || !f->second.minted || f->second.removed)
-            continue; // never minted here or already gone - nothing to remove
-        PeerBuild& pb = f->second;
-        pb.removed = true;
-        bool ok = engine::destroyBuildingByHand(gw, pb.localHand);
+        std::map<Key, BuildRemovePending>::iterator pending = buildRemovePending_.find(k);
+        if (pending != buildRemovePending_.end() &&
+            hostIntentAckCovers(ctx.localId, pending->second.seq,
+                                p.ackOwnerId, p.ackSeq))
+            buildRemovePending_.erase(pending);
+        if (!p.accepted) continue;
+
+        unsigned int localHand[5] = { 0, 0, 0, 0, 0 };
+        bool have = false; bool already = false;
+        std::map<Key, OwnBuild>::iterator own = ownBuilds_.find(k);
+        if (own != ownBuilds_.end()) {
+            memcpy(localHand, own->second.hand, sizeof(localHand));
+            already = own->second.removed; own->second.removed = true; have = true;
+        } else {
+            std::map<Key, PeerBuild>::iterator peer = peerBuilds_.find(k);
+            if (peer != peerBuilds_.end() && peer->second.minted) {
+                memcpy(localHand, peer->second.localHand, sizeof(localHand));
+                already = peer->second.removed; peer->second.removed = true; have = true;
+            }
+        }
+        if (!have) continue;
+        bool ok = already || engine::destroyBuildingByHand(gw, localHand);
         char b[192];
         _snprintf(b, sizeof(b) - 1,
                   "[build] REMOVE-RECV key=%u.%u.%u.%u.%u ok=%d "
                   "local=%u.%u.%u.%u.%u seq=%u",
                   p.key[0], p.key[1], p.key[2], p.key[3], p.key[4], ok ? 1 : 0,
-                  pb.localHand[0], pb.localHand[1], pb.localHand[2],
-                  pb.localHand[3], pb.localHand[4], p.seq);
+                  localHand[0], localHand[1], localHand[2], localHand[3],
+                  localHand[4], p.seq);
         b[sizeof(b) - 1] = '\0'; coop::logLine(b);
     }
 }
@@ -1745,6 +1987,9 @@ void Replicator::driveSampledChannels(const SyncContext& ctx) {
         ChFn               apply;
         bool               hostAuth; // true = host publishes / join applies
     };
+    // Requests must land before this tick's Host sample so the resulting
+    // placement/removal and progress state are published in canonical order.
+    if (ctx.isHost && buildSync_) applyBuildIntents(ctx);
     static const Desc kCh[] = {
         { &Replicator::factionSync_,  0,                     &Replicator::publishFactions,   &Replicator::applyFactions,   false },
         { &Replicator::doorSync_,     0,                     &Replicator::publishDoors,      &Replicator::applyDoors,      false },
@@ -1791,12 +2036,16 @@ void Replicator::onPeerConnected(NetLink& net, u32 ownerId) {
                 pkt.type    = (u8)PKT_BUILD_REMOVE;
                 pkt.ownerId = ownerId;
                 pkt.seq     = buildSeqOut_++;
-                for (unsigned int h = 0; h < 5; ++h) pkt.key[h] = ob.hand[h];
+                pkt.key[0] = it->first.t; pkt.key[1] = it->first.c;
+                pkt.key[2] = it->first.cs; pkt.key[3] = it->first.i;
+                pkt.key[4] = it->first.s; pkt.accepted = 1;
                 net.queueBuildRemove(pkt);
                 ++nRemove;
             } else {
                 ob.ann.ownerId = ownerId;
                 ob.ann.seq     = buildSeqOut_++;
+                ob.ann.accepted = 1;
+                ob.ann.ackOwnerId = 0; ob.ann.ackSeq = 0;
                 net.queueBuildPlace(ob.ann);
                 // Un-latch the STATE row: the next publishBuilds sample sees
                 // "changed" against the reset baseline and sends one fresh

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -82,7 +82,7 @@ Replicator::Replicator()
       claimSendMs_(0), claimAssertMs_(0), claimMapMs_(0),
       facSeqOut_(1), facSampleMs_(0), factionSync_(true),
       doorSeqOut_(1), doorSampleMs_(0), doorSync_(true),
-      buildSeqOut_(1), buildSampleMs_(0), buildSync_(true),
+      buildSeqOut_(1), buildIntentSeqOut_(1), buildSampleMs_(0), buildSync_(true),
       bdoorSeqOut_(1), bdoorSampleMs_(0), bdoorSync_(true),
       hungerSync_(true),
       prodSeqOut_(1), prodSampleMs_(0), prodSync_(true),
@@ -242,6 +242,9 @@ void Replicator::resetSession() {
     // reloaded save re-seeds them on first sample).
     ownBuilds_.clear();
     peerBuilds_.clear();
+    buildRemovePending_.clear();
+    buildPlaceIntentSeen_.clear();
+    buildRemoveIntentSeen_.clear();
     mintByLocal_.clear();
     bdoorRows_.clear();
     doorRows_.clear();

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -30,6 +30,7 @@
 #include "../plugin/core/SteamId.h"
 #include "../plugin/core/WorkPose.h"
 #include "../plugin/core/DeathLatch.h"
+#include "../plugin/core/HostIntent.h" // protocol 59 reusable intent/ack policy
 #include "../plugin/core/Inbound.h" // Phase 0 queue-lifecycle fixes (header-only)
 #include "../plugin/game/EngineFaults.h" // Phase 5c: fault throttle (pure inline)
 #include "../plugin/game/EngineCaps.h"   // Phase 5d: capability registry (pure inline)
@@ -101,10 +102,11 @@ static void testSizes() {
     CHECK_EQ("sizeof(FactionPacket)",           sizeof(FactionPacket),           61);
     CHECK_EQ("sizeof(TimePacket)",              sizeof(TimePacket),              17);
     CHECK_EQ("sizeof(DoorPacket)",              sizeof(DoorPacket),              31);
-    CHECK_EQ("sizeof(BuildPlacePacket)",        sizeof(BuildPlacePacket),        94);
+    CHECK_EQ("sizeof(BuildPlacePacket)",        sizeof(BuildPlacePacket),       103);
     CHECK_EQ("sizeof(BuildStatePacket)",        sizeof(BuildStatePacket),        34);
     CHECK_EQ("sizeof(BuildDoorPacket)",         sizeof(BuildDoorPacket),         32);
-    CHECK_EQ("sizeof(BuildRemovePacket)",       sizeof(BuildRemovePacket),       29);
+    CHECK_EQ("sizeof(BuildRemovePacket)",       sizeof(BuildRemovePacket),       38);
+    CHECK_EQ("sizeof(BuildIntentPacket)",       sizeof(BuildIntentPacket),       95);
     CHECK_EQ("sizeof(SaveReqPacket)",           sizeof(SaveReqPacket),           57);
     CHECK_EQ("sizeof(SaveBeginPacket)",         sizeof(SaveBeginPacket),         67);
     CHECK_EQ("sizeof(SaveFileHeader)",          sizeof(SaveFileHeader),          19);
@@ -310,8 +312,13 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v55: runtime-fixture identity)",
-             (int)PROTOCOL_VERSION, 55);
+    CHECK_EQ("PROTOCOL_VERSION (v59: host-canonical build intents)",
+             (int)PROTOCOL_VERSION, 59);
+    CHECK("PKT_BUILD_INTENT reserves series slot 52",
+          (int)PKT_BUILD_INTENT == 52 && PKT_BUILD_INTENT != PKT_BUILD_PLACE &&
+          PKT_BUILD_INTENT != PKT_BUILD_REMOVE && PKT_BUILD_INTENT != PKT_FIXTURE);
+    CHECK("build intent operations distinct",
+          BUILD_INTENT_PLACE != BUILD_INTENT_REMOVE && BUILD_INTENT_PLACE != 0);
 
     // Protocol 52: the shared money pool. The two players spend from ONE wallet,
     // so the join reports CHANGES and the host the authoritative TOTAL - swap
@@ -482,6 +489,7 @@ static void testRoundTrips() {
     roundTrip<BuildStatePacket>("BuildStatePacket", (u8)PKT_BUILD_STATE);
     roundTrip<BuildDoorPacket>("BuildDoorPacket", (u8)PKT_BUILD_DOOR);
     roundTrip<BuildRemovePacket>("BuildRemovePacket", (u8)PKT_BUILD_REMOVE);
+    roundTrip<BuildIntentPacket>("BuildIntentPacket", (u8)PKT_BUILD_INTENT);
     roundTrip<StealthPacket>("StealthPacket", (u8)PKT_STEALTH);
     roundTrip<SpawnReqPacket>("SpawnReqPacket", (u8)PKT_SPAWN_REQ);
     roundTrip<SpawnInfoPacket>("SpawnInfoPacket", (u8)PKT_SPAWN_INFO);
@@ -1386,6 +1394,7 @@ static void testFlushWorldStateContract() {
     BuildStatePacket  bs; std::memset(&bs,  0, sizeof(bs));
     BuildDoorPacket   bd; std::memset(&bd,  0, sizeof(bd));
     BuildRemovePacket br; std::memset(&br,  0, sizeof(br));
+    BuildIntentPacket bi; std::memset(&bi,  0, sizeof(bi));
     StealthPacket   sl;  std::memset(&sl,  0, sizeof(sl));
     SpawnReqPacket  sq;  std::memset(&sq,  0, sizeof(sq));
     SpawnInfoPacket si;  std::memset(&si,  0, sizeof(si));
@@ -1431,6 +1440,7 @@ static void testFlushWorldStateContract() {
     in.pushBuildState(1, bs);
     in.pushBuildDoor(1, bd);
     in.pushBuildRemove(1, br);
+    in.pushBuildIntent(1, bi);
     in.pushStealth(1, sl);
     in.pushSpawnReq(1, sq);
     in.pushSpawnInfo(1, si);
@@ -1484,6 +1494,7 @@ static void testFlushWorldStateContract() {
     WS_EMPTY("buildState",  InboundBuildState,  drainBuildState);
     WS_EMPTY("buildDoor",   InboundBuildDoor,   drainBuildDoor);
     WS_EMPTY("buildRemove", InboundBuildRemove, drainBuildRemove);
+    WS_EMPTY("buildIntent", InboundBuildIntent, drainBuildIntents);
     WS_EMPTY("stealth",     InboundStealth,     drainStealth);
     WS_EMPTY("spawnReq",    InboundSpawnReq,    drainSpawnReqs);
     WS_EMPTY("spawnInfo",   InboundSpawnInfo,   drainSpawnInfos);
@@ -1765,6 +1776,32 @@ static void testChangeGate() {
     CHECK("door change no throttle",
           gateShouldSend(true, 80001, 80000, 0, 10000, false));
 }
+// ---- Reusable Host-canonical intent contract (protocol 59) -----------------
+static void testHostIntentPolicy() {
+    std::printf("== host-canonical build intent policy ==\n");
+    CHECK("intent sequence starts at one", hostIntentIsNew(0u, 1u));
+    CHECK("intent duplicate is idempotent", !hostIntentIsNew(7u, 7u));
+    CHECK("intent older row is stale", !hostIntentIsNew(7u, 6u));
+    CHECK("intent newer row accepted", hostIntentIsNew(7u, 8u));
+    CHECK("intent zero is reserved", !hostIntentIsNew(0u, 0u));
+
+    CHECK("ack settles matching owner+seq",
+          hostIntentAckCovers(22u, 5u, 22u, 5u));
+    CHECK("later ack covers pending",
+          hostIntentAckCovers(22u, 5u, 22u, 6u));
+    CHECK("other owner's ack cannot settle",
+          !hostIntentAckCovers(22u, 5u, 23u, 99u));
+    CHECK("older ack cannot settle",
+          !hostIntentAckCovers(22u, 5u, 22u, 4u));
+    CHECK("no pending intent cannot settle",
+          !hostIntentAckCovers(22u, 0u, 22u, 9u));
+
+    CHECK("intent first send due", hostIntentRetryDue(1000ul, 0ul, 2000ul));
+    CHECK("intent retry held before deadline",
+          !hostIntentRetryDue(2999ul, 1000ul, 2000ul));
+    CHECK("intent retry due at deadline",
+          hostIntentRetryDue(3000ul, 1000ul, 2000ul));
+}
 
 int main() {
     std::printf("prototest: KenshiCoop wire/hash/interp unit layer (protocol v%u)\n",
@@ -1774,6 +1811,7 @@ int main() {
     testEngineFaults();
     testEngineCaps();
     testChangeGate();
+    testHostIntentPolicy();
     testRoundTrips();
     testFraming();
     testSaveCrc();


### PR DESCRIPTION
## Summary

- keep the Join placement UI responsive while routing create/remove decisions through reliable idempotent intents
- make the Host the sole publisher of canonical placement, construction progress and removal state
- explicitly acknowledge retries so packet loss/reconnect cannot create duplicate buildings or apply dismantle twice
- preserve the original placer key for build-task, inventory and placed-door translation

## Problem

Protocol 27/28 currently makes the placer authoritative. That means a Join-created site and its removal can become a second world writer, which conflicts with the host-authoritative model used for shared machines and makes desync hard to heal.

This addresses the authority portion of #38.

## Flow

Join commits local preview -> reliable PLACE intent -> Host validates/mints canonical site -> Host publishes PLACE + ack -> Host alone publishes progress.

Join dismantles local mapped site -> reliable REMOVE intent -> Host destroys canonical site -> Host publishes tombstone + ack.

Retries reuse the same per-Join sequence and are folded idempotently.

## Dependency and scope

Depends on #73 for the peer-minted Host copy to receive valid local player-faction ownership. This PR deliberately does not duplicate that engine-sensitive ownership fix.

Does not change the placed-door state channel (#76 handles door/lock authority separately). Does not attempt construction-material inventory authority; that belongs with inventory/container synchronization.

## Compatibility

Wire layout changes and protocol advances from 55 to 59. Slots 49-51 remain reserved for sibling PRs #75, #76 and #78; `PKT_BUILD_INTENT` uses 52. Mixed versions remain unsupported.

## Validation

- [x] exact base: `5a761e19a4184b42315e96ea7e92e3c1403d54db`
- [x] structural protocol/direction/idempotency contracts
- [x] project XML parses
- [x] `git diff --check`
- [ ] VC10 Harness/plugin build (v100 toolchain unavailable here)
- [ ] two-client Host/Join regression

## Manual validation requested

- Join places a workbench; Host mints one canonical site and Join does not duplicate it on ack/retry
- both sides build it; progress converges from Host
- Join dismantles it; both sides converge and retry does not double-remove
- repeat Host -> Join
- disconnect/reconnect and save/reload
- verify ownership/usability with #73 applied
