### PR TITLE
Fence coordinated saves on owner-authored inventory state

### DIFF
--- a/src/netproto/Wire.h
+++ b/src/netproto/Wire.h
@@ -25,7 +25,7 @@ typedef double         f64;
 // this header stays a definition file. When you bump PROTOCOL_VERSION, add the
 // matching entry at the bottom of that doc. The version is checked at handshake
 // and a mismatch is rejected (no back-compat).
-const u16 PROTOCOL_VERSION = 55;
+const u16 PROTOCOL_VERSION = 60;
 
 // Packet type tags (first byte of every packet).
 enum PacketType {
@@ -76,7 +76,10 @@ enum PacketType {
     PKT_INV_XFER_ACK     = 45,// RELIABLE transfer verdict (protocol 50); InvXferAckPacket
     PKT_MONEY_DELTA      = 46,// RELIABLE join money-pool delta (join -> host, protocol 52); MoneyDeltaPacket
     PKT_DEED             = 47,// RELIABLE property-ownership row (protocol 54); DeedPacket
-    PKT_FIXTURE          = 48 // RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    PKT_FIXTURE          = 48,// RELIABLE runtime-fixture identity row (protocol 55); FixturePacket
+    // Protocols 56-59 / packet ids 49-52 are reserved by the preceding
+    // host-canonical series PRs (production, doors, furniture, construction).
+    PKT_INV_SAVE_FENCE   = 53 // RELIABLE pre-save inventory checkpoint marker (protocol 60); InvSaveFencePacket
 };
 
 // One-shot transition events carried on the RELIABLE channel. Continuous state
@@ -553,6 +556,33 @@ const u8 INV_FLAG_TRUNCATED = 0x01;
 // INV_FLAG_TRUNCATED becomes the rare fallback (big storage chests) rather than the
 // routine case. Bounded by the u8 `count` field (255).
 const unsigned int INV_ITEMS_MAX = 64;
+
+// ---- Protocol 60: inventory save fence -------------------------------------
+// A coordinated save is authoritative only if the host has first applied the
+// join's latest owner-authored inventory snapshots. SaveManager::save starts a
+// deferred multi-file write immediately, while an inventory edit may still be
+// waiting out the snapshot settle window or crossing the network; without a
+// fence, the host can bake the prior backpack contents and the next load erases
+// the join's newer items.
+//
+// The host sends REQ with a monotonic fenceId. The join waits until every
+// inventory it authors is stable under the ordinary cursor/removal debounce,
+// queues a full reliable snapshot for each, then queues ACK on the SAME ordered
+// reliable channel. The host therefore knows all snapshots preceding the ACK
+// have reached its inbound queues. Because snapshots and ACKs drain through
+// separate main-thread queues, it waits two complete game ticks for ingestion
+// and post-engine apply, then re-issues the native save before watching and
+// transferring that folder.
+//
+// containers/truncated are ACK diagnostics (zero in REQ). A truncated snapshot
+// remains additive-only, so the save is loss-safe but the warning stays visible.
+struct InvSaveFencePacket {
+    u8  type;       // = PKT_INV_SAVE_FENCE; Host->Join REQ, Join->Host ACK
+    u32 ownerId;    // network player id of the sender
+    u32 fenceId;    // host-monotonic request id
+    u16 containers; // ACK: number of full container snapshots queued
+    u16 truncated;  // ACK: how many carried INV_FLAG_TRUNCATED
+};
 
 // ---- Phase W1: world-item (ground drop) snapshot ---------------------------
 // Generalizes the Phase 4a content-snapshot/reconcile model from CONTAINERS to the open

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -107,6 +107,14 @@ struct SessionController {
     // Coordinated save (protocol 31).
     std::string  savePending;      // host: save name awaiting quiescence
     coop::u32    saveReqId;        // join: monotonic PKT_SAVE_REQ counter
+    // Protocol 60: host save cannot be canonical until the join's latest
+    // owner-authored inventory snapshots have crossed and been applied.
+    coop::u32    saveFenceId;       // host: monotonic request id
+    coop::u32    saveFenceWaiting;  // host: non-zero while waiting for ACK
+    coop::u32    saveFenceAckTick;  // main-loop tick ACK was observed (apply follows)
+    DWORD        saveFenceStartTick;// timeout base
+    coop::u16    saveFenceContainers;
+    coop::u16    saveFenceTruncated;
     // Push-save-on-connect bootstrap (host): when a peer connects the host bakes
     // a fresh save of its live world and, once the folder quiesces, sends the
     // join a LOAD_GO for it (not a blind stream) - the join loads it if it has an
@@ -138,7 +146,9 @@ struct SessionController {
     SessionController()
       : gameStarted(false), gameStartTick(0), autoLoadDone(false),
         titleFirstTick(0), peerPresent(false),
-        saveReqId(0), bootstrapArmed(false),
+        saveReqId(0), saveFenceId(0), saveFenceWaiting(0),
+        saveFenceAckTick(0), saveFenceStartTick(0),
+        saveFenceContainers(0), saveFenceTruncated(0), bootstrapArmed(false),
         swapStartTick(0), swapHookTicks(0),
         loadSuppressOn(false), loadIdOut(0), loadIdSeen(0), loadReqId(0),
         loadCommitBase(0), loadPumpArmTick(0) {}
@@ -152,6 +162,12 @@ DWORD&       g_titleFirstTick  = g_session.titleFirstTick;
 bool&        g_peerPresent     = g_session.peerPresent;
 std::string& g_savePending     = g_session.savePending;
 coop::u32&   g_saveReqId       = g_session.saveReqId;
+coop::u32&   g_saveFenceId     = g_session.saveFenceId;
+coop::u32&   g_saveFenceWaiting = g_session.saveFenceWaiting;
+coop::u32&   g_saveFenceAckTick = g_session.saveFenceAckTick;
+DWORD&       g_saveFenceStartTick = g_session.saveFenceStartTick;
+coop::u16&   g_saveFenceContainers = g_session.saveFenceContainers;
+coop::u16&   g_saveFenceTruncated = g_session.saveFenceTruncated;
 bool&        g_bootstrapArmed  = g_session.bootstrapArmed;
 std::string& g_bootstrapName   = g_session.bootstrapName;
 DWORD&       g_swapStartTick   = g_session.swapStartTick;
@@ -235,12 +251,21 @@ void warnIfNoPortraits(const std::string& name) {
 // a fixed order; centralizing them keeps that order from drifting between the
 // several edges that each need one.
 
+void clearInventorySaveFence() {
+    g_saveFenceWaiting = 0;
+    g_saveFenceAckTick = 0;
+    g_saveFenceStartTick = 0;
+    g_saveFenceContainers = 0;
+    g_saveFenceTruncated = 0;
+}
+
 // UI connect/disconnect teardown: the world is live (reconnect/disconnect from
 // within a running game), so despawn our minted NPC + world-item proxies before
 // clearing the maps - else a reconnect leaves orphaned duplicates or bakes them
 // into the next save. Falls back to a plain map reset if no world has ticked yet.
 void sessionResetForUi() {
     g_peerPresent = false;
+    clearInventorySaveFence();
     if (g_lastGw) g_repl.clearPeerReplicationState(g_lastGw);
     else          g_repl.resetSession();
     g_inbound.flushWorldState();
@@ -253,6 +278,7 @@ void sessionResetForUi() {
 // OWN reload edge, and the synchronous-swap backstop reuses it, so the reset
 // order (repl maps, then inbound queues) is defined in exactly one place.
 void sessionResetForWorldReload() {
+    clearInventorySaveFence();
     g_repl.resetSession();
     g_inbound.flushWorldState();
     g_net.bumpSessionEpoch(); // v44: post-reload batches supersede the old session
@@ -278,6 +304,60 @@ void armConnectPush() {
     b[sizeof(b) - 1] = '\0'; coopLog(b);
     if (!coop::engine::saveGameAs(name))
         coopErr("[boot] connect-push save FAILED to issue");
+}
+
+// Protocol 60: saving is a barrier, not just a local button edge. The native
+// call that produced the SaveEdge may already be writing, so the host asks for
+// a stable owner-authored inventory checkpoint, applies it, then re-issues the
+// same save with edge capture bypassed. Only that second write is watched and
+// transferred. This preserves Kenshi's ordinary save slot semantics (no
+// sidecar and no pre-load live-state restore).
+const DWORD INV_SAVE_FENCE_TIMEOUT_MS = 15000;
+
+void armInventorySaveFence(const std::string& name) {
+    g_savePending = name;
+    ++g_saveFenceId;
+    if (g_saveFenceId == 0) ++g_saveFenceId; // 0 means no fence
+    g_saveFenceWaiting = g_saveFenceId;
+    g_saveFenceAckTick = 0;
+    g_saveFenceStartTick = GetTickCount();
+    g_saveFenceContainers = 0;
+    g_saveFenceTruncated = 0;
+
+    coop::InvSaveFencePacket req;
+    memset(&req, 0, sizeof(req));
+    req.type = (coop::u8)coop::PKT_INV_SAVE_FENCE;
+    req.ownerId = g_net.localId();
+    req.fenceId = g_saveFenceWaiting;
+    g_net.queueInvSaveFence(req);
+    char b[144];
+    _snprintf(b, sizeof(b) - 1,
+              "[invsave] REQ->join fence=%u name='%s'",
+              req.fenceId, name.c_str());
+    b[sizeof(b) - 1] = '\0'; coopLog(b);
+}
+
+void issueInventoryFencedResave(const char* why) {
+    if (g_savePending.empty()) { clearInventorySaveFence(); return; }
+    const std::string name = g_savePending;
+    // The detour must pass this native write through but not report another
+    // SaveEdge, or the re-save recursively starts a fresh fence forever.
+    coop::engine::setSaveEdgeBypassOnce();
+    bool ok = coop::engine::saveGameAs(name);
+    // saveGameAs can fail before reaching the detour. Never let an unconsumed
+    // one-shot bypass suppress the user's next genuine save edge.
+    coop::engine::clearSaveEdgeBypass();
+    coop::savexfer::armWatch(name);
+    char b[208];
+    _snprintf(b, sizeof(b) - 1,
+              "[invsave] RESAVE fence=%u name='%s' reason=%s containers=%u "
+              "truncated=%u issued=%d",
+              g_saveFenceWaiting, name.c_str(), why ? why : "unknown",
+              (unsigned)g_saveFenceContainers, (unsigned)g_saveFenceTruncated,
+              ok ? 1 : 0);
+    b[sizeof(b) - 1] = '\0';
+    if (ok) coopLog(b); else coopErr(b);
+    clearInventorySaveFence();
 }
 
 // Drain peer connect/leave events and surface a single game-thread confirmation
@@ -324,6 +404,7 @@ void processNetEvents(GameWorld* gw) {
         // release any carry or occupancy its driven copies still hold.
         if (gw && (g_cfg.carrySync || g_cfg.furnSync)) g_repl.sweepCarries(gw);
         g_peerPresent = false;
+        clearInventorySaveFence();
         // Coordinated save: disconnected = solo again; local saves must work.
         if (!g_cfg.isHost && g_cfg.saveSync) {
             coop::engine::setSaveSuppress(false);
@@ -398,6 +479,42 @@ void pumpSaveReceive() {
 // drives a coordinated save). Received BEGIN/FILE/DONE stage + verify +
 // commit the host's folder; the ACK reports the outcome.
 void driveSaveSync() {
+    // Protocol 60 inventory fence messages ride CH_RELIABLE beside the
+    // snapshots they order. The join latches REQ for publishInventories; the
+    // host observes ACK only after every preceding snapshot was queued inbound.
+    // The two payloads use separate inbound queues, however, so an ACK can be
+    // drained just after this tick's ingestInv pass while its snapshots wait for
+    // the next pass. Applying is post-engine; waiting TWO complete main-loop
+    // ticks after ACK covers that race before re-issuing the native save.
+    std::deque<coop::InboundInvSaveFence> invFences;
+    g_inbound.drainInvSaveFences(invFences);
+    for (std::deque<coop::InboundInvSaveFence>::iterator it = invFences.begin();
+         it != invFences.end(); ++it) {
+        if (!g_cfg.isHost && it->pkt.type == (coop::u8)coop::PKT_INV_SAVE_FENCE) {
+            g_repl.requestInventorySaveFence(it->pkt.fenceId);
+            char b[112]; _snprintf(b, sizeof(b) - 1,
+                "[invsave] REQ received fence=%u", it->pkt.fenceId);
+            b[sizeof(b) - 1] = '\0'; coopLog(b);
+        } else if (g_cfg.isHost &&
+                   it->pkt.type == (coop::u8)coop::PKT_INV_SAVE_FENCE) {
+            if (it->pkt.fenceId != g_saveFenceWaiting || g_saveFenceWaiting == 0) {
+                char b[128]; _snprintf(b, sizeof(b) - 1,
+                    "[invsave] stale ACK fence=%u waiting=%u ignored",
+                    it->pkt.fenceId, g_saveFenceWaiting);
+                b[sizeof(b) - 1] = '\0'; coopLog(b);
+                continue;
+            }
+            g_saveFenceAckTick = g_tick;
+            g_saveFenceContainers = it->pkt.containers;
+            g_saveFenceTruncated = it->pkt.truncated;
+            char b[144]; _snprintf(b, sizeof(b) - 1,
+                "[invsave] ACK<-join fence=%u containers=%u truncated=%u",
+                it->pkt.fenceId, (unsigned)it->pkt.containers,
+                (unsigned)it->pkt.truncated);
+            b[sizeof(b) - 1] = '\0'; coopLog(b);
+        }
+    }
+
     // Local save edges from the detour (max 8 queued per tick).
     coop::engine::SaveEdge edges[8];
     unsigned int nEdges = coop::engine::drainSaveEdges(edges, 8);
@@ -405,7 +522,10 @@ void driveSaveSync() {
         std::string name = edges[i].name[0] ? edges[i].name : "coopresume";
         if (g_cfg.isHost) {
             g_savePending = name;
-            coop::savexfer::armWatch(name);
+            if (g_peerPresent && g_cfg.invSync)
+                armInventorySaveFence(name);
+            else
+                coop::savexfer::armWatch(name);
         } else if (edges[i].suppressed && !edges[i].autosave) {
             coop::SaveReqPacket rq;
             memset(&rq, 0, sizeof(rq));
@@ -440,7 +560,23 @@ void driveSaveSync() {
                 coopErr("[save] join-requested save FAILED to issue");
         }
 
-        // Quiescence watch -> start the transfer once the save is on disk.
+        // ACK may have raced just behind this tick's inventory drain. By two
+        // ticks later, every snapshot that preceded it was necessarily ingested
+        // on the intervening pre-engine pass and applied on that pass's
+        // post-engine stage.
+        if (g_saveFenceWaiting != 0 && g_saveFenceAckTick != 0 &&
+            (coop::u32)(g_tick - g_saveFenceAckTick) >= 2) {
+            issueInventoryFencedResave("ack-applied");
+        } else if (g_saveFenceWaiting != 0 && g_saveFenceAckTick == 0 &&
+                   GetTickCount() - g_saveFenceStartTick >= INV_SAVE_FENCE_TIMEOUT_MS) {
+            // Availability fallback: the user's first native save already ran.
+            // Re-issue using the best state we have, but say loudly that the
+            // checkpoint was not proven instead of hanging save coordination.
+            coopErr("[invsave] checkpoint TIMEOUT; re-saving best-known host state");
+            issueInventoryFencedResave("timeout");
+        }
+
+        // Quiescence watch -> start the transfer once the fenced save is on disk.
         if (coop::savexfer::watching()) {
             unsigned int files = 0;
             unsigned __int64 bytes = 0;
@@ -537,6 +673,7 @@ void driveLoadSync(GameWorld* gw) {
             // A load supersedes any in-flight save coordination.
             coop::savexfer::abortAll();
             g_savePending.clear();
+            clearInventorySaveFence();
             coop::LoadGoPacket go;
             memset(&go, 0, sizeof(go));
             go.type        = (coop::u8)coop::PKT_LOAD_GO;

--- a/src/plugin/core/Inbound.h
+++ b/src/plugin/core/Inbound.h
@@ -47,6 +47,15 @@ struct InboundInv {
     std::vector<InvItemEntry> items;
 };
 
+// One side of the protocol-60 inventory save fence. REQ asks the join to
+// publish every stable owner-authored inventory; ACK is queued after those
+// snapshots on the same reliable ordered channel. World-state: a fence for a
+// world that was reloaded/disconnected must not trigger a save in the new one.
+struct InboundInvSaveFence {
+    u32                ownerId;
+    InvSaveFencePacket pkt;
+};
+
 // One received world-item snapshot (Phase W1): the authoritative owner (host) and the
 // netId-keyed ground items in its interest sphere. The join reconciles its local proxies
 // (spawn new / update moved / leave the rest) to match.
@@ -420,6 +429,7 @@ public:
         // without bound. ent_ = ~12 s of a 20 Hz * 17-entity stream; stealth/cam
         // are ~1 Hz refreshes. Every other queue is reliable and stays unbounded.
         ent_(worldReset_, 4096),  evt_(worldReset_),        inv_(worldReset_),
+        invSaveFence_(worldReset_),
         wi_(worldReset_),         wir_(worldReset_),        wic_(worldReset_),
         npcCensus_(worldReset_),
         wd_(worldReset_),         invXfer_(worldReset_),    invXferAck_(worldReset_),
@@ -484,6 +494,11 @@ public:
         for (int k = 0; k < 5; ++k) ii.cKey[k] = cKey[k];
         if (items && count > 0) ii.items.assign(items, items + count);
         EnterCriticalSection(&cs_); inv_.push_back(ii); LeaveCriticalSection(&cs_);
+    }
+    // NET thread: one inventory save-fence request/ack, owner-tagged.
+    void pushInvSaveFence(u32 ownerId, const InvSaveFencePacket& pkt) {
+        InboundInvSaveFence isf; isf.ownerId = ownerId; isf.pkt = pkt;
+        EnterCriticalSection(&cs_); invSaveFence_.push_back(isf); LeaveCriticalSection(&cs_);
     }
     // NET thread: one received world-item snapshot, owner-tagged.
     void pushWorldItems(u32 ownerId, const WorldItemEntry* items, unsigned int count) {
@@ -709,6 +724,9 @@ public:
     void drainInv(std::deque<InboundInv>& out) {
         EnterCriticalSection(&cs_); out.swap(inv_); LeaveCriticalSection(&cs_);
     }
+    void drainInvSaveFences(std::deque<InboundInvSaveFence>& out) {
+        EnterCriticalSection(&cs_); out.swap(invSaveFence_); LeaveCriticalSection(&cs_);
+    }
     void drainWorldItems(std::deque<InboundWorldItems>& out) {
         EnterCriticalSection(&cs_); out.swap(wi_); LeaveCriticalSection(&cs_);
     }
@@ -868,6 +886,7 @@ private:
     WorldQ<InboundEntity>          ent_;
     WorldQ<InboundEvent>           evt_;
     WorldQ<InboundInv>             inv_;
+    WorldQ<InboundInvSaveFence>    invSaveFence_;
     WorldQ<InboundWorldItems>      wi_;
     WorldQ<InboundWorldRemove>     wir_;
     WorldQ<InboundWorldClaim>      wic_;

--- a/src/plugin/game/Engine.h
+++ b/src/plugin/game/Engine.h
@@ -66,6 +66,12 @@ bool installSaveHook();
 // JOIN under save-sync: suppress the LOCAL write entirely (the host's save is
 // authoritative; a manual edge is forwarded as PKT_SAVE_REQ instead).
 void setSaveSuppress(bool on);
+// Protocol 60 host-side fenced re-save: the next save still runs natively but
+// does not enqueue another SaveEdge (which would recursively start a new fence).
+void setSaveEdgeBypassOnce();
+// Cancels a bypass that was armed but not consumed (for example when the
+// resolved engine save entry point rejects the re-save before reaching hook).
+void clearSaveEdgeBypass();
 unsigned int drainSaveEdges(SaveEdge* out, unsigned int maxOut);
 
 // ---- Protocol 32: coordinated load ------------------------------------------

--- a/src/plugin/game/EngineInternal.cpp
+++ b/src/plugin/game/EngineInternal.cpp
@@ -96,6 +96,7 @@ SaveMgrExecFn g_saveMgrExecFn = 0;
 // edge is forwarded to the host as PKT_SAVE_REQ by the Plugin instead.
 std::vector<SaveEdgeRec> g_saveEdges;
 bool g_saveSuppressAll = false;
+bool g_saveBypassEdgeOnce = false;
 SaveMgrSaveNameFn g_saveHookOrig = 0;
 
 void __fastcall saveMgrSave_hook(SaveManager* self, const std::string* name,
@@ -109,19 +110,29 @@ void __fastcall saveMgrSave_hook(SaveManager* self, const std::string* name,
         }
     } __except (EXCEPTION_EXECUTE_HANDLER) { nm[0] = '\0'; }
     const bool suppress = g_saveSuppressAll;
+    const bool bypassEdge = g_saveBypassEdgeOnce;
+    g_saveBypassEdgeOnce = false;
     if (!suppress) g_saveHookOrig(self, name, autosave);
     __try {
-        SaveEdgeRec r;
-        memset(&r, 0, sizeof(r));
-        strncpy(r.name, nm, sizeof(r.name) - 1);
-        r.autosave   = autosave ? 1 : 0;
-        r.suppressed = suppress ? 1 : 0;
-        if (g_saveEdges.size() < 8) g_saveEdges.push_back(r);
-        char b[144];
-        _snprintf(b, sizeof(b) - 1,
-                  "[save] LOCAL-SAVE name='%s' autosave=%d suppressed=%d",
-                  r.name, r.autosave, r.suppressed);
-        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        if (!bypassEdge) {
+            SaveEdgeRec r;
+            memset(&r, 0, sizeof(r));
+            strncpy(r.name, nm, sizeof(r.name) - 1);
+            r.autosave   = autosave ? 1 : 0;
+            r.suppressed = suppress ? 1 : 0;
+            if (g_saveEdges.size() < 8) g_saveEdges.push_back(r);
+            char b[144];
+            _snprintf(b, sizeof(b) - 1,
+                      "[save] LOCAL-SAVE name='%s' autosave=%d suppressed=%d",
+                      r.name, r.autosave, r.suppressed);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        } else {
+            char b[128];
+            _snprintf(b, sizeof(b) - 1,
+                      "[save] FENCED-RESAVE name='%s' autosave=%d",
+                      nm, autosave ? 1 : 0);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        }
     } __except (EXCEPTION_EXECUTE_HANDLER) {}
 }
 
@@ -2096,6 +2107,9 @@ bool installSaveHook() {
 }
 
 void setSaveSuppress(bool on) { g_saveSuppressAll = on; }
+
+void setSaveEdgeBypassOnce() { g_saveBypassEdgeOnce = true; }
+void clearSaveEdgeBypass() { g_saveBypassEdgeOnce = false; }
 
 unsigned int drainSaveEdges(SaveEdge* out, unsigned int maxOut) {
     unsigned int n = 0;

--- a/src/plugin/net/NetLink.cpp
+++ b/src/plugin/net/NetLink.cpp
@@ -162,6 +162,10 @@ void NetLink::queueInvSnapshot(u32 ownerId, u8 keyKind, const u32 cKey[5],
     pushLocked(outCs_, outInv_, oi);
 }
 
+void NetLink::queueInvSaveFence(const InvSaveFencePacket& pkt) {
+    pushLocked(outCs_, outInvSaveFence_, pkt);
+}
+
 void NetLink::queueWorldItems(u32 ownerId, const WorldItemEntry* items, unsigned int count) {
     OutWorldItems ow;
     ow.ownerId = ownerId;
@@ -572,6 +576,14 @@ void NetLink::threadLoop() {
                                 inbound_->pushInv(hdr.ownerId, hdr.keyKind, cKey,
                                                   items, hdr.count, hdr.flags);
                             }
+                        }
+                    } else if (type == PKT_INV_SAVE_FENCE) {
+                        // Protocol 60 inventory save fence. Direction determines
+                        // whether the marker is a Host request or Join completion.
+                        InvSaveFencePacket sfp;
+                        if (readPacket(ev.packet->data, (unsigned)ev.packet->dataLength, &sfp)
+                            && inbound_) {
+                            inbound_->pushInvSaveFence(sfp.ownerId, sfp);
                         }
                     } else if (type == PKT_WORLD_ITEM) {
                         // Reliable world-item snapshot (Phase W1). Delivered immediately
@@ -1089,8 +1101,14 @@ void NetLink::threadLoop() {
         // is [InvSnapshotHeader][InvItemEntry*count]; only enqueued on content-change,
         // so this channel stays quiet. Reliable so the change survives WAN loss.
         std::vector<OutInv> invs;
+        std::vector<InvSaveFencePacket> invSaveFences;
         EnterCriticalSection(&outCs_);
         invs.swap(outInv_);
+        // Swap snapshots and fence markers under ONE lock. The main thread
+        // queues every checkpoint snapshot before its ACK; this atomic batch
+        // observation plus the send order below means an ACK can never overtake
+        // a snapshot, even if the two threads meet between queue calls.
+        invSaveFences.swap(outInvSaveFence_);
         LeaveCriticalSection(&outCs_);
         for (size_t i = 0; i < invs.size(); ++i) {
             unsigned count = (unsigned)invs[i].items.size();
@@ -1113,6 +1131,20 @@ void NetLink::threadLoop() {
             if (count > 0)
                 std::memcpy(out->data + sizeof(hdr), &invs[i].items[0],
                             count * sizeof(InvItemEntry));
+            if (isHost_) {
+                enet_host_broadcast(enetHost_, CH_RELIABLE, out);
+            } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {
+                enet_peer_send(serverPeer_, CH_RELIABLE, out);
+            } else {
+                enet_packet_destroy(out);
+            }
+        }
+        // Same CH_RELIABLE and strictly AFTER invs: protocol 60 relies on ENet's
+        // per-channel ordering to make ACK a real snapshot-delivery fence.
+        for (size_t i = 0; i < invSaveFences.size(); ++i) {
+            ENetPacket* out = enet_packet_create(&invSaveFences[i],
+                                                 sizeof(InvSaveFencePacket),
+                                                 ENET_PACKET_FLAG_RELIABLE);
             if (isHost_) {
                 enet_host_broadcast(enetHost_, CH_RELIABLE, out);
             } else if (serverPeer_ && serverPeer_->state == ENET_PEER_STATE_CONNECTED) {

--- a/src/plugin/net/NetLink.h
+++ b/src/plugin/net/NetLink.h
@@ -56,6 +56,10 @@ public:
     // the receiver reconciles additive-only instead of deleting past the cap.
     void queueInvSnapshot(u32 ownerId, u8 keyKind, const u32 cKey[5],
                           const InvItemEntry* items, unsigned int count, u8 flags = 0);
+    // MAIN thread: queue one side of the protocol-60 inventory save fence.
+    // The net thread swaps this queue atomically with outInv_ and sends it
+    // AFTER those snapshots on CH_RELIABLE, preserving snapshot-before-ACK.
+    void queueInvSaveFence(const InvSaveFencePacket& pkt);
 
     // MAIN thread: queue a reliable world-item snapshot (Phase W1). The net thread
     // serializes [WorldItemSnapshotHeader][WorldItemEntry*count] and sends it on the
@@ -265,6 +269,7 @@ private:
         std::vector<InvItemEntry> items;
     };
     std::vector<OutInv>      outInv_;
+    std::vector<InvSaveFencePacket> outInvSaveFence_;
     // Reliable world-item snapshots / culls queued by the main thread (Phase W1),
     // drained + serialized by the net thread. Guarded by outCs_.
     struct OutWorldItems { u32 ownerId; std::vector<WorldItemEntry> items; };

--- a/src/plugin/sync/Replicator.h
+++ b/src/plugin/sync/Replicator.h
@@ -218,6 +218,14 @@ public:
     // resend elapsed). No-op when no owned container is registered / resolves.
     void publishInventories(GameWorld* gw, NetLink& net, u32 ownerId);
 
+    // Protocol 60 pre-save fence (join side): latch a host request. The ordinary
+    // publisher waits until every owned inventory is stable under its cursor /
+    // removal debounce, forces one full snapshot per container, and queues ACK
+    // after them on the same reliable ordered channel.
+    void requestInventorySaveFence(u32 fenceId) {
+        if (fenceId > invSaveFencePending_) invSaveFencePending_ = fenceId;
+    }
+
     // BEFORE engine (BOTH clients since the W1 bidir fix): scan the interest sphere for
     // free ground items WE author (peer proxies are filtered by the echo guard), assign/
     // reuse a netId per item (keyed by its local engine hand), and queue a reliable
@@ -1416,6 +1424,7 @@ private:
     std::set<Key>          ownedContainers_;
     std::map<Key, InvPub>  invPub_;
     std::map<Key, InvRecv> invRecv_;
+    u32                    invSaveFencePending_;
     // Protocol 34: the host's ~1 Hz container census result (LOCAL hands of
     // complete STORAGE/machine-class buildings in the interest spheres).
     // Folded into the authored set each publishInventories pass while

--- a/src/plugin/sync/ReplicatorCore.cpp
+++ b/src/plugin/sync/ReplicatorCore.cpp
@@ -89,7 +89,7 @@ Replicator::Replicator()
       researchSeqOut_(1), researchSampleMs_(0), researchSync_(true),
       deedSeqOut_(1), deedSampleMs_(0), deedAuditMs_(0), deedSync_(true),
       fixtureSeqOut_(1), fixtureSampleMs_(0), fixtureSync_(true),
-      storeSync_(false), contCensusMs_(0),
+      invSaveFencePending_(0), storeSync_(false), contCensusMs_(0),
       timeSync_(true), timeBrake_(true),
       timeSlew_(1.0f), timeSeqOut_(1), timeSeqSeen_(0),
       timeLastSendMs_(0), timeLastLogMs_(0), timeSlewApplied_(-1.0f),
@@ -251,6 +251,7 @@ void Replicator::resetSession() {
     facRows_.clear();
     invPub_.clear();
     invRecv_.clear();
+    invSaveFencePending_ = 0;
     ownedContainers_.clear();
     censusContainers_.clear(); // protocol 34: re-censused in the new world
     worldTrack_.clear();

--- a/src/plugin/sync/ReplicatorItems.cpp
+++ b/src/plugin/sync/ReplicatorItems.cpp
@@ -50,7 +50,26 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
         }
         owned.insert(censusContainers_.begin(), censusContainers_.end());
     }
-    if (owned.empty()) return;
+    const bool fencePending = (invSaveFencePending_ != 0);
+    bool fenceReady = true;
+    u16 fenceContainers = 0;
+    u16 fenceTruncated = 0;
+    if (owned.empty()) {
+        // A valid ownership partition can contain no join-owned tab (one-tab
+        // saves). ACKing zero containers is still a completed fence.
+        if (fencePending) {
+            InvSaveFencePacket ack; memset(&ack, 0, sizeof(ack));
+            ack.type = (u8)PKT_INV_SAVE_FENCE; ack.ownerId = ownerId;
+            ack.fenceId = invSaveFencePending_;
+            net.queueInvSaveFence(ack);
+            char b[128]; _snprintf(b, sizeof(b) - 1,
+                "[invsave] ACK fence=%u containers=0 truncated=0 (no owned inventory)",
+                ack.fenceId);
+            b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+            invSaveFencePending_ = 0;
+        }
+        return;
+    }
     // Periodic safety resend (late join / a container returning to interest). The channel
     // is RELIABLE, so this is not loss recovery - it is a cheap re-assert. With
     // INV_ITEMS_MAX at 64 a full snapshot is ~10 KB, so a censused chest farm re-asserting
@@ -76,7 +95,10 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
         unsigned int cHand[5] = { it->t, it->c, it->cs, it->i, it->s };
         // Skip until the container actually resolves here (post-load it may not yet),
         // so we never blast a spurious "empty" snapshot that would wipe baked contents.
-        if (engine::resolveObjectByHand(cHand) == 0) continue;
+        if (engine::resolveObjectByHand(cHand) == 0) {
+            if (fencePending) fenceReady = false;
+            continue;
+        }
         u32 hash = 0;
         bool trunc = false;
         // includeNested (protocol 48): the ONLY capture that wants a worn container's own
@@ -113,7 +135,13 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
         bool changed  = differs && settled;
         unsigned long resendMs = (n >= INV_RESEND_BIG_N) ? INV_RESEND_BIG_MS : INV_RESEND_MS;
         bool periodic = sent && !differs && (now - pub.lastSendMs >= resendMs);
-        if (!changed && !periodic) continue;
+        // Protocol 60: a save fence forces one full re-assert even when the
+        // content hash is unchanged, but only after the SAME settle guard the
+        // ordinary publisher uses. This never snapshots an item held transiently
+        // on the cursor just because the host happened to save at that moment.
+        if (fencePending && !settled) fenceReady = false;
+        bool fenceSend = fencePending && settled;
+        if (!changed && !periodic && !fenceSend) continue;
         // W2 race guard: while the gear census has an unresolved DECREASE pending for this
         // container, a drop intent for it may still be debouncing (the spatial ground query
         // fails in towns, so detectAndPublishWeaponDrops retries for up to MAX_RETRY ticks).
@@ -125,6 +153,7 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
         // this reads is only ever populated by detectAndPublishWeaponDrops, which the tick
         // skips entirely when world sync is off - so the predicate is false by construction.
         if (wdPendingDrop(*it)) {
+            if (fencePending) fenceReady = false;
             static int dumpHold = -1;
             if (dumpHold < 0) { const char* e = getenv("KENSHICOOP_INV_DUMP"); dumpHold = (e && e[0] == '1') ? 1 : 0; }
             if (dumpHold) { char b[160]; _snprintf(b, sizeof(b) - 1,
@@ -152,6 +181,10 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
         u8 sflags = trunc ? INV_FLAG_TRUNCATED : (u8)0;
         net.queueInvSnapshot(ownerId, keyKind, wireKey, items, n, sflags);
         pub.hash = hash; pub.lastSendMs = now; pub.lastSentN = n; pub.lastSentUnits = units;
+        if (fenceSend) {
+            if (fenceContainers != 0xFFFFu) ++fenceContainers;
+            if (trunc && fenceTruncated != 0xFFFFu) ++fenceTruncated;
+        }
         if (changed) {
             char b[200];
             _snprintf(b, sizeof(b) - 1,
@@ -173,6 +206,21 @@ void Replicator::publishInventories(GameWorld* gw, NetLink& net, u32 ownerId) {
             if (dumpInv < 0) { const char* e = getenv("KENSHICOOP_INV_DUMP"); dumpInv = (e && e[0] == '1') ? 1 : 0; }
             if (dumpInv) { coop::logLine("[inv] SEND-state:"); engine::dumpInventory(gw, cHand); }
         }
+    }
+    if (fencePending && fenceReady) {
+        // Every checkpoint snapshot was queued before this marker. NetLink
+        // observes both queues atomically and sends the marker after snapshots
+        // on CH_RELIABLE, making this a real ordered delivery fence.
+        InvSaveFencePacket ack; memset(&ack, 0, sizeof(ack));
+        ack.type = (u8)PKT_INV_SAVE_FENCE; ack.ownerId = ownerId;
+        ack.fenceId = invSaveFencePending_;
+        ack.containers = fenceContainers; ack.truncated = fenceTruncated;
+        net.queueInvSaveFence(ack);
+        char b[160]; _snprintf(b, sizeof(b) - 1,
+            "[invsave] ACK fence=%u containers=%u truncated=%u",
+            ack.fenceId, (unsigned)ack.containers, (unsigned)ack.truncated);
+        b[sizeof(b) - 1] = '\0'; coop::logLine(b);
+        invSaveFencePending_ = 0;
     }
 }
 

--- a/src/prototest/main.cpp
+++ b/src/prototest/main.cpp
@@ -79,6 +79,7 @@ static void testSizes() {
     CHECK_EQ("sizeof(EntityBatchHeader)",       sizeof(EntityBatchHeader),       14); // v35: +sendMs; v44: +epoch
     CHECK_EQ("sizeof(InvItemEntry)",            sizeof(InvItemEntry),            159); // v42: +locked, v48: reserved byte became parentIdx (size unchanged), v51: +level (craft grade)
     CHECK_EQ("sizeof(InvSnapshotHeader)",       sizeof(InvSnapshotHeader),       28); // v33: +keyKind; v46: +flags
+    CHECK_EQ("sizeof(InvSaveFencePacket)",      sizeof(InvSaveFencePacket),      13); // v60: pre-save inventory barrier
     CHECK_EQ("sizeof(WorldItemEntry)",          sizeof(WorldItemEntry),          73);
     CHECK_EQ("sizeof(WorldItemSnapshotHeader)", sizeof(WorldItemSnapshotHeader), 6);
     CHECK_EQ("sizeof(WorldItemRemoveHeader)",   sizeof(WorldItemRemoveHeader),   6);
@@ -310,8 +311,10 @@ static void testSizes() {
     CHECK_EQ("EVT_SQUAD_MOVE id", (int)EVT_SQUAD_MOVE, 11);
     CHECK("EVT_SQUAD_MOVE distinct", EVT_SQUAD_MOVE != EVT_RECRUIT &&
           EVT_SQUAD_MOVE != EVT_NONE && EVT_SQUAD_MOVE != EVT_EXIT_FURNITURE);
-    CHECK_EQ("PROTOCOL_VERSION (v55: runtime-fixture identity)",
-             (int)PROTOCOL_VERSION, 55);
+    CHECK_EQ("PROTOCOL_VERSION (v60: inventory save fence)",
+             (int)PROTOCOL_VERSION, 60);
+    CHECK_EQ("inventory save fence packet id",
+             (int)PKT_INV_SAVE_FENCE, 53);
 
     // Protocol 52: the shared money pool. The two players spend from ONE wallet,
     // so the join reports CHANGES and the host the authoritative TOTAL - swap
@@ -495,6 +498,7 @@ static void testRoundTrips() {
     roundTrip<ResearchPacket>("ResearchPacket", (u8)PKT_RESEARCH);
     roundTrip<DeedPacket>("DeedPacket", (u8)PKT_DEED);
     roundTrip<FixturePacket>("FixturePacket", (u8)PKT_FIXTURE);
+    roundTrip<InvSaveFencePacket>("InvSaveFencePacket", (u8)PKT_INV_SAVE_FENCE);
     roundTrip<CellClaimPacket>("CellClaimPacket", (u8)PKT_CELL_CLAIM);
     roundTrip<InvXferAckPacket>("InvXferAckPacket", (u8)PKT_INV_XFER_ACK);
 
@@ -1392,6 +1396,7 @@ static void testFlushWorldStateContract() {
     CamHintPacket   ch;  std::memset(&ch,  0, sizeof(ch));
     CellClaimPacket cc;  std::memset(&cc,  0, sizeof(cc));
     InvXferAckPacket xa; std::memset(&xa,  0, sizeof(xa));
+    InvSaveFencePacket isf; std::memset(&isf, 0, sizeof(isf));
     // Session-preserving payloads.
     SaveReqPacket   srq; std::memset(&srq, 0, sizeof(srq));
     SaveBeginPacket sbg; std::memset(&sbg, 0, sizeof(sbg));
@@ -1402,7 +1407,7 @@ static void testFlushWorldStateContract() {
     LoadReqPacket   lrq; std::memset(&lrq, 0, sizeof(lrq));
     LoadNackPacket  lnk; std::memset(&lnk, 0, sizeof(lnk));
 
-    // --- Push one sentinel into every WORLD-STATE queue (34).
+    // --- Push one sentinel into every WORLD-STATE queue (35).
     in.pushEntity(1, 0, e);
     in.pushEvent(1, ev);
     in.pushInv(1, 0, cKey, 0, 0);
@@ -1437,6 +1442,7 @@ static void testFlushWorldStateContract() {
     in.pushCamHint(1, ch);
     in.pushCellClaim(1, cc);
     in.pushInvXferAck(1, xa);
+    in.pushInvSaveFence(1, isf);
 
     // --- Push one sentinel into every SESSION-PRESERVING queue (10).
     in.pushConnect(0);
@@ -1490,6 +1496,7 @@ static void testFlushWorldStateContract() {
     WS_EMPTY("camHint",     InboundCamHint,     drainCamHints);
     WS_EMPTY("cellClaim",   InboundCellClaim,   drainCellClaims);
     WS_EMPTY("invXferAck",  InboundInvXferAck,  drainInvXferAcks);
+    WS_EMPTY("invSaveFence", InboundInvSaveFence, drainInvSaveFences);
     #undef WS_EMPTY
 
     // --- Every SESSION-PRESERVING queue must still hold its sentinel.


### PR DESCRIPTION
## Summary

- turn every coordinated Host save into a checkpoint for the Join's latest owner-authored inventory state
- have the Join wait for the existing cursor/removal settle guards, then force one full reliable snapshot per owned container, including nested backpack contents
- queue the completion marker after those snapshots on the same ordered channel
- let the Host ingest and apply the checkpoint before reissuing the native save that the existing SaveXfer watches and distributes
- fail available after 15 seconds with a loud timeout instead of hanging save coordination

Addresses #77.

## Why this is not PR #35

#35 proposed adding nested backpack serialization. Current main already has nested capture/apply (InvItemEntry::parentIdx, opt-in nested capture, and nested container reconciliation), plus the newer drop/pickup conservation work. Issue #77 was reported after those changes.

This PR targets the remaining persistence boundary: SaveManager::save can start while the Join's newest inventory edit is still inside the normal settle window or crossing the network. The Host can therefore bake the previous backpack state even though live inventory sync is otherwise working.

## Save flow

Host native save edge -> reliable SAVE_FENCE request -> Join settles and queues full inventory snapshots -> Join queues ACK after them -> Host ingests and applies -> Host waits two complete main-loop ticks -> native re-save -> existing folder watch/transfer.

Two ticks are intentional. Snapshots and the ACK use the same ordered network channel but drain through separate inbound queues; the extra tick covers the case where the ACK arrives just after that frame's inventory drain, guaranteeing an intervening ingest and post-engine apply before saving.

## Safety and traffic

- no per-click or continuous request traffic; the fence runs only when a save occurs
- unchanged inventories still use the existing quiet, change-gated publisher outside a fence
- unresolved, cursor-active, removal-debounced, or pending-drop containers delay ACK rather than snapshotting a transient state
- truncated snapshots keep the existing additive-only behavior and are counted in ACK diagnostics
- disconnect, reload, and session reset clear pending fence state
- the fenced re-save bypass is one-shot and explicitly cleared if the native save entry point fails before consuming it
- no sidecar and no pre-load live-state restore; the second ordinary Kenshi save remains the canonical artifact

## Protocol / series ordering

Protocol advances from 55 to 60 and this PR uses packet id 53. Protocols 56-59 / packet ids 49-52 remain reserved for the preceding coherent series PRs #75, #76, #78 and #79. This branch is reviewable independently; mixed protocol builds remain unsupported.

## Validation

- [x] exact upstream base: 5a761e19a4184b42315e96ea7e92e3c1403d54db
- [x] all 11 uploaded Git blobs match the locally reviewed files exactly
- [x] git diff --check
- [x] project XML parses
- [x] structural contracts for packet/version, snapshot-before-ACK ordering, two-tick apply fence, world-reset cleanup, and save-bypass cleanup
- [ ] Visual C++ 2010 (v100) plugin/prototest build; that toolchain is unavailable here
- [ ] real two-client Host/Join regression

## Manual validation requested

1. On Join, put distinctive items/stacks inside a worn backpack and wait for the normal settle window.
2. Save on Host, then reload that same save on Host.
3. Confirm the nested contents and counts agree on both sides.
4. Repeat after dropping the backpack before the save.
5. Repeat a save requested from Join.
6. Inspect [invsave] REQ, ACK, and RESAVE; there should be no timeout and truncated=0 for the fixture.

Draft because the fix crosses Kenshi's native save boundary and needs the project's v100 build plus a real Host/Join save-reload session before it is safe to mark ready.